### PR TITLE
Perform type checks instead of derefs in `unary_op` and `binary_op`

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -100,30 +100,20 @@ impl<F: FieldExt> Frame<F> {
                         interp.stack.pop(rw_operations)?;
                         Ok(())
                     }
-                    Bytecode::Add => {
-                        interp.binary_op(Value::add, rw_operations, &mut self.locals, call_index)
-                    }
-                    Bytecode::Sub => {
-                        interp.binary_op(Value::sub, rw_operations, &mut self.locals, call_index)
-                    }
-                    Bytecode::Mul => {
-                        interp.binary_op(Value::mul, rw_operations, &mut self.locals, call_index)
-                    }
+                    Bytecode::Add => interp.binary_op(Value::add, rw_operations),
+                    Bytecode::Sub => interp.binary_op(Value::sub, rw_operations),
+                    Bytecode::Mul => interp.binary_op(Value::mul, rw_operations),
                     Bytecode::Div => interp.binary_op_auxiliary(
                         Value::div,
                         Value::rem,
                         rw_operations,
                         &mut execution_step,
-                        &mut self.locals,
-                        call_index,
                     ),
                     Bytecode::Mod => interp.binary_op_auxiliary(
                         Value::rem,
                         Value::div,
                         rw_operations,
                         &mut execution_step,
-                        &mut self.locals,
-                        call_index,
                     ),
                     Bytecode::Ret => {
                         trace!("step #{}, {:?}", interp.step, execution_step);
@@ -283,34 +273,22 @@ impl<F: FieldExt> Frame<F> {
                         Value::delta_invert,
                         rw_operations,
                         &mut execution_step,
-                        &mut self.locals,
-                        call_index,
                     ),
                     Bytecode::Neq => interp.binary_op_auxiliary(
                         Value::neq,
                         Value::delta_invert,
                         rw_operations,
                         &mut execution_step,
-                        &mut self.locals,
-                        call_index,
                     ),
                     Bytecode::Lt => interp.binary_op_auxiliary(
                         Value::lt,
                         Value::diff,
                         rw_operations,
                         &mut execution_step,
-                        &mut self.locals,
-                        call_index,
                     ),
-                    Bytecode::And => {
-                        interp.binary_op(Value::and, rw_operations, &mut self.locals, call_index)
-                    }
-                    Bytecode::Or => {
-                        interp.binary_op(Value::or, rw_operations, &mut self.locals, call_index)
-                    }
-                    Bytecode::Not => {
-                        interp.unary_op(Value::not, rw_operations, &mut self.locals, call_index)
-                    }
+                    Bytecode::And => interp.binary_op(Value::and, rw_operations),
+                    Bytecode::Or => interp.binary_op(Value::or, rw_operations),
+                    Bytecode::Not => interp.unary_op(Value::not, rw_operations),
                     _ => unreachable!(),
                 }?;
 

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -163,24 +163,28 @@ impl<F: FieldExt> Interpreter<F> {
 
     // TODO: we should have better access to different types of containers that refs
     // can point to. perhaps we should encapsulate this in the frame and pass that down instead.
-    pub fn binary_op<Fn>(
-        &mut self,
-        op: Fn,
-        rw_operations: &mut Vec<RWOperation<F>>,
-        locals: &mut Locals<F>,
-        call_index: usize,
-    ) -> VmResult<()>
+    pub fn binary_op<Fn>(&mut self, op: Fn, rw_operations: &mut Vec<RWOperation<F>>) -> VmResult<()>
     where
         Fn: FnOnce(Value<F>, Value<F>) -> VmResult<Value<F>>,
     {
-        let mut right = self.stack.pop(rw_operations)?;
+        let right = self.stack.pop(rw_operations)?;
         if let Value::Reference(r) = right {
-            right = locals.read_ref(r.index(), call_index, rw_operations)?;
+            return Err(
+                RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
+                    "Cannot dereference reference {:?} in unary operation",
+                    r
+                )),
+            );
         };
 
-        let mut left = self.stack.pop(rw_operations)?;
+        let left = self.stack.pop(rw_operations)?;
         if let Value::Reference(l) = left {
-            left = locals.read_ref(l.index(), call_index, rw_operations)?;
+            return Err(
+                RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
+                    "Cannot dereference reference {:?} in unary operation",
+                    l
+                )),
+            );
         };
 
         let result = op(left, right)?;
@@ -193,21 +197,29 @@ impl<F: FieldExt> Interpreter<F> {
         fn_aux: Fb,
         rw_operations: &mut Vec<RWOperation<F>>,
         step: &mut ExecutionStep<F>,
-        locals: &mut Locals<F>,
-        call_index: usize,
     ) -> VmResult<()>
     where
         Fa: FnOnce(Value<F>, Value<F>) -> VmResult<Value<F>>,
         Fb: FnOnce(Value<F>, Value<F>) -> VmResult<Value<F>>,
     {
-        let mut right = self.stack.pop(rw_operations)?;
+        let right = self.stack.pop(rw_operations)?;
         if let Value::Reference(r) = right {
-            right = locals.read_ref(r.index(), call_index, rw_operations)?;
+            return Err(
+                RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
+                    "Cannot dereference reference {:?} in unary operation",
+                    r
+                )),
+            );
         };
 
-        let mut left = self.stack.pop(rw_operations)?;
+        let left = self.stack.pop(rw_operations)?;
         if let Value::Reference(l) = left {
-            left = locals.read_ref(l.index(), call_index, rw_operations)?;
+            return Err(
+                RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
+                    "Cannot dereference reference {:?} in unary operation",
+                    l
+                )),
+            );
         };
 
         let result = op(left.clone(), right.clone())?;
@@ -218,19 +230,18 @@ impl<F: FieldExt> Interpreter<F> {
         Ok(())
     }
 
-    pub fn unary_op<Fn>(
-        &mut self,
-        op: Fn,
-        rw_operations: &mut Vec<RWOperation<F>>,
-        locals: &mut Locals<F>,
-        call_index: usize,
-    ) -> VmResult<()>
+    pub fn unary_op<Fn>(&mut self, op: Fn, rw_operations: &mut Vec<RWOperation<F>>) -> VmResult<()>
     where
         Fn: FnOnce(Value<F>) -> VmResult<Value<F>>,
     {
-        let mut operand = self.stack.pop(rw_operations)?;
+        let operand = self.stack.pop(rw_operations)?;
         if let Value::Reference(o) = operand {
-            operand = locals.read_ref(o.index(), call_index, rw_operations)?;
+            return Err(
+                RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
+                    "Cannot dereference reference {:?} in unary operation",
+                    o
+                )),
+            );
         };
 
         let result = op(operand)?;


### PR DESCRIPTION
Fixes #16