### PR TITLE
stack: fix the indexing of popn op

### DIFF
--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -71,10 +71,10 @@ impl<F: FieldExt> EvalStack<F> {
 
         for (i, value) in values.iter().enumerate() {
             let stack_op = StackOp {
-                address: self.0.len() - values.len() + 1 + i,
+                address: remaining_stack_size + 1 + i,
                 value: value.clone(),
                 rw: RW::READ,
-                gc: rw_operations.len() + i,
+                gc: rw_operations.len(),
             };
             rw_operations.push(RWOperation::StackOp(stack_op));
         }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -71,7 +71,7 @@ impl<F: FieldExt> EvalStack<F> {
 
         for (i, value) in values.iter().enumerate() {
             let stack_op = StackOp {
-                address: remaining_stack_size + 1 + i,
+                address: remaining_stack_size + i,
                 value: value.clone(),
                 rw: RW::READ,
                 gc: rw_operations.len(),


### PR DESCRIPTION
stack size is changed after split_off, and len of rw_opertions also changes after push.