### PR TITLE
constrain the correct method is called

### DIFF
--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -157,7 +157,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     ];
 
     let circuit_config = CircuitConfig::default();
-    let witness = Witness::new(exec_steps, rw_operations, bytecodes, circuit_config);
+    let witness = Witness::new(exec_steps, rw_operations, bytecodes, vec![], circuit_config);
     let vm_circuit = VmCircuit { witness };
     let k = 10;
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
@@ -316,7 +316,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
     // let wrong_sorted_stack_operations = vec![rw_op_4, rw_op_5, rw_op_0, rw_op_3, rw_op_1, rw_op_2];
 
     let circuit_config = CircuitConfig::default();
-    let witness = Witness::new(exec_steps, rw_operations, bytecodes, circuit_config);
+    let witness = Witness::new(exec_steps, rw_operations, bytecodes, vec![], circuit_config);
     // witness.sorted_stack_ops.0 = wrong_sorted_stack_operations;
     let vm_circuit = VmCircuit { witness };
     let k = 10;

--- a/vm-circuit/src/chips/execution_chip.rs
+++ b/vm-circuit/src/chips/execution_chip.rs
@@ -1,5 +1,6 @@
 // Copyright (c) zkMove Authors
 
+use crate::chips::execution_chip::lookup_tables::CallLookupTable;
 use crate::witness::rw_operations::ConvertedRWOperation;
 use crate::witness::Witness;
 use halo2_proofs::circuit::{AssignedCell, Chip, Region};
@@ -23,6 +24,7 @@ pub struct ExecutionChipConfig<F: FieldExt> {
     step_config: StepConfig<F>,
     rw_table: RWTable,
     bytecode_table: BytecodeLookupTable,
+    call_table: CallLookupTable,
 }
 
 #[derive(Clone, Debug)]
@@ -56,6 +58,7 @@ impl<F: FieldExt> ExecutionChip<F> {
     pub fn configure(meta: &mut ConstraintSystem<F>) -> <Self as Chip<F>>::Config {
         let rw_table = RWTable::construct(meta);
         let bytecode_table = BytecodeLookupTable::construct(meta);
+        let call_table = CallLookupTable::construct(meta);
         let advices = [(); STEP_CHIP_WIDTH].map(|_| meta.advice_column());
         let step_config = StepChip::configure(meta, advices, &rw_table, &bytecode_table);
 
@@ -63,6 +66,7 @@ impl<F: FieldExt> ExecutionChip<F> {
             step_config,
             rw_table,
             bytecode_table,
+            call_table,
         }
     }
 
@@ -230,6 +234,34 @@ impl<F: FieldExt> ExecutionChip<F> {
                                         Error::Synthesis
                                     })?;
                                     Ok(field)
+                                },
+                            )
+                        })
+                        .fold(Ok(()), |acc, res| acc.and(res))
+                },
+            )?;
+        }
+
+        let func_calls = &self.witness.func_calls;
+        for (column_idx, column) in self.config.call_table.columns().into_iter().enumerate() {
+            layouter.assign_table(
+                || format!("call_table[{}]", column_idx),
+                |mut table_column| {
+                    table_column.assign_cell(
+                        || format!("call_table[{}][0]", column_idx),
+                        column,
+                        0,
+                        || Ok(F::zero()),
+                    )?;
+                    (0..func_calls.len())
+                        .map(|i| {
+                            table_column.assign_cell(
+                                || format!("call_table[{}][{}]", column_idx, i),
+                                column,
+                                i + 1,
+                                || {
+                                    let func_call: Vec<F> = func_calls[i].into();
+                                    Ok(func_call[column_idx])
                                 },
                             )
                         })

--- a/vm-circuit/src/chips/execution_chip.rs
+++ b/vm-circuit/src/chips/execution_chip.rs
@@ -60,7 +60,8 @@ impl<F: FieldExt> ExecutionChip<F> {
         let bytecode_table = BytecodeLookupTable::construct(meta);
         let call_table = CallLookupTable::construct(meta);
         let advices = [(); STEP_CHIP_WIDTH].map(|_| meta.advice_column());
-        let step_config = StepChip::configure(meta, advices, &rw_table, &bytecode_table);
+        let step_config =
+            StepChip::configure(meta, advices, &rw_table, &bytecode_table, &call_table);
 
         ExecutionChipConfig {
             step_config,

--- a/vm-circuit/src/chips/execution_chip/instructions.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::RWOperations;
@@ -62,8 +62,7 @@ pub trait Instructions<F: FieldExt> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     );
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/_mod.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/_mod.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Mod<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Mod.index()].expression.clone();
 
@@ -33,8 +32,14 @@ impl<F: FieldExt> Instructions<F> for Mod<F> {
         let constraint = cond.clone() * (lhs - rhs * quotient - remainder);
         constraints.push(("Mod", constraint));
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Mod, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Mod,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/abort.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/abort.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,11 +21,16 @@ impl<F: FieldExt> Instructions<F> for Abort<F> {
     fn configure(
         cells: &StepChipCells<F>,
         _constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Abort.index()].expression.clone();
-        LookupBytecode::lookup_bytecode(cells, Opcode::Abort, 0.expr(), bytecode_lookups, cond);
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Abort,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/add.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/add.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for Add<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Add
         let cond = cells.conditions[Opcode::Add.index()].expression.clone();
@@ -49,8 +48,14 @@ impl<F: FieldExt> Instructions<F> for Add<F> {
         constraints.push(("add range check", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Add, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Add,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/and.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/and.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for And<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::And.index()].expression.clone();
 
@@ -38,8 +37,14 @@ impl<F: FieldExt> Instructions<F> for And<F> {
         constraints.push(("And", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::And, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::And,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
@@ -41,12 +41,16 @@ impl<F: FieldExt> Instructions<F> for BrFalse<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
 
         constraints.append(&mut vec![
             ("BrFalse pc", cond.clone() * pc_expr),
             ("BrFalse stack size", cond.clone() * stack_size_expr),
             ("BrFalse call index", cond.clone() * call_index_expr),
             ("BrFalse gc", cond.clone() * gc_expr),
+            ("BrFalse module index", cond.clone() * module_index),
+            ("BrFalse function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for BrFalse<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::BrFalse.index()].expression.clone();
 
@@ -41,8 +40,10 @@ impl<F: FieldExt> Instructions<F> for BrFalse<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
 
         constraints.append(&mut vec![
             ("BrFalse pc", cond.clone() * pc_expr),
@@ -53,7 +54,7 @@ impl<F: FieldExt> Instructions<F> for BrFalse<F> {
             ("BrFalse function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -66,7 +67,7 @@ impl<F: FieldExt> Instructions<F> for BrFalse<F> {
             cells,
             Opcode::BrFalse,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for BrTrue<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::BrTrue.index()].expression.clone();
 
@@ -41,8 +40,10 @@ impl<F: FieldExt> Instructions<F> for BrTrue<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
 
         constraints.append(&mut vec![
             ("BrTrue pc", cond.clone() * pc_expr),
@@ -53,7 +54,7 @@ impl<F: FieldExt> Instructions<F> for BrTrue<F> {
             ("BrFalse function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -66,7 +67,7 @@ impl<F: FieldExt> Instructions<F> for BrTrue<F> {
             cells,
             Opcode::BrTrue,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
@@ -41,12 +41,16 @@ impl<F: FieldExt> Instructions<F> for BrTrue<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
 
         constraints.append(&mut vec![
             ("BrTrue pc", cond.clone() * pc_expr),
             ("BrTrue stack size", cond.clone() * stack_size_expr),
             ("BrTrue call index", cond.clone() * call_index_expr),
             ("BrTrue gc", cond.clone() * gc_expr),
+            ("BrFalse module index", cond.clone() * module_index),
+            ("BrFalse function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/branch.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/branch.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Branch<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Branch.index()].expression.clone();
         // next pc is assigned in the auxiliary_1
@@ -32,8 +31,10 @@ impl<F: FieldExt> Instructions<F> for Branch<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("branch pc", cond.clone() * pc_expr),
             ("branch stack size", cond.clone() * stack_size_expr),
@@ -47,7 +48,7 @@ impl<F: FieldExt> Instructions<F> for Branch<F> {
             cells,
             Opcode::Branch,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/branch.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/branch.rs
@@ -32,11 +32,15 @@ impl<F: FieldExt> Instructions<F> for Branch<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("branch pc", cond.clone() * pc_expr),
             ("branch stack size", cond.clone() * stack_size_expr),
             ("branch call index", cond.clone() * call_index_expr),
             ("branch gc", cond.clone() * gc_expr),
+            ("branch module index", cond.clone() * module_index),
+            ("branch function index", cond.clone() * func_index),
         ]);
 
         LookupBytecode::lookup_bytecode(

--- a/vm-circuit/src/chips/execution_chip/instructions/call.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/call.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup, RWTarget};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup, RWTarget};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::{
     StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
@@ -23,8 +23,7 @@ impl<F: FieldExt> Instructions<F> for Call<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        _bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Call.index()].expression.clone();
         let arg_num = cells.auxiliary_1.expression.clone();
@@ -56,11 +55,11 @@ impl<F: FieldExt> Instructions<F> for Call<F> {
                 cells.args_or_fields[i].expression.clone(),
             );
 
-            rw_lookups.push((
+            lookups.rw_lookups.push((
                 read,
                 cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));
-            rw_lookups.push((
+            lookups.rw_lookups.push((
                 write,
                 cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));

--- a/vm-circuit/src/chips/execution_chip/instructions/call.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/call.rs
@@ -1,13 +1,17 @@
 // Copyright (c) zkMove Authors
 
+use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup, RWTarget};
+use crate::chips::execution_chip::lookup_tables::{
+    CallLookup, LookupsWithCondition, RWLookup, RWTarget,
+};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::{
     StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
 };
 use crate::chips::utilities::Expr;
 use crate::witness::execution_steps::ExecutionStep;
+use crate::witness::function_calls::EntryType;
 use crate::witness::rw_operations::{RWOperations, RW};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
@@ -65,7 +69,28 @@ impl<F: FieldExt> Instructions<F> for Call<F> {
             ));
         }
 
-        // todo: lookup Call(index: FunctionHandleIndex) in bytecode table. how to constrain index?
+        // (type_, module_index, function_index, pc, next_module_index, next_function_index, next_pc)
+        // must be in the calls table.
+        lookups.call_lookups.push((
+            CallLookup {
+                type_: (EntryType::CALL as u64).expr(),
+                module_index: cells.module_index.expression.clone(),
+                function_index: cells.function_index.expression.clone(),
+                pc: cells.pc.expression.clone(),
+                next_module_index: cells.next_module_index.expression.clone(),
+                next_function_index: cells.next_function_index.expression.clone(),
+                next_pc: cells.next_pc.expression.clone(),
+            },
+            cond.clone(),
+        ));
+
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Call,
+            cells.auxiliary_2.expression.clone(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(
@@ -105,6 +130,14 @@ impl<F: FieldExt> Instructions<F> for Call<F> {
         for i in arg_num..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
             cells.args_or_fields_mask[i].assign(region, offset, Some(F::one()))?;
         }
+
+        let func_handle_idx = step.auxiliary_2.as_ref().ok_or_else(|| {
+            error!("auxiliary_2 is None");
+            Error::Synthesis
+        })?;
+        cells
+            .auxiliary_2
+            .assign(region, offset, func_handle_idx.value())?;
 
         Ok(())
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/call.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/call.rs
@@ -3,7 +3,9 @@
 use crate::chips::execution_chip::instructions::Instructions;
 use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup, RWTarget};
 use crate::chips::execution_chip::opcode::Opcode;
-use crate::chips::execution_chip::step_chip::{StepChipCells, MAX_NUM_OF_ARGUMENTS};
+use crate::chips::execution_chip::step_chip::{
+    StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
+};
 use crate::chips::utilities::Expr;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::{RWOperations, RW};
@@ -45,22 +47,22 @@ impl<F: FieldExt> Instructions<F> for Call<F> {
             ("Call gc", cond.clone() * gc_expr),
         ]);
 
-        for i in 0..MAX_NUM_OF_ARGUMENTS {
+        for i in 0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
             let (read, write) = RWLookup::locals_store(
                 cells.gc.expression.clone() + (i as u64 * 2).expr(),
                 cells.call_index.expression.clone() + 1.expr(),
                 arg_num.clone() - (i as u64 + 1).expr(),
                 cells.stack_size.expression.clone() - (i as u64).expr(),
-                cells.args[i].expression.clone(),
+                cells.args_or_fields[i].expression.clone(),
             );
 
             rw_lookups.push((
                 read,
-                cond.clone() * (1.expr() - cells.args_mask[i].expression.clone()),
+                cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));
             rw_lookups.push((
                 write,
-                cond.clone() * (1.expr() - cells.args_mask[i].expression.clone()),
+                cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));
         }
 
@@ -97,12 +99,12 @@ impl<F: FieldExt> Instructions<F> for Call<F> {
                 .get(step.gc + i * 2)
                 .ok_or(Error::Synthesis)?;
             debug_assert!(op.rw() == RW::READ && op.rw_target() == RWTarget::Stack);
-            cells.args[i].assign(region, offset, op.value().value())?;
-            cells.args_mask[i].assign(region, offset, Some(F::zero()))?;
+            cells.args_or_fields[i].assign(region, offset, op.value().value())?;
+            cells.args_or_fields_mask[i].assign(region, offset, Some(F::zero()))?;
         }
 
-        for i in arg_num..MAX_NUM_OF_ARGUMENTS {
-            cells.args_mask[i].assign(region, offset, Some(F::one()))?;
+        for i in arg_num..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
+            cells.args_or_fields_mask[i].assign(region, offset, Some(F::one()))?;
         }
 
         Ok(())

--- a/vm-circuit/src/chips/execution_chip/instructions/castu128.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/castu128.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, UnaryOp};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for CastU128<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::CastU128.index()]
             .expression
@@ -43,8 +42,14 @@ impl<F: FieldExt> Instructions<F> for CastU128<F> {
         constraints.push(("cast u128 range check", constraint));
 
         UnaryOp::constrain_unary_op(cells, constraints, cond.clone());
-        UnaryOp::lookup_unary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::CastU128, 0.expr(), bytecode_lookups, cond);
+        UnaryOp::lookup_unary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::CastU128,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/castu64.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/castu64.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, UnaryOp};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for CastU64<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::CastU64.index()].expression.clone();
         let x = cells.value_a.expression.clone();
@@ -41,8 +40,14 @@ impl<F: FieldExt> Instructions<F> for CastU64<F> {
         constraints.push(("cast u64 range check", constraint));
 
         UnaryOp::constrain_unary_op(cells, constraints, cond.clone());
-        UnaryOp::lookup_unary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::CastU64, 0.expr(), bytecode_lookups, cond);
+        UnaryOp::lookup_unary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::CastU64,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/castu8.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/castu8.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, UnaryOp};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for CastU8<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::CastU8.index()].expression.clone();
         let x = cells.value_a.expression.clone();
@@ -41,8 +40,14 @@ impl<F: FieldExt> Instructions<F> for CastU8<F> {
         constraints.push(("cast u8 range check", constraint));
 
         UnaryOp::constrain_unary_op(cells, constraints, cond.clone());
-        UnaryOp::lookup_unary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::CastU8, 0.expr(), bytecode_lookups, cond);
+        UnaryOp::lookup_unary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::CastU8,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -37,7 +37,7 @@ impl<F: FieldExt> BinaryOp<F> {
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
             ("module index", cond.clone() * module_index),
-            ("function index", cond.clone() * func_index),
+            ("function index", cond * func_index),
         ]);
     }
 
@@ -141,7 +141,7 @@ impl<F: FieldExt> UnaryOp<F> {
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
             ("module index", cond.clone() * module_index),
-            ("function index", cond.clone() * func_index),
+            ("function index", cond * func_index),
         ]);
     }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -27,11 +27,15 @@ impl<F: FieldExt> BinaryOp<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
-            ("gc", cond * gc_expr),
+            ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
     }
 
@@ -125,11 +129,15 @@ impl<F: FieldExt> UnaryOp<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
-            ("gc", cond * gc_expr),
+            ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
     }
 
@@ -192,11 +200,15 @@ impl<F: FieldExt> LoadOp<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
-            ("gc", cond * gc_expr),
+            ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond * func_index),
         ]);
     }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -27,8 +27,10 @@ impl<F: FieldExt> BinaryOp<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -129,8 +131,10 @@ impl<F: FieldExt> UnaryOp<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -200,8 +204,10 @@ impl<F: FieldExt> LoadOp<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),

--- a/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for CopyLoc<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::CopyLoc.index()].expression.clone();
 
@@ -33,8 +32,10 @@ impl<F: FieldExt> Instructions<F> for CopyLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -52,13 +53,13 @@ impl<F: FieldExt> Instructions<F> for CopyLoc<F> {
             cells.value_a.expression.clone(),
         );
 
-        rw_lookups.push((read, cond.clone()));
-        rw_lookups.push((write, cond.clone()));
+        lookups.rw_lookups.push((read, cond.clone()));
+        lookups.rw_lookups.push((write, cond.clone()));
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::CopyLoc,
             cells.locals_index.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
@@ -33,11 +33,15 @@ impl<F: FieldExt> Instructions<F> for CopyLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         let (read, write) = RWLookup::locals_copy(

--- a/vm-circuit/src/chips/execution_chip/instructions/div.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/div.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Div<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Div.index()].expression.clone();
 
@@ -33,8 +32,14 @@ impl<F: FieldExt> Instructions<F> for Div<F> {
         let constraint = cond.clone() * (lhs - rhs * quotient - remainder);
         constraints.push(("Div", constraint));
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Div, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Div,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/eq.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/eq.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Eq<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Eq
         let cond = cells.conditions[Opcode::Eq.index()].expression.clone();
@@ -44,8 +43,14 @@ impl<F: FieldExt> Instructions<F> for Eq<F> {
 
         constraints.push(("Eq", constraint));
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Eq, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Eq,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/exists.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/exists.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::RWOperations;
@@ -18,8 +18,7 @@ impl<F: FieldExt> Instructions<F> for Exists<F> {
     fn configure(
         _cells: &StepChipCells<F>,
         _constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        _bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        _lookups: &mut LookupsWithCondition<F>,
     ) {
     }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/freeze_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/freeze_ref.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for FreezeRef<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::FreezeRef.index()]
             .expression
@@ -34,8 +33,10 @@ impl<F: FieldExt> Instructions<F> for FreezeRef<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -49,7 +50,7 @@ impl<F: FieldExt> Instructions<F> for FreezeRef<F> {
             cells,
             Opcode::FreezeRef,
             cells.locals_index.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/freeze_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/freeze_ref.rs
@@ -34,11 +34,15 @@ impl<F: FieldExt> Instructions<F> for FreezeRef<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         LookupBytecode::lookup_bytecode(

--- a/vm-circuit/src/chips/execution_chip/instructions/ge.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ge.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for Ge<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Ge
         let cond = cells.conditions[Opcode::Ge.index()].expression.clone();
@@ -47,8 +46,14 @@ impl<F: FieldExt> Instructions<F> for Ge<F> {
         constraints.push(("Ge", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Ge, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Ge,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/gt.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/gt.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for Gt<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Gt
         let cond = cells.conditions[Opcode::Gt.index()].expression.clone();
@@ -47,8 +46,14 @@ impl<F: FieldExt> Instructions<F> for Gt<F> {
         constraints.push(("Gt", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Gt, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Gt,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_field.rs
@@ -35,11 +35,15 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowField<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_field.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowField<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::ImmBorrowField.index()]
             .expression
@@ -35,8 +34,10 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowField<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -46,7 +47,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowField<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -57,7 +58,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowField<F> {
 
         // todo: constrain that the pushed value is what we read from the struct field
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -70,7 +71,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowField<F> {
             cells,
             Opcode::ImmBorrowField,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_global.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::ImmBorrowGlobal.index()]
             .expression
@@ -34,8 +33,10 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -45,7 +46,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -54,7 +55,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::global_read(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.value_a.expression.clone(), //address
@@ -64,7 +65,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + 2.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -77,7 +78,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
             cells,
             Opcode::ImmBorrowGlobal,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_global.rs
@@ -34,11 +34,15 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowGlobal<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_loc.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowLoc<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::ImmBorrowLoc.index()]
             .expression
@@ -35,8 +34,10 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -55,13 +56,13 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowLoc<F> {
             cells.value_c.expression.clone(),
         );
 
-        rw_lookups.push((read, cond.clone()));
-        rw_lookups.push((write, cond.clone()));
+        lookups.rw_lookups.push((read, cond.clone()));
+        lookups.rw_lookups.push((write, cond.clone()));
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::ImmBorrowLoc,
             cells.locals_index.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/imm_borrow_loc.rs
@@ -35,11 +35,15 @@ impl<F: FieldExt> Instructions<F> for ImmBorrowLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         let (read, write) = RWLookup::locals_ref(

--- a/vm-circuit/src/chips/execution_chip/instructions/ld_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ld_false.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LoadOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,14 +21,19 @@ impl<F: FieldExt> Instructions<F> for LdFalse<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdFalse
         let cond = cells.conditions[Opcode::LdFalse.index()].expression.clone();
         LoadOp::constrain_ld_op(cells, constraints, cond.clone());
-        LoadOp::lookup_ld_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::LdFalse, 0.expr(), bytecode_lookups, cond);
+        LoadOp::lookup_ld_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::LdFalse,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/ld_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ld_true.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LoadOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,14 +21,19 @@ impl<F: FieldExt> Instructions<F> for LdTrue<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdTrue
         let cond = cells.conditions[Opcode::LdTrue.index()].expression.clone();
         LoadOp::constrain_ld_op(cells, constraints, cond.clone());
-        LoadOp::lookup_ld_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::LdTrue, 0.expr(), bytecode_lookups, cond);
+        LoadOp::lookup_ld_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::LdTrue,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/ldu128.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ldu128.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LoadOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
@@ -20,18 +20,17 @@ impl<F: FieldExt> Instructions<F> for LdU128<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdU128
         let cond = cells.conditions[Opcode::LdU128.index()].expression.clone();
         LoadOp::constrain_ld_op(cells, constraints, cond.clone());
-        LoadOp::lookup_ld_op(cells, rw_lookups, cond.clone());
+        LoadOp::lookup_ld_op(cells, &mut lookups.rw_lookups, cond.clone());
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::LdU128,
             cells.value_a.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/ldu64.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ldu64.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LoadOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
@@ -20,18 +20,17 @@ impl<F: FieldExt> Instructions<F> for LdU64<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdU64
         let cond = cells.conditions[Opcode::LdU64.index()].expression.clone();
         LoadOp::constrain_ld_op(cells, constraints, cond.clone());
-        LoadOp::lookup_ld_op(cells, rw_lookups, cond.clone());
+        LoadOp::lookup_ld_op(cells, &mut lookups.rw_lookups, cond.clone());
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::LdU64,
             cells.value_a.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/ldu8.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ldu8.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LoadOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
@@ -20,18 +20,17 @@ impl<F: FieldExt> Instructions<F> for LdU8<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdU8
         let cond = cells.conditions[Opcode::LdU8.index()].expression.clone();
         LoadOp::constrain_ld_op(cells, constraints, cond.clone());
-        LoadOp::lookup_ld_op(cells, rw_lookups, cond.clone());
+        LoadOp::lookup_ld_op(cells, &mut lookups.rw_lookups, cond.clone());
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::LdU8,
             cells.value_a.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/le.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/le.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for Le<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Le
         let cond = cells.conditions[Opcode::Le.index()].expression.clone();
@@ -50,8 +49,14 @@ impl<F: FieldExt> Instructions<F> for Le<F> {
         constraints.push(("Le", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Le, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Le,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/lt.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/lt.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for Lt<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Lt
         let cond = cells.conditions[Opcode::Lt.index()].expression.clone();
@@ -47,8 +46,14 @@ impl<F: FieldExt> Instructions<F> for Lt<F> {
         constraints.push(("Lt", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Lt, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Lt,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::MoveFrom.index()]
             .expression
@@ -34,8 +33,10 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -45,7 +46,7 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -54,7 +55,7 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::global_read(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.value_a.expression.clone(), //address
@@ -64,7 +65,7 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + 2.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -77,7 +78,7 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             cells,
             Opcode::MoveFrom,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -34,11 +34,15 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
@@ -33,11 +33,15 @@ impl<F: FieldExt> Instructions<F> for MoveLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         let (read, write_locals, write_stack) = RWLookup::locals_move(

--- a/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for MoveLoc<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::MoveLoc.index()].expression.clone();
 
@@ -33,8 +32,10 @@ impl<F: FieldExt> Instructions<F> for MoveLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -52,14 +53,14 @@ impl<F: FieldExt> Instructions<F> for MoveLoc<F> {
             cells.value_a.expression.clone(),
         );
 
-        rw_lookups.push((read, cond.clone()));
-        rw_lookups.push((write_locals, cond.clone()));
-        rw_lookups.push((write_stack, cond.clone()));
+        lookups.rw_lookups.push((read, cond.clone()));
+        lookups.rw_lookups.push((write_locals, cond.clone()));
+        lookups.rw_lookups.push((write_stack, cond.clone()));
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::MoveLoc,
             cells.locals_index.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -33,11 +33,15 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::MoveTo.index()].expression.clone();
 
@@ -33,8 +32,10 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -44,7 +45,7 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -53,7 +54,7 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -62,7 +63,7 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::global_write(
                 cells.gc.expression.clone() + 2.expr(),
                 cells.value_c.expression.clone(), //address
@@ -78,7 +79,7 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
             cells,
             Opcode::MoveTo,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/mul.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mul.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for Mul<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Mul.index()].expression.clone();
 
@@ -48,8 +47,14 @@ impl<F: FieldExt> Instructions<F> for Mul<F> {
         constraints.push(("mul range check", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Mul, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Mul,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_field.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowField<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::MutBorrowField.index()]
             .expression
@@ -35,8 +34,10 @@ impl<F: FieldExt> Instructions<F> for MutBorrowField<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -46,7 +47,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowField<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -57,7 +58,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowField<F> {
 
         // todo: constrain that the pushed value is what we read from the struct field
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -70,7 +71,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowField<F> {
             cells,
             Opcode::MutBorrowField,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_field.rs
@@ -35,11 +35,15 @@ impl<F: FieldExt> Instructions<F> for MutBorrowField<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_global.rs
@@ -34,11 +34,15 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_global.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::MutBorrowGlobal.index()]
             .expression
@@ -34,8 +33,10 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -45,7 +46,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -54,7 +55,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::global_read(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.value_a.expression.clone(), //address
@@ -64,7 +65,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
             cond.clone(),
         ));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + 2.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -77,7 +78,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowGlobal<F> {
             cells,
             Opcode::MutBorrowGlobal,
             cells.auxiliary_1.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_loc.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for MutBorrowLoc<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::MutBorrowLoc.index()]
             .expression
@@ -35,8 +34,10 @@ impl<F: FieldExt> Instructions<F> for MutBorrowLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -55,13 +56,13 @@ impl<F: FieldExt> Instructions<F> for MutBorrowLoc<F> {
             cells.value_c.expression.clone(),
         );
 
-        rw_lookups.push((read, cond.clone()));
-        rw_lookups.push((write, cond.clone()));
+        lookups.rw_lookups.push((read, cond.clone()));
+        lookups.rw_lookups.push((write, cond.clone()));
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::MutBorrowLoc,
             cells.locals_index.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mut_borrow_loc.rs
@@ -35,11 +35,15 @@ impl<F: FieldExt> Instructions<F> for MutBorrowLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         let (read, write) = RWLookup::locals_ref(

--- a/vm-circuit/src/chips/execution_chip/instructions/neq.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/neq.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Neq<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Neq
         let cond = cells.conditions[Opcode::Neq.index()].expression.clone();
@@ -48,8 +47,14 @@ impl<F: FieldExt> Instructions<F> for Neq<F> {
         constraints.push(("Neq", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Neq, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Neq,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/nop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/nop.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
@@ -19,8 +19,7 @@ impl<F: FieldExt> Instructions<F> for Nop<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        _bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        _lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Nop.index()].expression.clone();
         let pc_expr = cells.pc.expression.clone() - cells.next_pc.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/not.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/not.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, UnaryOp};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Not<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Not.index()].expression.clone();
         let x = cells.value_a.expression.clone();
@@ -37,8 +36,14 @@ impl<F: FieldExt> Instructions<F> for Not<F> {
         constraints.push(("Not", constraint));
 
         UnaryOp::constrain_unary_op(cells, constraints, cond.clone());
-        UnaryOp::lookup_unary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Not, 0.expr(), bytecode_lookups, cond);
+        UnaryOp::lookup_unary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Not,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/or.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/or.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::Expr;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Or<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Or.index()].expression.clone();
 
@@ -38,8 +37,14 @@ impl<F: FieldExt> Instructions<F> for Or<F> {
         constraints.push(("Or", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Or, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Or,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pack.rs
@@ -40,11 +40,15 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone()
             + field_num.clone()
             + 1.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         for i in 0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {

--- a/vm-circuit/src/chips/execution_chip/instructions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pack.rs
@@ -4,7 +4,9 @@ use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
 use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup, RWTarget};
 use crate::chips::execution_chip::opcode::Opcode;
-use crate::chips::execution_chip::step_chip::{StepChipCells, MAX_NUM_OF_ARGUMENTS};
+use crate::chips::execution_chip::step_chip::{
+    StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
+};
 use crate::chips::utilities::Expr;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::{RWOperations, RW};
@@ -45,7 +47,7 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
             ("gc", cond.clone() * gc_expr),
         ]);
 
-        for i in 0..MAX_NUM_OF_ARGUMENTS {
+        for i in 0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
             rw_lookups.push((
                 RWLookup {
                     gc: cells.gc.expression.clone() + (i as u64).expr(),
@@ -54,10 +56,10 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
                     call_index: 0.expr(),
                     address: cells.stack_size.expression.clone() - field_num.clone()
                         + (i as u64).expr(),
-                    value: cells.args[i].expression.clone(),
+                    value: cells.args_or_fields[i].expression.clone(),
                     sd_index: 0.expr(),
                 },
-                cond.clone() * (1.expr() - cells.args_mask[i].expression.clone()),
+                cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));
         }
         rw_lookups.push((
@@ -101,18 +103,16 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
             })?
             .get_lower_128() as usize;
 
-        // todo: We temporarily reuse cells for args here. should be abstracted as a gadget.
-
-        // fixme: field_num may be large than MAX_NUM_OF_ARGUMENTS
+        // fixme: field_num may be large than MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS
         for i in 0..field_num {
             let op = rw_operations.0.get(step.gc + i).ok_or(Error::Synthesis)?;
             debug_assert!(op.rw() == RW::READ && op.rw_target() == RWTarget::Stack);
-            cells.args[i].assign(region, offset, op.value().value())?;
-            cells.args_mask[i].assign(region, offset, Some(F::zero()))?;
+            cells.args_or_fields[i].assign(region, offset, op.value().value())?;
+            cells.args_or_fields_mask[i].assign(region, offset, Some(F::zero()))?;
         }
 
-        for i in field_num..MAX_NUM_OF_ARGUMENTS {
-            cells.args_mask[i].assign(region, offset, Some(F::one()))?;
+        for i in field_num..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
+            cells.args_or_fields_mask[i].assign(region, offset, Some(F::one()))?;
         }
 
         let op = rw_operations

--- a/vm-circuit/src/chips/execution_chip/instructions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pack.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup, RWTarget};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup, RWTarget};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::{
     StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Pack
         let cond = cells.conditions[Opcode::Pack.index()].expression.clone();
@@ -40,8 +39,10 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone()
             + field_num.clone()
             + 1.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -52,7 +53,7 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
         ]);
 
         for i in 0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
-            rw_lookups.push((
+            lookups.rw_lookups.push((
                 RWLookup {
                     gc: cells.gc.expression.clone() + (i as u64).expr(),
                     rw_target: (RWTarget::Stack as u64).expr(),
@@ -66,7 +67,7 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
                 cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));
         }
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + field_num.clone(),
                 cells.stack_size.expression.clone() - field_num,
@@ -79,7 +80,7 @@ impl<F: FieldExt> Instructions<F> for Pack<F> {
             cells,
             Opcode::Pack,
             cells.auxiliary_2.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pop.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for Pop<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Pop.index()].expression.clone();
 
@@ -34,8 +33,10 @@ impl<F: FieldExt> Instructions<F> for Pop<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -45,7 +46,7 @@ impl<F: FieldExt> Instructions<F> for Pop<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -54,7 +55,13 @@ impl<F: FieldExt> Instructions<F> for Pop<F> {
             cond.clone(),
         ));
 
-        LookupBytecode::lookup_bytecode(cells, Opcode::Pop, 0.expr(), bytecode_lookups, cond);
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Pop,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pop.rs
@@ -34,11 +34,15 @@ impl<F: FieldExt> Instructions<F> for Pop<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 1.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::ReadRef.index()].expression.clone();
 
@@ -33,8 +32,10 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -44,7 +45,7 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -60,7 +61,7 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
             cells.locals_index.expression.clone(),
             cells.value_b.expression.clone(),
         );
-        rw_lookups.push((read, cond.clone() * is_locals));
+        lookups.rw_lookups.push((read, cond.clone() * is_locals));
 
         let is_global = cells.auxiliary_1.expression.clone();
         let read = RWLookup::global_read(
@@ -69,9 +70,9 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
             cells.value_b.expression.clone(),
             cells.auxiliary_3.expression.clone(), //sd_index
         );
-        rw_lookups.push((read, cond.clone() * is_global));
+        lookups.rw_lookups.push((read, cond.clone() * is_global));
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_push(
                 cells.gc.expression.clone() + 2.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -80,7 +81,13 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
             cond.clone(),
         ));
 
-        LookupBytecode::lookup_bytecode(cells, Opcode::ReadRef, 0.expr(), bytecode_lookups, cond);
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::ReadRef,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -33,11 +33,15 @@ impl<F: FieldExt> Instructions<F> for ReadRef<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/ret.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ret.rs
@@ -2,11 +2,12 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
+use crate::chips::execution_chip::lookup_tables::{CallLookup, LookupsWithCondition};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, SubInvert};
 use crate::witness::execution_steps::ExecutionStep;
+use crate::witness::function_calls::EntryType;
 use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
@@ -27,17 +28,13 @@ impl<F: FieldExt> Instructions<F> for Ret<F> {
         let call_index = cells.call_index.expression.clone();
         let inverse = cells.auxiliary_1.expression.clone();
 
-        // todo:
-        // if call_index != 0, the next step will be a normal bytecode, we have
-        // call_index * inverse(call_index) == 1
-        // next_pc == ?
-        // let pc_expr = (call_index * inverse - 1.expr()) - (cells.next_pc.expression.clone() - cells.pc.expression.clone() - 1.expr());
-
-        // if call_index == 0, the next step will be 'Nop' or 'Stop', we have
-        // call_index * inverse(call_index) == 0
-        // next_pc == pc
+        // constrain the inverse, if call_index != 0, call_index * inverse(call_index) == 1
         let call_index_expr =
             call_index.clone() * (call_index.clone() * inverse.clone() - 1.expr());
+
+        // if call_index == 0, the next step will be 'Nop' or 'Stop', we have
+        // call_index * inverse(call_index) != 1
+        // next_pc == pc
         let pc_expr = (call_index * inverse - 1.expr())
             * (cells.next_pc.expression.clone() - cells.pc.expression.clone());
 
@@ -48,6 +45,23 @@ impl<F: FieldExt> Instructions<F> for Ret<F> {
             ("pc", cond.clone() * pc_expr),
             ("gc", cond.clone() * gc_expr),
         ]);
+
+        // if call_index != 0, the next step will be a normal bytecode,
+        // (type_, module_index, function_index, pc, next_module_index, next_function_index, next_pc)
+        // must be in calls table.
+        lookups.call_lookups.push((
+            CallLookup {
+                type_: (EntryType::RET as u64).expr(),
+                module_index: cells.module_index.expression.clone(),
+                function_index: cells.function_index.expression.clone(),
+                pc: cells.pc.expression.clone(),
+                next_module_index: cells.next_module_index.expression.clone(),
+                next_function_index: cells.next_function_index.expression.clone(),
+                next_pc: cells.next_pc.expression.clone(),
+            },
+            cond.clone(),
+        ));
+
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::Ret,

--- a/vm-circuit/src/chips/execution_chip/instructions/ret.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ret.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, SubInvert};
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for Ret<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::Ret.index()].expression.clone();
         let call_index = cells.call_index.expression.clone();
@@ -49,7 +48,13 @@ impl<F: FieldExt> Instructions<F> for Ret<F> {
             ("pc", cond.clone() * pc_expr),
             ("gc", cond.clone() * gc_expr),
         ]);
-        LookupBytecode::lookup_bytecode(cells, Opcode::Ret, 0.expr(), bytecode_lookups, cond);
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Ret,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/ret.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ret.rs
@@ -35,7 +35,7 @@ impl<F: FieldExt> Instructions<F> for Ret<F> {
         // if call_index == 0, the next step will be 'Nop' or 'Stop', we have
         // call_index * inverse(call_index) != 1
         // next_pc == pc
-        let pc_expr = (call_index * inverse - 1.expr())
+        let pc_expr = (call_index.clone() * inverse.clone() - 1.expr())
             * (cells.next_pc.expression.clone() - cells.pc.expression.clone());
 
         // gc should not change
@@ -59,7 +59,7 @@ impl<F: FieldExt> Instructions<F> for Ret<F> {
                 next_function_index: cells.next_function_index.expression.clone(),
                 next_pc: cells.next_pc.expression.clone(),
             },
-            cond.clone(),
+            call_index * inverse * cond.clone(), // only take effect when call_index != 0
         ));
 
         LookupBytecode::lookup_bytecode(

--- a/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -21,8 +21,7 @@ impl<F: FieldExt> Instructions<F> for StLoc<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::StLoc.index()].expression.clone();
 
@@ -33,8 +32,10 @@ impl<F: FieldExt> Instructions<F> for StLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -52,13 +53,13 @@ impl<F: FieldExt> Instructions<F> for StLoc<F> {
             cells.value_a.expression.clone(),
         );
 
-        rw_lookups.push((read, cond.clone()));
-        rw_lookups.push((write, cond.clone()));
+        lookups.rw_lookups.push((read, cond.clone()));
+        lookups.rw_lookups.push((write, cond.clone()));
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::StLoc,
             cells.locals_index.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
@@ -33,11 +33,15 @@ impl<F: FieldExt> Instructions<F> for StLoc<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 2.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         let (read, write) = RWLookup::locals_store(

--- a/vm-circuit/src/chips/execution_chip/instructions/stop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/stop.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::RWOperations;
@@ -18,8 +18,7 @@ impl<F: FieldExt> Instructions<F> for Stop<F> {
     fn configure(
         _cells: &StepChipCells<F>,
         _constraints: &mut Vec<(&str, Expression<F>)>,
-        _rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        _bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        _lookups: &mut LookupsWithCondition<F>,
     ) {
     }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/sub.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/sub.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::{BinaryOp, LookupBytecode};
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::{Expr, FieldBytes};
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for Sub<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Sub
         let cond = cells.conditions[Opcode::Sub.index()].expression.clone();
@@ -49,8 +48,14 @@ impl<F: FieldExt> Instructions<F> for Sub<F> {
         constraints.push(("sub range check", constraint));
 
         BinaryOp::constrain_binary_op(cells, constraints, cond.clone());
-        BinaryOp::lookup_binary_op(cells, rw_lookups, cond.clone());
-        LookupBytecode::lookup_bytecode(cells, Opcode::Sub, 0.expr(), bytecode_lookups, cond);
+        BinaryOp::lookup_binary_op(cells, &mut lookups.rw_lookups, cond.clone());
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::Sub,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup, RWTarget};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup, RWTarget};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::{
     StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
@@ -24,8 +24,7 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         //Unpack
         let cond = cells.conditions[Opcode::Unpack.index()].expression.clone();
@@ -39,8 +38,10 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr =
             cells.gc.expression.clone() - cells.next_gc.expression.clone() + field_num + 1.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -50,7 +51,7 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -60,7 +61,7 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
         ));
 
         for i in 0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
-            rw_lookups.push((
+            lookups.rw_lookups.push((
                 RWLookup {
                     gc: cells.gc.expression.clone() + 1.expr() + (i as u64).expr(),
                     rw_target: (RWTarget::Stack as u64).expr(),
@@ -78,7 +79,7 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
             cells,
             Opcode::Unpack,
             cells.auxiliary_2.expression.clone(),
-            bytecode_lookups,
+            &mut lookups.bytecode_lookups,
             cond,
         );
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -4,7 +4,9 @@ use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
 use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup, RWTarget};
 use crate::chips::execution_chip::opcode::Opcode;
-use crate::chips::execution_chip::step_chip::{StepChipCells, MAX_NUM_OF_ARGUMENTS};
+use crate::chips::execution_chip::step_chip::{
+    StepChipCells, MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS,
+};
 use crate::chips::utilities::Expr;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::{RWOperations, RW};
@@ -53,7 +55,7 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
             cond.clone(),
         ));
 
-        for i in 0..MAX_NUM_OF_ARGUMENTS {
+        for i in 0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
             rw_lookups.push((
                 RWLookup {
                     gc: cells.gc.expression.clone() + 1.expr() + (i as u64).expr(),
@@ -61,10 +63,10 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
                     rw: (RW::WRITE as u64).expr(),
                     call_index: 0.expr(),
                     address: cells.stack_size.expression.clone() - 1.expr() + (i as u64).expr(),
-                    value: cells.args[i].expression.clone(),
+                    value: cells.args_or_fields[i].expression.clone(),
                     sd_index: 0.expr(),
                 },
-                cond.clone() * (1.expr() - cells.args_mask[i].expression.clone()),
+                cond.clone() * (1.expr() - cells.args_or_fields_mask[i].expression.clone()),
             ));
         }
 
@@ -105,21 +107,19 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
             })?
             .get_lower_128() as usize;
 
-        // todo: We temporarily reuse cells for args here. should be abstracted as a gadget.
-
-        // fixme: field_num may be large than MAX_NUM_OF_ARGUMENTS
+        // fixme: field_num may be large than MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS
         for i in 0..field_num {
             let op = rw_operations
                 .0
                 .get(step.gc + 1 + i)
                 .ok_or(Error::Synthesis)?;
             debug_assert!(op.rw() == RW::WRITE && op.rw_target() == RWTarget::Stack);
-            cells.args[i].assign(region, offset, op.value().value())?;
-            cells.args_mask[i].assign(region, offset, Some(F::zero()))?;
+            cells.args_or_fields[i].assign(region, offset, op.value().value())?;
+            cells.args_or_fields_mask[i].assign(region, offset, Some(F::zero()))?;
         }
 
-        for i in field_num..MAX_NUM_OF_ARGUMENTS {
-            cells.args_mask[i].assign(region, offset, Some(F::one()))?;
+        for i in field_num..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS {
+            cells.args_or_fields_mask[i].assign(region, offset, Some(F::one()))?;
         }
 
         let sd_idx = step.auxiliary_2.as_ref().ok_or_else(|| {

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -39,11 +39,15 @@ impl<F: FieldExt> Instructions<F> for Unpack<F> {
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr =
             cells.gc.expression.clone() - cells.next_gc.expression.clone() + field_num + 1.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -36,11 +36,15 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
             ("call index", cond.clone() * call_index_expr),
             ("gc", cond.clone() * gc_expr),
+            ("module index", cond.clone() * module_index),
+            ("function index", cond.clone() * func_index),
         ]);
 
         rw_lookups.push((

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::LookupBytecode;
 use crate::chips::execution_chip::instructions::Instructions;
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::{LookupsWithCondition, RWLookup};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::utilities::*;
@@ -22,8 +22,7 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
     fn configure(
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         let cond = cells.conditions[Opcode::WriteRef.index()]
             .expression
@@ -36,8 +35,10 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
         let call_index_expr =
             cells.call_index.expression.clone() - cells.next_call_index.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
-        let module_index = cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
-        let func_index = cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
+        let module_index =
+            cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
+        let func_index =
+            cells.function_index.expression.clone() - cells.next_function_index.expression.clone();
         constraints.append(&mut vec![
             ("pc", cond.clone() * pc_expr),
             ("stack size", cond.clone() * stack_size_expr),
@@ -47,7 +48,7 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
             ("function index", cond.clone() * func_index),
         ]);
 
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
@@ -55,7 +56,7 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
             ),
             cond.clone(),
         ));
-        rw_lookups.push((
+        lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone() + 1.expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
@@ -71,7 +72,7 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
             cells.locals_index.expression.clone(),
             cells.value_c.expression.clone(),
         );
-        rw_lookups.push((write, cond.clone() * is_locals));
+        lookups.rw_lookups.push((write, cond.clone() * is_locals));
 
         let is_global = cells.auxiliary_1.expression.clone();
         let write = RWLookup::global_write(
@@ -80,9 +81,15 @@ impl<F: FieldExt> Instructions<F> for WriteRef<F> {
             cells.value_c.expression.clone(),
             cells.auxiliary_3.expression.clone(), //sd_index
         );
-        rw_lookups.push((write, cond.clone() * is_global));
+        lookups.rw_lookups.push((write, cond.clone() * is_global));
 
-        LookupBytecode::lookup_bytecode(cells, Opcode::WriteRef, 0.expr(), bytecode_lookups, cond);
+        LookupBytecode::lookup_bytecode(
+            cells,
+            Opcode::WriteRef,
+            0.expr(),
+            &mut lookups.bytecode_lookups,
+            cond,
+        );
     }
 
     fn assign(

--- a/vm-circuit/src/chips/execution_chip/lookup_tables.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables.rs
@@ -338,3 +338,44 @@ pub struct BytecodeLookup<F: FieldExt> {
     pub opcode: Expression<F>,
     pub operand: Expression<F>,
 }
+
+
+#[derive(Clone, Debug)]
+pub struct CallLookupTable {
+    pub module_index_column: TableColumn,
+    pub function_index_column: TableColumn,
+    pub pc_column: TableColumn,
+    pub callee_module_index_column: TableColumn,
+    pub callee_function_index_column: TableColumn,
+}
+pub const CALL_LOOKUP_TABLE_WIDTH: usize = 5;
+
+impl CallLookupTable {
+    pub fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        CallLookupTable {
+            module_index_column: meta.lookup_table_column(),
+            function_index_column: meta.lookup_table_column(),
+            pc_column: meta.lookup_table_column(),
+            callee_module_index_column: meta.lookup_table_column(),
+            callee_function_index_column: meta.lookup_table_column(),
+        }
+    }
+
+    pub fn columns(&self) -> Vec<TableColumn> {
+        vec![
+            self.module_index_column,
+            self.function_index_column,
+            self.pc_column,
+            self.callee_module_index_column,
+            self.callee_function_index_column,
+        ]
+    }
+}
+
+pub struct CallLookup<F: FieldExt> {
+    pub module_index: Expression<F>,
+    pub function_index: Expression<F>,
+    pub pc: Expression<F>,
+    pub callee_module_index: Expression<F>,
+    pub callee_function_index: Expression<F>,
+}

--- a/vm-circuit/src/chips/execution_chip/lookup_tables.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables.rs
@@ -341,47 +341,57 @@ pub struct BytecodeLookup<F: FieldExt> {
 
 #[derive(Clone, Debug)]
 pub struct CallLookupTable {
+    pub type_column: TableColumn,
     pub module_index_column: TableColumn,
     pub function_index_column: TableColumn,
     pub pc_column: TableColumn,
     pub callee_module_index_column: TableColumn,
     pub callee_function_index_column: TableColumn,
+    pub next_pc_column: TableColumn,
 }
-pub const CALL_LOOKUP_TABLE_WIDTH: usize = 5;
+
+pub const CALL_LOOKUP_TABLE_WIDTH: usize = 7;
 
 impl CallLookupTable {
     pub fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
         CallLookupTable {
+            type_column: meta.lookup_table_column(),
             module_index_column: meta.lookup_table_column(),
             function_index_column: meta.lookup_table_column(),
             pc_column: meta.lookup_table_column(),
             callee_module_index_column: meta.lookup_table_column(),
             callee_function_index_column: meta.lookup_table_column(),
+            next_pc_column: meta.lookup_table_column(),
         }
     }
 
     pub fn columns(&self) -> Vec<TableColumn> {
         vec![
+            self.type_column,
             self.module_index_column,
             self.function_index_column,
             self.pc_column,
             self.callee_module_index_column,
             self.callee_function_index_column,
+            self.next_pc_column,
         ]
     }
 }
 
 pub struct CallLookup<F: FieldExt> {
+    pub type_: Expression<F>,
     pub module_index: Expression<F>,
     pub function_index: Expression<F>,
     pub pc: Expression<F>,
-    pub callee_module_index: Expression<F>,
-    pub callee_function_index: Expression<F>,
+    pub next_module_index: Expression<F>,
+    pub next_function_index: Expression<F>,
+    pub next_pc: Expression<F>,
 }
 
 pub struct LookupsWithCondition<F: FieldExt> {
     pub rw_lookups: Vec<(RWLookup<F>, /*condition*/ Expression<F>)>,
     pub bytecode_lookups: Vec<(BytecodeLookup<F>, /*condition*/ Expression<F>)>,
+    pub call_lookups: Vec<(CallLookup<F>, /*condition*/ Expression<F>)>,
 }
 
 impl<F: FieldExt> LookupsWithCondition<F> {
@@ -389,6 +399,13 @@ impl<F: FieldExt> LookupsWithCondition<F> {
         Self {
             rw_lookups: Vec::new(),
             bytecode_lookups: Vec::new(),
+            call_lookups: Vec::new(),
         }
+    }
+}
+
+impl<F: FieldExt> Default for LookupsWithCondition<F> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/vm-circuit/src/chips/execution_chip/lookup_tables.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables.rs
@@ -339,7 +339,6 @@ pub struct BytecodeLookup<F: FieldExt> {
     pub operand: Expression<F>,
 }
 
-
 #[derive(Clone, Debug)]
 pub struct CallLookupTable {
     pub module_index_column: TableColumn,
@@ -378,4 +377,18 @@ pub struct CallLookup<F: FieldExt> {
     pub pc: Expression<F>,
     pub callee_module_index: Expression<F>,
     pub callee_function_index: Expression<F>,
+}
+
+pub struct LookupsWithCondition<F: FieldExt> {
+    pub rw_lookups: Vec<(RWLookup<F>, /*condition*/ Expression<F>)>,
+    pub bytecode_lookups: Vec<(BytecodeLookup<F>, /*condition*/ Expression<F>)>,
+}
+
+impl<F: FieldExt> LookupsWithCondition<F> {
+    pub fn new() -> Self {
+        Self {
+            rw_lookups: Vec::new(),
+            bytecode_lookups: Vec::new(),
+        }
+    }
 }

--- a/vm-circuit/src/chips/execution_chip/opcode.rs
+++ b/vm-circuit/src/chips/execution_chip/opcode.rs
@@ -11,7 +11,7 @@ use crate::chips::execution_chip::instructions::{
     read_ref::ReadRef, ret::Ret, st_loc::StLoc, stop::Stop, sub::Sub, unpack::Unpack,
     write_ref::WriteRef,
 };
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookup, RWLookup};
+use crate::chips::execution_chip::lookup_tables::LookupsWithCondition;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::RWOperations;
@@ -141,78 +141,59 @@ impl Opcode {
         &self,
         cells: &StepChipCells<F>,
         constraints: &mut Vec<(&str, Expression<F>)>,
-        rw_lookups: &mut Vec<(RWLookup<F>, Expression<F>)>,
-        bytecode_lookups: &mut Vec<(BytecodeLookup<F>, Expression<F>)>,
+        lookups: &mut LookupsWithCondition<F>,
     ) {
         match self {
-            Opcode::LdU8 => LdU8::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::LdU64 => LdU64::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::LdU128 => LdU128::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::CastU8 => CastU8::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::CastU64 => CastU64::configure(cells, constraints, rw_lookups, bytecode_lookups),
+            Opcode::LdU8 => LdU8::configure(cells, constraints, lookups),
+            Opcode::LdU64 => LdU64::configure(cells, constraints, lookups),
+            Opcode::LdU128 => LdU128::configure(cells, constraints, lookups),
+            Opcode::CastU8 => CastU8::configure(cells, constraints, lookups),
+            Opcode::CastU64 => CastU64::configure(cells, constraints, lookups),
             Opcode::CastU128 => {
-                CastU128::configure(cells, constraints, rw_lookups, bytecode_lookups)
+                CastU128::configure(cells, constraints, lookups)
             }
-            Opcode::Pop => Pop::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Ret => Ret::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Add => Add::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Mul => Mul::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::CopyLoc => CopyLoc::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Sub => Sub::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Div => Div::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Mod => Mod::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::LdTrue => LdTrue::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::LdFalse => LdFalse::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Eq => Eq::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Neq => Neq::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::And => And::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Or => Or::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Not => Not::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::MoveLoc => MoveLoc::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::StLoc => StLoc::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Branch => Branch::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::BrTrue => BrTrue::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::BrFalse => BrFalse::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Call => Call::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Abort => Abort::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Le => Le::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Lt => Lt::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Ge => Ge::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Gt => Gt::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Pack => Pack::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Unpack => Unpack::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::MutBorrowLoc => {
-                MutBorrowLoc::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::ImmBorrowLoc => {
-                ImmBorrowLoc::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::ReadRef => ReadRef::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::WriteRef => {
-                WriteRef::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::FreezeRef => {
-                FreezeRef::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::ImmBorrowField => {
-                ImmBorrowField::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::MutBorrowField => {
-                MutBorrowField::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::MoveFrom => {
-                MoveFrom::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::MoveTo => MoveTo::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Exists => Exists::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::ImmBorrowGlobal => {
-                ImmBorrowGlobal::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::MutBorrowGlobal => {
-                MutBorrowGlobal::configure(cells, constraints, rw_lookups, bytecode_lookups)
-            }
-            Opcode::Stop => Stop::configure(cells, constraints, rw_lookups, bytecode_lookups),
-            Opcode::Nop => Nop::configure(cells, constraints, rw_lookups, bytecode_lookups),
+            Opcode::Pop => Pop::configure(cells, constraints, lookups),
+            Opcode::Ret => Ret::configure(cells, constraints, lookups),
+            Opcode::Add => Add::configure(cells, constraints, lookups),
+            Opcode::Mul => Mul::configure(cells, constraints, lookups),
+            Opcode::CopyLoc => CopyLoc::configure(cells, constraints, lookups),
+            Opcode::Sub => Sub::configure(cells, constraints, lookups),
+            Opcode::Div => Div::configure(cells, constraints, lookups),
+            Opcode::Mod => Mod::configure(cells, constraints, lookups),
+            Opcode::LdTrue => LdTrue::configure(cells, constraints, lookups),
+            Opcode::LdFalse => LdFalse::configure(cells, constraints, lookups),
+            Opcode::Eq => Eq::configure(cells, constraints, lookups),
+            Opcode::Neq => Neq::configure(cells, constraints, lookups),
+            Opcode::And => And::configure(cells, constraints, lookups),
+            Opcode::Or => Or::configure(cells, constraints, lookups),
+            Opcode::Not => Not::configure(cells, constraints, lookups),
+            Opcode::MoveLoc => MoveLoc::configure(cells, constraints, lookups),
+            Opcode::StLoc => StLoc::configure(cells, constraints, lookups),
+            Opcode::Branch => Branch::configure(cells, constraints, lookups),
+            Opcode::BrTrue => BrTrue::configure(cells, constraints, lookups),
+            Opcode::BrFalse => BrFalse::configure(cells, constraints, lookups),
+            Opcode::Call => Call::configure(cells, constraints, lookups),
+            Opcode::Abort => Abort::configure(cells, constraints, lookups),
+            Opcode::Le => Le::configure(cells, constraints, lookups),
+            Opcode::Lt => Lt::configure(cells, constraints, lookups),
+            Opcode::Ge => Ge::configure(cells, constraints, lookups),
+            Opcode::Gt => Gt::configure(cells, constraints, lookups),
+            Opcode::Pack => Pack::configure(cells, constraints, lookups),
+            Opcode::Unpack => Unpack::configure(cells, constraints, lookups),
+            Opcode::MutBorrowLoc => MutBorrowLoc::configure(cells, constraints, lookups),
+            Opcode::ImmBorrowLoc => ImmBorrowLoc::configure(cells, constraints, lookups),
+            Opcode::ReadRef => ReadRef::configure(cells, constraints, lookups),
+            Opcode::WriteRef => WriteRef::configure(cells, constraints, lookups),
+            Opcode::FreezeRef => FreezeRef::configure(cells, constraints, lookups),
+            Opcode::ImmBorrowField => ImmBorrowField::configure(cells, constraints, lookups),
+            Opcode::MutBorrowField => MutBorrowField::configure(cells, constraints, lookups),
+            Opcode::MoveFrom => MoveFrom::configure(cells, constraints, lookups),
+            Opcode::MoveTo => MoveTo::configure(cells, constraints, lookups),
+            Opcode::Exists => Exists::configure(cells, constraints, lookups),
+            Opcode::ImmBorrowGlobal => ImmBorrowGlobal::configure(cells, constraints, lookups),
+            Opcode::MutBorrowGlobal => MutBorrowGlobal::configure(cells, constraints, lookups),
+            Opcode::Stop => Stop::configure(cells, constraints, lookups),
+            Opcode::Nop => Nop::configure(cells, constraints, lookups),
         }
     }
 

--- a/vm-circuit/src/chips/execution_chip/opcode.rs
+++ b/vm-circuit/src/chips/execution_chip/opcode.rs
@@ -149,9 +149,7 @@ impl Opcode {
             Opcode::LdU128 => LdU128::configure(cells, constraints, lookups),
             Opcode::CastU8 => CastU8::configure(cells, constraints, lookups),
             Opcode::CastU64 => CastU64::configure(cells, constraints, lookups),
-            Opcode::CastU128 => {
-                CastU128::configure(cells, constraints, lookups)
-            }
+            Opcode::CastU128 => CastU128::configure(cells, constraints, lookups),
             Opcode::Pop => Pop::configure(cells, constraints, lookups),
             Opcode::Ret => Ret::configure(cells, constraints, lookups),
             Opcode::Add => Add::configure(cells, constraints, lookups),

--- a/vm-circuit/src/chips/execution_chip/step_chip.rs
+++ b/vm-circuit/src/chips/execution_chip/step_chip.rs
@@ -17,7 +17,8 @@ pub const STEP_CHIP_WIDTH: usize = 10;
 pub const STEP_HEIGHT: usize = 10; //todo: calculate step height automatically
 pub const NUM_OF_STEP_STATE: usize = 10; //pc, stack_size, call_index, locals_index, gc, auxiliary_1, auxiliary_2, auxiliary_3, module_index, func_index
 pub const MAX_OPERANDS_PER_STEP: usize = 3; //value_a, value_b, value_c
-pub const MAX_NUM_OF_ARGUMENTS: usize = 10; //todo: dynamic configure according to the real argument number
+pub const MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS: usize = 10; //max(method_arguments#, struct_fields#)
+                                                             //todo: dynamic configure according to the real argument number and struct fields
 
 #[derive(Clone, Debug)]
 pub struct StepChipCells<F: FieldExt> {
@@ -38,8 +39,8 @@ pub struct StepChipCells<F: FieldExt> {
     pub value_b: Cell<F>,
     pub value_c: Cell<F>,
 
-    pub args: Vec<Cell<F>>,
-    pub args_mask: Vec<Cell<F>>,
+    pub args_or_fields: Vec<Cell<F>>,
+    pub args_or_fields_mask: Vec<Cell<F>>,
 
     pub bytes: Vec<Cell<F>>,
 
@@ -101,7 +102,7 @@ impl<F: FieldExt> StepChip<F> {
         let cell_amount = NUM_OF_STEP_STATE
             + MAX_OPERANDS_PER_STEP
             + Opcode::total_numbers()
-            + MAX_NUM_OF_ARGUMENTS * 2
+            + MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS * 2
             + NUM_OF_BYTES_U128;
         let mut cells = VecDeque::with_capacity(cell_amount);
         meta.create_gate("step", |meta| {
@@ -138,8 +139,12 @@ impl<F: FieldExt> StepChip<F> {
             value_b: cells.pop_front().unwrap(),
             value_c: cells.pop_front().unwrap(),
 
-            args: cells.drain(0..MAX_NUM_OF_ARGUMENTS).collect(),
-            args_mask: cells.drain(0..MAX_NUM_OF_ARGUMENTS).collect(),
+            args_or_fields: cells
+                .drain(0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS)
+                .collect(),
+            args_or_fields_mask: cells
+                .drain(0..MAX_NUM_OF_ARGUMENTS_OR_STRUCT_FIELDS)
+                .collect(),
 
             bytes: cells.drain(0..NUM_OF_BYTES_U128).collect(),
 

--- a/vm-circuit/src/chips/execution_chip/step_chip.rs
+++ b/vm-circuit/src/chips/execution_chip/step_chip.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::lookup_tables::{
-    BytecodeLookupTable, LookupsWithCondition, RWTable,
+    BytecodeLookupTable, CallLookupTable, LookupsWithCondition, RWTable,
 };
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::utilities::*;
@@ -99,6 +99,7 @@ impl<F: FieldExt> StepChip<F> {
         advices: [Column<Advice>; STEP_CHIP_WIDTH],
         rw_table: &RWTable,
         bytecode_table: &BytecodeLookupTable,
+        calls_table: &CallLookupTable,
     ) -> <Self as Chip<F>>::Config {
         // query advice for each state of the step
         let cell_amount = NUM_OF_STEP_STATE
@@ -239,6 +240,39 @@ impl<F: FieldExt> StepChip<F> {
                         s_step * lookup.operand * cond.clone(),
                         bytecode_table.operand_column,
                     ),
+                ]
+            });
+        }
+
+        for (lookup, cond) in lookups.call_lookups {
+            meta.lookup(|meta| {
+                let s_step = meta.query_selector(s_step);
+                vec![
+                    (
+                        s_step.clone() * lookup.type_ * cond.clone(),
+                        calls_table.type_column,
+                    ),
+                    (
+                        s_step.clone() * lookup.module_index * cond.clone(),
+                        calls_table.module_index_column,
+                    ),
+                    (
+                        s_step.clone() * lookup.function_index * cond.clone(),
+                        calls_table.function_index_column,
+                    ),
+                    (
+                        s_step.clone() * lookup.pc * cond.clone(),
+                        calls_table.pc_column,
+                    ),
+                    (
+                        s_step.clone() * lookup.next_module_index * cond.clone(),
+                        calls_table.callee_module_index_column,
+                    ),
+                    (
+                        s_step.clone() * lookup.next_function_index * cond.clone(),
+                        calls_table.callee_function_index_column,
+                    ),
+                    (s_step * lookup.next_pc * cond, calls_table.next_pc_column),
                 ]
             });
         }

--- a/vm-circuit/src/chips/execution_chip/step_chip.rs
+++ b/vm-circuit/src/chips/execution_chip/step_chip.rs
@@ -1,6 +1,8 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::lookup_tables::{BytecodeLookupTable, RWTable};
+use crate::chips::execution_chip::lookup_tables::{
+    BytecodeLookupTable, LookupsWithCondition, RWTable,
+};
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::utilities::*;
 use crate::witness::execution_steps::ExecutionStep;
@@ -165,17 +167,9 @@ impl<F: FieldExt> StepChip<F> {
 
         // config each execution path of the step
         let mut constraints = Vec::new();
-        let mut rw_lookups = Vec::new();
-        let mut bytecode_lookups = Vec::new();
+        let mut lookups = LookupsWithCondition::new();
         StepChip::constrain_step_conditions(&cells, &mut constraints);
-        Opcode::iter().for_each(|opcode| {
-            opcode.configure(
-                &cells,
-                &mut constraints,
-                &mut rw_lookups,
-                &mut bytecode_lookups,
-            )
-        });
+        Opcode::iter().for_each(|opcode| opcode.configure(&cells, &mut constraints, &mut lookups));
 
         let s_step = meta.complex_selector();
 
@@ -189,7 +183,7 @@ impl<F: FieldExt> StepChip<F> {
                 .map(move |(name, constraint)| (name, s_step.clone() * constraint))
         });
 
-        for (lookup, cond) in rw_lookups {
+        for (lookup, cond) in lookups.rw_lookups {
             meta.lookup_any(|meta| {
                 let s_step = meta.query_selector(s_step);
                 vec![
@@ -221,7 +215,7 @@ impl<F: FieldExt> StepChip<F> {
             });
         }
 
-        for (lookup, cond) in bytecode_lookups {
+        for (lookup, cond) in lookups.bytecode_lookups {
             meta.lookup(|meta| {
                 let s_step = meta.query_selector(s_step);
                 vec![

--- a/vm-circuit/src/witness.rs
+++ b/vm-circuit/src/witness.rs
@@ -8,10 +8,12 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
 use std::fmt;
+use crate::witness::function_calls::FunctionCall;
 
 pub mod bytecode_table;
 pub mod execution_steps;
 pub mod rw_operations;
+pub mod function_calls;
 
 pub const DEFAULT_MAX_CALL_INDEX: usize = 16;
 pub const DEFAULT_MAX_LOCALS_SIZE: usize = 16;
@@ -76,6 +78,7 @@ pub struct Witness<F: FieldExt> {
     pub exec_steps: Vec<ExecutionStep<F>>,
     pub rw_operations: RWOperations<F>,
     pub bytecode_table: BytecodeTable,
+    pub func_calls: Vec<FunctionCall>,
     pub circuit_config: CircuitConfig,
 }
 
@@ -84,12 +87,14 @@ impl<F: FieldExt> Witness<F> {
         exec_steps: Vec<ExecutionStep<F>>,
         rw_operations: Vec<RWOperation<F>>,
         bytecode_table: BytecodeTable,
+        func_calls: Vec<FunctionCall>,
         circuit_config: CircuitConfig,
     ) -> Self {
         Witness {
             exec_steps,
             rw_operations: RWOperations(rw_operations),
             bytecode_table,
+            func_calls,
             circuit_config,
         }
     }
@@ -160,6 +165,11 @@ impl<F: FieldExt> fmt::Debug for Witness<F> {
         writeln!(f, "Bytecode table:")?;
         self.bytecode_table.as_inner().iter().for_each(|bytecode| {
             writeln!(f, "{:?}", bytecode).unwrap();
+        });
+        writeln!(f)?;
+        writeln!(f, "Function calls table:")?;
+        self.func_calls.iter().for_each(|call| {
+            writeln!(f, "{:?}", call).unwrap();
         });
         writeln!(f)?;
         writeln!(f, "Circuit Config:")?;

--- a/vm-circuit/src/witness.rs
+++ b/vm-circuit/src/witness.rs
@@ -3,17 +3,17 @@
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::witness::bytecode_table::BytecodeTable;
 use crate::witness::execution_steps::ExecutionStep;
+use crate::witness::function_calls::FunctionCall;
 use crate::witness::rw_operations::{RWOperation, RWOperations};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
 use std::fmt;
-use crate::witness::function_calls::FunctionCall;
 
 pub mod bytecode_table;
 pub mod execution_steps;
-pub mod rw_operations;
 pub mod function_calls;
+pub mod rw_operations;
 
 pub const DEFAULT_MAX_CALL_INDEX: usize = 16;
 pub const DEFAULT_MAX_LOCALS_SIZE: usize = 16;

--- a/vm-circuit/src/witness/execution_steps.rs
+++ b/vm-circuit/src/witness/execution_steps.rs
@@ -1,3 +1,5 @@
+// Copyright (c) zkMove Authors
+
 use crate::chips::execution_chip::opcode::Opcode;
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::value::Value;

--- a/vm-circuit/src/witness/function_calls.rs
+++ b/vm-circuit/src/witness/function_calls.rs
@@ -3,23 +3,34 @@
 use halo2_proofs::arithmetic::FieldExt;
 
 #[derive(Clone, Debug, Copy)]
+pub enum EntryType {
+    CALL = 0,
+    RET,
+}
+
+// a struct to record the location of function call and return
+#[derive(Clone, Debug, Copy)]
 pub struct FunctionCall {
-    pub module_index: u16,   //caller's module index
-    pub function_index: u16, //caller's function index
+    pub type_: EntryType,
+    pub module_index: u16,
+    pub function_index: u16,
     pub pc: u16,
-    pub callee_module_index: u16,
-    pub callee_function_index: u16,
+    pub next_module_index: u16,
+    pub next_function_index: u16,
+    pub next_pc: u16,
 }
 
 // convert FunctionCall into a vector of field values
 impl<F: FieldExt> From<FunctionCall> for Vec<F> {
     fn from(func_call: FunctionCall) -> Vec<F> {
         vec![
+            F::from_u128(func_call.type_ as u128),
             F::from_u128(func_call.module_index as u128),
             F::from_u128(func_call.function_index as u128),
             F::from_u128(func_call.pc as u128),
-            F::from_u128(func_call.callee_module_index as u128),
-            F::from_u128(func_call.callee_function_index as u128),
+            F::from_u128(func_call.next_module_index as u128),
+            F::from_u128(func_call.next_function_index as u128),
+            F::from_u128(func_call.next_pc as u128),
         ]
     }
 }

--- a/vm-circuit/src/witness/function_calls.rs
+++ b/vm-circuit/src/witness/function_calls.rs
@@ -4,7 +4,7 @@ use halo2_proofs::arithmetic::FieldExt;
 
 #[derive(Clone, Debug, Copy)]
 pub struct FunctionCall {
-    pub module_index: u16, //caller's module index
+    pub module_index: u16,   //caller's module index
     pub function_index: u16, //caller's function index
     pub pc: u16,
     pub callee_module_index: u16,

--- a/vm-circuit/src/witness/function_calls.rs
+++ b/vm-circuit/src/witness/function_calls.rs
@@ -1,0 +1,25 @@
+// Copyright (c) zkMove Authors
+
+use halo2_proofs::arithmetic::FieldExt;
+
+#[derive(Clone, Debug, Copy)]
+pub struct FunctionCall {
+    pub module_index: u16, //caller's module index
+    pub function_index: u16, //caller's function index
+    pub pc: u16,
+    pub callee_module_index: u16,
+    pub callee_function_index: u16,
+}
+
+// convert FunctionCall into a vector of field values
+impl<F: FieldExt> From<FunctionCall> for Vec<F> {
+    fn from(func_call: FunctionCall) -> Vec<F> {
+        vec![
+            F::from_u128(func_call.module_index as u128),
+            F::from_u128(func_call.function_index as u128),
+            F::from_u128(func_call.pc as u128),
+            F::from_u128(func_call.callee_module_index as u128),
+            F::from_u128(func_call.callee_function_index as u128),
+        ]
+    }
+}

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -18,8 +18,8 @@ use movelang::value::{GlobalValue, Value};
 use std::sync::Arc;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::witness::execution_steps::ExecutionStep;
-use vm_circuit::witness::rw_operations::RWOperation;
 use vm_circuit::witness::function_calls::FunctionCall;
+use vm_circuit::witness::rw_operations::RWOperation;
 
 pub struct Interpreter<F: FieldExt> {
     pub stack: EvalStack<F>,

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -126,25 +126,40 @@ impl<F: FieldExt> Interpreter<F> {
             let status = frame.execute(self, loader, data_store, exec_steps, rw_operations)?;
             match status {
                 ExitStatus::Return => {
+                    let step_current = exec_steps
+                        .last()
+                        .ok_or_else(|| RuntimeError::new(StatusCode::ShouldNotReachHere))?;
                     if let Some(caller_frame) = self.frames.pop() {
+                        // record function ret
+                        let next_module_index = caller_frame
+                            .module_index(data_store)
+                            .ok_or_else(|| RuntimeError::new(StatusCode::ModuleNotFound))?;
+                        let next_function_index = caller_frame.func().index().0;
+                        func_calls.push(FunctionCall {
+                            type_: EntryType::RET,
+                            module_index: step_current.module_index,
+                            function_index: step_current.function_index,
+                            pc: step_current.pc,
+                            next_module_index,
+                            next_function_index,
+                            next_pc: caller_frame.pc() + 1, //next instruction after 'Call'
+                        });
+
                         frame = caller_frame;
                         frame.add_pc();
                     } else {
-                        let last = exec_steps
-                            .last()
-                            .ok_or_else(|| RuntimeError::new(StatusCode::ShouldNotReachHere))?;
                         let stop = ExecutionStep {
                             opcode: Opcode::Stop,
-                            pc: last.pc,
-                            stack_size: last.stack_size,
-                            call_index: last.call_index,
-                            locals_index: last.locals_index,
-                            gc: last.gc,
-                            module_index: last.module_index,
-                            function_index: last.function_index,
-                            auxiliary_1: last.auxiliary_1.clone(),
-                            auxiliary_2: last.auxiliary_2.clone(),
-                            auxiliary_3: last.auxiliary_3.clone(),
+                            pc: step_current.pc,
+                            stack_size: step_current.stack_size,
+                            call_index: step_current.call_index,
+                            locals_index: step_current.locals_index,
+                            gc: step_current.gc,
+                            module_index: step_current.module_index,
+                            function_index: step_current.function_index,
+                            auxiliary_1: step_current.auxiliary_1.clone(),
+                            auxiliary_2: step_current.auxiliary_2.clone(),
+                            auxiliary_3: step_current.auxiliary_3.clone(),
                         };
                         exec_steps.push(stop);
                         return Ok(());

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::witness::execution_steps::ExecutionStep;
 use vm_circuit::witness::rw_operations::RWOperation;
+use vm_circuit::witness::function_calls::FunctionCall;
 
 pub struct Interpreter<F: FieldExt> {
     pub stack: EvalStack<F>,
@@ -113,6 +114,7 @@ impl<F: FieldExt> Interpreter<F> {
         data_store: &mut StateStore<F>,
         exec_steps: &mut Vec<ExecutionStep<F>>,
         rw_operations: &mut Vec<RWOperation<F>>,
+        func_calls: &mut Vec<FunctionCall>,
     ) -> VmResult<()> {
         let mut locals = Locals::new(entry.local_count());
 
@@ -154,10 +156,27 @@ impl<F: FieldExt> Interpreter<F> {
                     execution_step.auxiliary_1 = Some(Value::u64(func.arg_count() as u64, None)?);
                     execution_step.call_index = call_index;
                     trace!("step #{}, {:?}", self.step, execution_step);
+                    let module_index = execution_step.module_index;
+                    let function_index = execution_step.function_index;
+                    let pc = execution_step.pc;
                     exec_steps.push(execution_step);
                     self.step += 1;
                     trace!("Call into function: {:?}", func.name());
                     let callee_frame = self.make_frame(func, call_index + 1, rw_operations)?;
+
+                    // record function call
+                    let callee_module_index = callee_frame
+                        .module_index(data_store)
+                        .ok_or_else(|| RuntimeError::new(StatusCode::ModuleNotFound))?;
+                    let callee_function_index = callee_frame.func().index().0;
+                    func_calls.push(FunctionCall {
+                        module_index,
+                        function_index,
+                        pc,
+                        callee_module_index,
+                        callee_function_index,
+                    });
+
                     callee_frame.print_frame();
                     self.frames.push(frame)?;
                     frame = callee_frame;

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -18,7 +18,7 @@ use movelang::value::{GlobalValue, Value};
 use std::sync::Arc;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::witness::execution_steps::ExecutionStep;
-use vm_circuit::witness::function_calls::FunctionCall;
+use vm_circuit::witness::function_calls::{EntryType, FunctionCall};
 use vm_circuit::witness::rw_operations::RWOperation;
 
 pub struct Interpreter<F: FieldExt> {
@@ -154,6 +154,7 @@ impl<F: FieldExt> Interpreter<F> {
                     let call_index = self.frames.size();
                     let func = loader.function_from_handle(frame.func(), index);
                     execution_step.auxiliary_1 = Some(Value::u64(func.arg_count() as u64, None)?);
+                    execution_step.auxiliary_2 = Some(Value::u64(index.0 as u64, None)?);
                     execution_step.call_index = call_index;
                     trace!("step #{}, {:?}", self.step, execution_step);
                     let module_index = execution_step.module_index;
@@ -165,16 +166,18 @@ impl<F: FieldExt> Interpreter<F> {
                     let callee_frame = self.make_frame(func, call_index + 1, rw_operations)?;
 
                     // record function call
-                    let callee_module_index = callee_frame
+                    let next_module_index = callee_frame
                         .module_index(data_store)
                         .ok_or_else(|| RuntimeError::new(StatusCode::ModuleNotFound))?;
-                    let callee_function_index = callee_frame.func().index().0;
+                    let next_function_index = callee_frame.func().index().0;
                     func_calls.push(FunctionCall {
+                        type_: EntryType::CALL,
                         module_index,
                         function_index,
                         pc,
-                        callee_module_index,
-                        callee_function_index,
+                        next_module_index,
+                        next_function_index,
+                        next_pc: 0,
                     });
 
                     callee_frame.print_frame();

--- a/vm/src/runtime.rs
+++ b/vm/src/runtime.rs
@@ -76,6 +76,7 @@ impl<F: FieldExt> Runtime<F> {
 
         let mut exec_steps = Vec::new();
         let mut rw_operations = Vec::new();
+        let mut func_calls = Vec::new();
         interp.run_script(
             entry,
             args,
@@ -84,6 +85,7 @@ impl<F: FieldExt> Runtime<F> {
             data_store,
             &mut exec_steps,
             &mut rw_operations,
+            &mut func_calls,
         )?;
 
         let bytecodes = BytecodeTable::from((script.clone(), modules));
@@ -91,6 +93,7 @@ impl<F: FieldExt> Runtime<F> {
             exec_steps,
             rw_operations,
             bytecodes,
+            func_calls,
             circuit_config,
         ))
     }

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -47,6 +47,7 @@ fn test_execution_step() -> VmResult<()> {
 
     let mut exec_steps = Vec::new();
     let mut rw_operations = Vec::new();
+    let mut func_calls = Vec::new();
     interp
         .run_script(
             entry,
@@ -56,6 +57,7 @@ fn test_execution_step() -> VmResult<()> {
             &mut data_store,
             &mut exec_steps,
             &mut rw_operations,
+            &mut func_calls,
         )
         .unwrap();
 
@@ -190,7 +192,7 @@ fn test_execution_step() -> VmResult<()> {
     assert_eq!(rw_operations[5], expected_rw_op_5, "result is not expected");
 
     let circuit_config = CircuitConfig::default();
-    let witness = Witness::new(exec_steps, rw_operations, bytecodes, circuit_config);
+    let witness = Witness::new(exec_steps, rw_operations, bytecodes, vec![], circuit_config);
     let vm_circuit = VmCircuit { witness };
     let k = 10; // todo: how to chose a proper degree
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
@@ -373,7 +375,7 @@ fn test_nop_step() -> VmResult<()> {
     ];
 
     let circuit_config = CircuitConfig::default();
-    let witness = Witness::new(exec_steps, rw_operations, bytecodes, circuit_config);
+    let witness = Witness::new(exec_steps, rw_operations, bytecodes, vec![], circuit_config);
     let vm_circuit = VmCircuit { witness };
     let k = 10;
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {


### PR DESCRIPTION
- construct CallLookupTable
- for instruction call/ret, next_module_index/next_func_index/next_pc must be in CallLookupTable
- for instructions other than call/ret, module_index/func_index is equal to the next step