### PR TITLE
fix the missing equality constraints on gc of the last execution step

### DIFF
--- a/vm-circuit/src/chips/execution_chip.rs
+++ b/vm-circuit/src/chips/execution_chip.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::witness::Witness;
-use halo2_proofs::circuit::{Chip, Region};
+use halo2_proofs::circuit::{AssignedCell, Chip, Region};
 use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::Layouter,
@@ -26,8 +26,8 @@ pub struct ExecutionChipConfig<F: FieldExt> {
 
 #[derive(Clone, Debug)]
 pub struct ExecutionChip<F: FieldExt> {
-    pub witness: Witness<F>,
-    pub config: ExecutionChipConfig<F>,
+    pub(crate) witness: Witness<F>,
+    pub(crate) config: ExecutionChipConfig<F>,
 }
 
 impl<F: FieldExt> Chip<F> for ExecutionChip<F> {
@@ -65,23 +65,28 @@ impl<F: FieldExt> ExecutionChip<F> {
         }
     }
 
-    pub fn assign(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+    pub fn assign(
+        &self,
+        layouter: &mut impl Layouter<F>,
+    ) -> Result<Option<AssignedCell<F, F>>, Error> {
         let step_chip = StepChip::<F>::construct(self.config.step_config.clone(), ());
         let exec_steps = self.witness.process_exec_steps()?;
-
+        let mut gc_cell = None;
         layouter.assign_region(
             || "execution steps",
             |mut region: Region<'_, F>| {
                 let mut offset = 0;
                 for step in &exec_steps {
                     step_chip.config.s_step.enable(&mut region, offset)?;
-                    step_chip.assign(&mut region, offset, step, &self.witness.rw_operations)?;
+                    gc_cell =
+                        step_chip.assign(&mut region, offset, step, &self.witness.rw_operations)?;
 
                     offset += STEP_HEIGHT;
                 }
                 Ok(())
             },
         )?;
+        let last_step_gc_cell = gc_cell;
 
         let (sorted_stack_ops, sorted_locals_ops) = self.witness.rw_operations.clone().into();
         let mut stack_operations: Vec<Vec<Option<F>>> = (&sorted_stack_ops).into();
@@ -164,6 +169,6 @@ impl<F: FieldExt> ExecutionChip<F> {
             )?;
         }
 
-        Ok(())
+        Ok(last_step_gc_cell)
     }
 }

--- a/vm-circuit/src/chips/execution_chip/step_chip.rs
+++ b/vm-circuit/src/chips/execution_chip/step_chip.rs
@@ -6,7 +6,7 @@ use crate::chips::utilities::*;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
-use halo2_proofs::circuit::{Chip, Region};
+use halo2_proofs::circuit::{AssignedCell, Chip, Region};
 use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector};
 use halo2_proofs::poly::Rotation;
 use std::collections::VecDeque;
@@ -147,6 +147,9 @@ impl<F: FieldExt> StepChip<F> {
             next_auxiliary: cells.pop_front().unwrap(),
         };
 
+        // enable equality for gc column, because we will copy last gc cell to memory chip.
+        meta.enable_equality(cells.gc.column);
+
         // config each execution path of the step
         let mut constraints = Vec::new();
         let mut rw_lookups = Vec::new();
@@ -266,14 +269,14 @@ impl<F: FieldExt> StepChip<F> {
         constraints.push(("sum to one", sum_to_one));
     }
 
-    // assign each cell of the step
+    // assign each cell of the step, return assigned cell for gc
     pub fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
         step: &ExecutionStep<F>,
         rw_operations: &RWOperations<F>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<AssignedCell<F, F>>, Error> {
         // assign step states
         self.config
             .cells
@@ -294,10 +297,11 @@ impl<F: FieldExt> StepChip<F> {
             offset,
             Some(F::from(step.locals_index as u64)),
         )?;
-        self.config
-            .cells
-            .gc
-            .assign(region, offset, Some(F::from(step.gc as u64)))?;
+        let gc_assigned_cell =
+            self.config
+                .cells
+                .gc
+                .assign(region, offset, Some(F::from(step.gc as u64)))?;
         self.config.cells.module_index.assign(
             region,
             offset,
@@ -328,6 +332,6 @@ impl<F: FieldExt> StepChip<F> {
         step.opcode
             .assign(region, offset, step, rw_operations, &self.config.cells)?;
 
-        Ok(())
+        Ok(Some(gc_assigned_cell))
     }
 }

--- a/vm-circuit/src/chips/memory_chip.rs
+++ b/vm-circuit/src/chips/memory_chip.rs
@@ -2,7 +2,7 @@
 
 use crate::witness::rw_operations::{LocalsOp, StackOp};
 use crate::witness::{CircuitConfig, Witness};
-use halo2_proofs::circuit::{Chip, Region};
+use halo2_proofs::circuit::{AssignedCell, Chip, Region};
 use halo2_proofs::plonk::{Advice, Column};
 use halo2_proofs::plonk::{Selector, TableColumn};
 use halo2_proofs::poly::Rotation;
@@ -114,6 +114,7 @@ impl<F: FieldExt> MemoryChip<F> {
         &self,
         layouter: &mut impl Layouter<F>,
         circuit_config: &CircuitConfig,
+        last_step_gc_cell: AssignedCell<F, F>,
     ) -> Result<(), Error> {
         let stack_op_chip = StackOpChip::<F>::construct(self.config.stack_op_config.clone(), ());
         let (sorted_stack_ops, sorted_locals_ops) = self.witness.rw_operations.clone().into();
@@ -251,16 +252,6 @@ impl<F: FieldExt> MemoryChip<F> {
             },
         )?;
 
-        let last_step_gc = self
-            .witness
-            .exec_steps
-            .last()
-            .ok_or_else(|| {
-                error!("last step gc is None");
-                Error::Synthesis
-            })?
-            .gc;
-
         layouter.assign_region(
             || "add counter",
             |mut region: Region<'_, F>| {
@@ -300,15 +291,26 @@ impl<F: FieldExt> MemoryChip<F> {
                     region.assign_advice(|| "rhs", self.config.advices[1], 0, || Ok(F::zero()))?;
                 }
 
-                region.assign_advice(
+                last_step_gc_cell.copy_advice(
                     || "last step gc",
+                    &mut region,
                     self.config.advices[2],
                     0,
-                    || Ok(F::from_u128(last_step_gc as u128)),
                 )?;
+
                 Ok(())
             },
         )?;
+
+        let last_step_gc = self
+            .witness
+            .exec_steps
+            .last()
+            .ok_or_else(|| {
+                error!("last step gc is None");
+                Error::Synthesis
+            })?
+            .gc;
 
         layouter.assign_table(
             || "gc_table",

--- a/vm-circuit/src/circuit.rs
+++ b/vm-circuit/src/circuit.rs
@@ -8,6 +8,7 @@ use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner},
     plonk::{Circuit, ConstraintSystem, Error},
 };
+use logger::prelude::*;
 
 #[derive(Clone)]
 pub struct VmCircuitConfig<F: FieldExt> {
@@ -42,11 +43,18 @@ impl<F: FieldExt> Circuit<F> for VmCircuit<F> {
     ) -> Result<(), Error> {
         let execution_chip =
             ExecutionChip::<F>::construct(self.witness.clone(), config.execution_chip_config, ());
-        execution_chip.assign(&mut layouter)?;
+        let last_step_gc_cell = execution_chip.assign(&mut layouter)?.ok_or_else(|| {
+            error!("last step gc cell is None");
+            Error::Synthesis
+        })?;
 
         let memory_chip =
             MemoryChip::<F>::construct(self.witness.clone(), config.memory_chip_config, ());
-        memory_chip.assign(&mut layouter, &self.witness.circuit_config)?;
+        memory_chip.assign(
+            &mut layouter,
+            &self.witness.circuit_config,
+            last_step_gc_cell,
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
- copy cell of the last gc from execution chip to memory chip
- num of stack ops plus num of locals ops equals to gc of the last execution step