### PR TITLE
implement move_from/move_to using the new added flattened-struct

### DIFF
--- a/functional-tests/tests/modules/counter.move
+++ b/functional-tests/tests/modules/counter.move
@@ -3,9 +3,21 @@ module Counter {
     struct Counter has key, store {
         value: u64,
     }
+    struct NestedCounter has key, store {
+        outer_value: u128,
+        counter: Counter,
+    }
 
     public fun init(account: &signer) {
         move_to(account, Counter { value: 0 });
+    }
+    public fun init_nested_counter(account: &signer) {
+        move_to(account, NestedCounter {
+            outer_value: 1,
+            counter: Counter {
+                value: 2
+            }
+        });
     }
 
     public fun check(addr: address): bool {
@@ -24,6 +36,10 @@ module Counter {
 
     public fun delete(account: address) acquires Counter {
         let Counter { value: _ } = move_from<Counter>(account);
+    }
+    public fun delete_nested_counter(account: address) acquires NestedCounter {
+        let NestedCounter { outer_value: _, counter } = move_from<NestedCounter>(account);
+        let Counter {value: _} = counter;
     }
 }
 }

--- a/functional-tests/tests/scripts/counter.move
+++ b/functional-tests/tests/scripts/counter.move
@@ -2,18 +2,22 @@
 //! signer: 0x1
 //! args: 0x1
 script {
-//    use 0x1::Counter;
+    use 0x1::Counter;
 
     // We haven't implemented Signer.move yet, so we have to pass
     // the same address 0x1 twice, the first time as the signer and
     // the second time as the account address
-    fun main(_account: signer, _addr: address) {
-//        Counter::init(&account);
-//        let is_exist = Counter::check(addr);
-//        assert!(is_exist, 101);
-//        Counter::incr(addr);
-//        let value = Counter::value(addr);
-//        assert!(value == 1, 102);
-//        Counter::delete(addr);
+    fun main(account: signer, addr: address) {
+       Counter::init(&account);
+       // let is_exist = Counter::check(addr);
+       // assert!(is_exist, 101);
+       // Counter::incr(addr);
+       // let value = Counter::value(addr);
+       // assert!(value == 1, 102);
+       Counter::delete(addr);
+
+
+       Counter::init_nested_counter(&account);
+       Counter::delete_nested_counter(addr);
     }
 }

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -112,6 +112,11 @@ impl<F: FieldExt> ValueAddress<F> {
                 let path = parent.address_path()?;
                 Ok(path.extend(index.0))
             }
+            Self::Global(addr, sd_index) => Ok(AddressPath(vec![
+                // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
+                addr.value().get_lower_128() as usize,
+                sd_index.0 as usize,
+            ])),
             _ => unimplemented!(),
         }
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -34,7 +34,7 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             cells.frame_index.expression.clone() - cells.next_frame_index.expression.clone();
         let word_elem_num = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone()
-            + word_elem_num.clone() * 2.expr() // one for global read resource, one for stack push value
+            + word_elem_num.clone() * 3.expr() // two for global read resource, one for stack push value
             + 1.expr(); // stack pop account_address
         let module_index =
             cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
@@ -62,21 +62,25 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
         ));
 
         for i in 0..WORD_CAPACITY {
-            let (read_global, write_stack) = RWLookup::move_from_global_to_stack(
-                cells.gc.expression.clone() + (i as u64 + 1).expr(),
-                account_address_expr.clone(),
-                sd_index_expr.clone(),
-                cells.stack_size.expression.clone(),
-                cells.word_a_addr_ext_0[i].expression.clone(),
-                cells.word_a_addr_ext_1[i].expression.clone(),
-                cells.word_a[i].expression.clone(),
-                word_elem_num.clone(),
-            );
+            let (read_global, write_invalid_to_global, write_stack) =
+                RWLookup::move_from_global_to_stack(
+                    cells.gc.expression.clone() + (i as u64 + 1).expr(),
+                    account_address_expr.clone(),
+                    sd_index_expr.clone(),
+                    cells.stack_size.expression.clone(),
+                    cells.word_a_addr_ext_0[i].expression.clone(),
+                    cells.word_a_addr_ext_1[i].expression.clone(),
+                    cells.word_a[i].expression.clone(),
+                    word_elem_num.clone(),
+                );
             lookups.rw_lookups.push((
                 read_global,
                 cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),
             ));
-
+            lookups.rw_lookups.push((
+                write_invalid_to_global,
+                cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),
+            ));
             lookups.rw_lookups.push((
                 write_stack,
                 cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -1,10 +1,10 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::LookupBytecode;
+use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::Instructions;
 use crate::chips::execution_chip::lookup_tables::{rw_table::RWLookup, LookupsWithCondition};
 use crate::chips::execution_chip::opcode::Opcode;
-use crate::chips::execution_chip::step_chip::StepChipCells;
+use crate::chips::execution_chip::step_chip::{StepChipCells, WORD_CAPACITY};
 use crate::chips::utilities::Expr;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::{RWOperations, RW};
@@ -32,7 +32,10 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             cells.stack_size.expression.clone() - cells.next_stack_size.expression.clone();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cells.next_frame_index.expression.clone();
-        let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let word_elem_num = cells.auxiliary_3.expression.clone();
+        let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone()
+            + word_elem_num.clone() * 2.expr() // one for global read resource, one for stack push value
+            + 1.expr(); // stack pop account_address
         let module_index =
             cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
         let func_index =
@@ -45,45 +48,45 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
             ("module index", cond.clone() * module_index),
             ("function index", cond.clone() * func_index),
         ]);
-
+        let account_address_expr = cells.value_a.expression.clone();
+        let sd_index_expr = cells.auxiliary_1.expression.clone();
         lookups.rw_lookups.push((
             RWLookup::stack_pop(
                 cells.gc.expression.clone(),
                 cells.stack_size.expression.clone(),
                 0.expr(),
                 0.expr(),
-                cells.value_a.expression.clone(), //address
+                account_address_expr.clone(),
             ),
             cond.clone(),
         ));
 
-        lookups.rw_lookups.push((
-            RWLookup::global_read(
-                cells.gc.expression.clone() + 1.expr(),
-                cells.value_a.expression.clone(), //address
-                cells.value_b.expression.clone(),
-                cells.auxiliary_1.expression.clone(), //sd_index
-                0.expr(),
-                0.expr(),
-            ),
-            cond.clone(),
-        ));
+        for i in 0..WORD_CAPACITY {
+            let (read_global, write_stack) = RWLookup::move_from_global_to_stack(
+                cells.gc.expression.clone() + (i as u64 + 1).expr(),
+                account_address_expr.clone(),
+                sd_index_expr.clone(),
+                cells.stack_size.expression.clone(),
+                cells.word_a_addr_ext_0[i].expression.clone(),
+                cells.word_a_addr_ext_1[i].expression.clone(),
+                cells.word_a[i].expression.clone(),
+                word_elem_num.clone(),
+            );
+            lookups.rw_lookups.push((
+                read_global,
+                cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),
+            ));
 
-        lookups.rw_lookups.push((
-            RWLookup::stack_push(
-                cells.gc.expression.clone() + 2.expr(),
-                cells.stack_size.expression.clone() - 1.expr(),
-                0.expr(),
-                0.expr(),
-                cells.value_b.expression.clone(),
-            ),
-            cond.clone(),
-        ));
+            lookups.rw_lookups.push((
+                write_stack,
+                cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),
+            ));
+        }
 
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::MoveFrom,
-            cells.auxiliary_1.expression.clone(),
+            sd_index_expr,
             &mut lookups.bytecode_lookups,
             cond,
         );
@@ -98,14 +101,29 @@ impl<F: FieldExt> Instructions<F> for MoveFrom<F> {
     ) -> Result<(), Error> {
         let op = rw_operations.0.get(step.gc).ok_or(Error::Synthesis)?;
         debug_assert!(op.rw() == RW::READ);
+
+        // account address
         cells.value_a.assign(region, offset, op.value().value())?;
 
-        let op = rw_operations.0.get(step.gc + 1).ok_or(Error::Synthesis)?;
-        debug_assert!(op.rw() == RW::READ);
-        cells.value_b.assign(region, offset, op.value().value())?;
+        // resource structs
+        let word_element_num = Word::get_word_element_num(region, offset, step, cells)?;
+        Word::assign_word_a(
+            region,
+            offset,
+            step,
+            rw_operations,
+            cells,
+            step.gc + 1,
+            word_element_num,
+        )?;
+        let sd_index = rw_operations
+            .0
+            .get(step.gc + 1)
+            .ok_or(Error::Synthesis)?
+            .sd_index();
         cells
             .auxiliary_1
-            .assign(region, offset, Some(F::from_u128(op.sd_index() as u128)))?;
+            .assign(region, offset, Some(F::from_u128(sd_index as u128)))?;
 
         Ok(())
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -1,10 +1,10 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::LookupBytecode;
+use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::Instructions;
 use crate::chips::execution_chip::lookup_tables::{rw_table::RWLookup, LookupsWithCondition};
 use crate::chips::execution_chip::opcode::Opcode;
-use crate::chips::execution_chip::step_chip::StepChipCells;
+use crate::chips::execution_chip::step_chip::{StepChipCells, WORD_CAPACITY};
 use crate::chips::utilities::Expr;
 use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::{RWOperations, RW};
@@ -31,7 +31,10 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
             - 2.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cells.next_frame_index.expression.clone();
-        let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone() + 3.expr();
+        let word_elem_num = cells.auxiliary_3.expression.clone();
+        let gc_expr = cells.gc.expression.clone() - cells.next_gc.expression.clone()
+            + 2.expr() * word_elem_num
+            + 1.expr();
         let module_index =
             cells.module_index.expression.clone() - cells.next_module_index.expression.clone();
         let func_index =
@@ -44,47 +47,47 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
             ("module index", cond.clone() * module_index),
             ("function index", cond.clone() * func_index),
         ]);
-
-        lookups.rw_lookups.push((
-            RWLookup::stack_pop(
-                cells.gc.expression.clone(),
+        let global_address = cells.value_c.expression.clone();
+        let sd_index = cells.auxiliary_1.expression.clone();
+        let word_elem_num = cells.auxiliary_3.expression.clone();
+        for i in 0..WORD_CAPACITY {
+            let (read_stack, write_global) = RWLookup::move_to_global(
+                cells.gc.expression.clone() + (i as u64).expr(),
                 cells.stack_size.expression.clone(),
-                0.expr(),
-                0.expr(),
-                cells.value_a.expression.clone(), //global value
-            ),
-            cond.clone(),
-        ));
+                global_address.clone(),
+                sd_index.clone(),
+                cells.word_a_addr_ext_0[i].expression.clone(),
+                cells.word_a_addr_ext_1[i].expression.clone(),
+                cells.word_a[i].expression.clone(),
+                word_elem_num.clone(),
+            );
+            lookups.rw_lookups.push((
+                read_stack,
+                cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),
+            ));
+            lookups.rw_lookups.push((
+                write_global,
+                cond.clone() * (1.expr() - cells.word_a_mask[i].expression.clone()),
+            ));
+        }
 
         lookups.rw_lookups.push((
             RWLookup::stack_pop(
-                cells.gc.expression.clone() + 1.expr(),
+                cells.gc.expression.clone() + word_elem_num,
                 cells.stack_size.expression.clone() - 1.expr(),
                 0.expr(),
                 0.expr(),
-                cells.value_b.expression.clone(), //signer
+                cells.value_b.expression.clone(),
             ),
             cond.clone(),
         ));
 
-        lookups.rw_lookups.push((
-            RWLookup::global_write(
-                cells.gc.expression.clone() + 2.expr(),
-                cells.value_c.expression.clone(), //address
-                cells.value_a.expression.clone(),
-                cells.auxiliary_1.expression.clone(), //sd_index
-                0.expr(),
-                0.expr(),
-            ),
-            cond.clone(),
-        ));
-
-        // todo: constrain the relationship between value_b (signer) and value_c (address)
+        // todo: constrain the relationship between value_b (signer reference) and value_c (address)
 
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::MoveTo,
-            cells.auxiliary_1.expression.clone(),
+            sd_index,
             &mut lookups.bytecode_lookups,
             cond,
         );
@@ -97,15 +100,31 @@ impl<F: FieldExt> Instructions<F> for MoveTo<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let op = rw_operations.0.get(step.gc).ok_or(Error::Synthesis)?;
-        debug_assert!(op.rw() == RW::READ);
-        cells.value_a.assign(region, offset, op.value().value())?;
+        // word_a is resource on stack
+        let word_element_num = Word::get_word_element_num(region, offset, step, cells)?;
+        Word::assign_word_a(
+            region,
+            offset,
+            step,
+            rw_operations,
+            cells,
+            step.gc,
+            word_element_num,
+        )?;
 
-        let op = rw_operations.0.get(step.gc + 1).ok_or(Error::Synthesis)?;
+        // value_b is the signer reference
+        let op = rw_operations
+            .0
+            .get(step.gc + word_element_num)
+            .ok_or(Error::Synthesis)?;
         debug_assert!(op.rw() == RW::READ);
         cells.value_b.assign(region, offset, op.value().value())?;
 
-        let op = rw_operations.0.get(step.gc + 2).ok_or(Error::Synthesis)?;
+        // value c is the global address
+        let op = rw_operations
+            .0
+            .get(step.gc + word_element_num + 1)
+            .ok_or(Error::Synthesis)?;
         debug_assert!(op.rw() == RW::WRITE);
         cells
             .value_c

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
@@ -361,7 +361,7 @@ impl<F: FieldExt> RWLookup<F> {
                 value: 0.expr(),
             },
             RWLookup {
-                gc: gc + word_element_num * F::from_u128(2),
+                gc: gc + word_element_num * 2.expr(),
                 rw_target: (RWTarget::Stack as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
@@ -336,21 +336,32 @@ impl<F: FieldExt> RWLookup<F> {
         address_ext_1: Expression<F>,
         value: Expression<F>,
         word_element_num: Expression<F>,
-    ) -> (RWLookup<F>, RWLookup<F>) {
+    ) -> (RWLookup<F>, RWLookup<F>, RWLookup<F>) {
         (
             RWLookup {
                 gc: gc.clone(),
                 rw_target: (RWTarget::Global as u64).expr(),
                 rw: (RW::READ as u64).expr(),
                 frame_index: 0.expr(),
-                address: global_address,
-                sd_index,
+                address: global_address.clone(),
+                sd_index: sd_index.clone(),
                 address_ext_0: address_ext_0.clone(),
                 address_ext_1: address_ext_1.clone(),
                 value: value.clone(),
             },
             RWLookup {
-                gc: gc + word_element_num,
+                gc: gc.clone() + word_element_num.clone(),
+                rw_target: (RWTarget::Global as u64).expr(),
+                rw: (RW::WRITE as u64).expr(),
+                frame_index: 0.expr(),
+                address: global_address,
+                sd_index,
+                address_ext_0: address_ext_0.clone(),
+                address_ext_1: address_ext_1.clone(),
+                value: 0.expr(),
+            },
+            RWLookup {
+                gc: gc + word_element_num * F::from_u128(2),
                 rw_target: (RWTarget::Stack as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
@@ -326,6 +326,79 @@ impl<F: FieldExt> RWLookup<F> {
             sd_index,
         }
     }
+    #[allow(clippy::too_many_arguments)]
+    pub fn move_from_global_to_stack(
+        gc: Expression<F>,
+        global_address: Expression<F>,
+        sd_index: Expression<F>,
+        stack_size: Expression<F>,
+        address_ext_0: Expression<F>,
+        address_ext_1: Expression<F>,
+        value: Expression<F>,
+        word_element_num: Expression<F>,
+    ) -> (RWLookup<F>, RWLookup<F>) {
+        (
+            RWLookup {
+                gc: gc.clone(),
+                rw_target: (RWTarget::Global as u64).expr(),
+                rw: (RW::READ as u64).expr(),
+                frame_index: 0.expr(),
+                address: global_address,
+                sd_index,
+                address_ext_0: address_ext_0.clone(),
+                address_ext_1: address_ext_1.clone(),
+                value: value.clone(),
+            },
+            RWLookup {
+                gc: gc + word_element_num,
+                rw_target: (RWTarget::Stack as u64).expr(),
+                rw: (RW::WRITE as u64).expr(),
+                frame_index: 0.expr(),
+                address: stack_size - 1.expr(),
+                address_ext_0,
+                address_ext_1,
+                value,
+                sd_index: 0.expr(),
+            },
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn move_to_global(
+        gc: Expression<F>,
+        stack_size: Expression<F>,
+        global_address: Expression<F>,
+        sd_index: Expression<F>,
+        address_ext_0: Expression<F>,
+        address_ext_1: Expression<F>,
+        value: Expression<F>,
+        word_elem_num: Expression<F>,
+    ) -> (RWLookup<F>, RWLookup<F>) {
+        (
+            RWLookup {
+                gc: gc.clone(),
+                rw_target: (RWTarget::Stack as u64).expr(),
+                rw: (RW::READ as u64).expr(),
+                frame_index: 0.expr(),
+                address: stack_size - 1.expr(),
+                address_ext_0: address_ext_0.clone(),
+                address_ext_1: address_ext_1.clone(),
+                value: value.clone(),
+                sd_index: 0.expr(),
+            },
+            RWLookup {
+                gc: gc + 1.expr() + word_elem_num, // +1 because, in the middle, a signer reference is popped.
+                rw_target: (RWTarget::Global as u64).expr(),
+                rw: (RW::WRITE as u64).expr(),
+                frame_index: 0.expr(),
+                address: global_address,
+                sd_index,
+                address_ext_0,
+                address_ext_1,
+                value,
+            },
+        )
+    }
 
     pub fn global_read(
         gc: Expression<F>,

--- a/vm-circuit/src/chips/memory_chip/global_op_chip.rs
+++ b/vm-circuit/src/chips/memory_chip/global_op_chip.rs
@@ -13,15 +13,15 @@ use logger::prelude::*;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-pub const GLOBAL_OP_CHIP_WIDTH: usize = 11;
+pub const GLOBAL_OP_CHIP_WIDTH: usize = 13;
 
 #[derive(Clone, Debug)]
 pub struct GlobalOpCells<F: FieldExt> {
     pub counter: Cell<F>, // the total number of global rw operations
     pub address: Cell<F>,
+    pub sd_index: Cell<F>, // struct definition index
     pub address_ext_0: Cell<F>,
     pub address_ext_1: Cell<F>,
-    pub sd_index: Cell<F>, // struct definition index
     pub gc: Cell<F>,
     pub rw: Cell<F>,
     pub value: Cell<F>,
@@ -31,12 +31,14 @@ pub struct GlobalOpCells<F: FieldExt> {
     // increment of gc for the same global address
     pub delta_invert_address: Cell<F>,
     pub delta_invert_sd_index: Cell<F>,
+    pub delta_invert_addr_ext_0: Cell<F>,
+    pub delta_invert_addr_ext_1: Cell<F>,
 
     pub prev_counter: Cell<F>,
     pub prev_address: Cell<F>,
+    pub prev_sd_index: Cell<F>,
     pub prev_address_ext_0: Cell<F>,
     pub prev_address_ext_1: Cell<F>,
-    pub prev_sd_index: Cell<F>,
     pub prev_gc: Cell<F>,
     pub prev_rw: Cell<F>,
     pub prev_value: Cell<F>,
@@ -49,6 +51,8 @@ pub struct GlobalOpChipConfig<F: FieldExt> {
     pub cells: GlobalOpCells<F>,
     pub s_first_global_op: Selector,
     pub s_global_op: Selector,
+    addr_ext_0_table: TableColumn,
+    addr_ext_1_table: TableColumn,
 }
 
 pub struct GlobalOpChip<F: FieldExt> {
@@ -94,7 +98,7 @@ impl<F: FieldExt> GlobalOpChip<F> {
             }
 
             // previous op, without delta_invert cells
-            for i in 0..(GLOBAL_OP_CHIP_WIDTH - 2) {
+            for i in 0..(GLOBAL_OP_CHIP_WIDTH - 4) {
                 let column_index = i;
                 let rotation = -1;
                 cells.push_back(Cell::new(meta, advices[column_index], rotation))
@@ -115,7 +119,8 @@ impl<F: FieldExt> GlobalOpChip<F> {
             is_empty: cells.pop_front().unwrap(),
             delta_invert_address: cells.pop_front().unwrap(),
             delta_invert_sd_index: cells.pop_front().unwrap(),
-
+            delta_invert_addr_ext_0: cells.pop_front().unwrap(),
+            delta_invert_addr_ext_1: cells.pop_front().unwrap(),
             prev_counter: cells.pop_front().unwrap(),
             prev_address: cells.pop_front().unwrap(),
             prev_address_ext_0: cells.pop_front().unwrap(),
@@ -127,17 +132,38 @@ impl<F: FieldExt> GlobalOpChip<F> {
             prev_is_empty: cells.pop_front().unwrap(),
         };
 
+        let addr_ext_0_table = meta.lookup_table_column();
+        let addr_ext_1_table = meta.lookup_table_column();
+
         let s_first_global_op = meta.complex_selector();
-        Self::config_global_op(meta, s_first_global_op, &cells, true, gc_table);
+        Self::config_global_op(
+            meta,
+            s_first_global_op,
+            &cells,
+            true,
+            gc_table,
+            &addr_ext_0_table,
+            &addr_ext_1_table,
+        );
 
         let s_global_op = meta.complex_selector();
-        Self::config_global_op(meta, s_global_op, &cells, false, gc_table);
+        Self::config_global_op(
+            meta,
+            s_global_op,
+            &cells,
+            false,
+            gc_table,
+            &addr_ext_0_table,
+            &addr_ext_1_table,
+        );
 
         GlobalOpChipConfig {
             advices,
             cells,
             s_first_global_op,
             s_global_op,
+            addr_ext_0_table,
+            addr_ext_1_table,
         }
     }
 
@@ -147,10 +173,21 @@ impl<F: FieldExt> GlobalOpChip<F> {
         cells: &GlobalOpCells<F>,
         is_first_op: bool,
         gc_table: &TableColumn,
+        addr_ext0_table: &TableColumn,
+        addr_ext1_table: &TableColumn,
     ) {
         let mut constraints = Vec::new();
         let mut gc_lookups = Vec::new();
-        Self::constrain_global_op(cells, &mut constraints, is_first_op, &mut gc_lookups);
+        let mut addr_ext0_lookup = Vec::new();
+        let mut addr_ext1_lookup = Vec::new();
+        Self::constrain_global_op(
+            cells,
+            &mut constraints,
+            is_first_op,
+            &mut gc_lookups,
+            &mut addr_ext0_lookup,
+            &mut addr_ext1_lookup,
+        );
 
         meta.create_gate("constrain global op", |meta| {
             let selector = meta.query_selector(selector);
@@ -165,7 +202,18 @@ impl<F: FieldExt> GlobalOpChip<F> {
                 vec![(selector * lookup, *gc_table)]
             });
         }
-
+        for lookup in addr_ext0_lookup {
+            meta.lookup(|meta| {
+                let selector = meta.query_selector(selector);
+                vec![(selector * lookup, *addr_ext0_table)]
+            });
+        }
+        for lookup in addr_ext1_lookup {
+            meta.lookup(|meta| {
+                let selector = meta.query_selector(selector);
+                vec![(selector * lookup, *addr_ext1_table)]
+            });
+        }
         // todo: lookup address_ext_0, address_ext_1 for range check
     }
 
@@ -174,6 +222,8 @@ impl<F: FieldExt> GlobalOpChip<F> {
         constraints: &mut Vec<(&str, Expression<F>)>,
         is_first: bool,
         gc_lookups: &mut Vec<Expression<F>>,
+        addr_ext0_lookups: &mut Vec<Expression<F>>,
+        addr_ext1_lookups: &mut Vec<Expression<F>>,
     ) {
         constraints.push((
             "is_empty is bool",
@@ -190,7 +240,7 @@ impl<F: FieldExt> GlobalOpChip<F> {
         } else {
             // counter == prev_counter + 1
             constraints.push((
-                "counter",
+                "counter == prev_counter+1",
                 cond.clone()
                     * (cells.counter.expression.clone()
                         - cells.prev_counter.expression.clone()
@@ -199,7 +249,7 @@ impl<F: FieldExt> GlobalOpChip<F> {
             // for read op: value == prev_value
             let is_read = (RW::WRITE as u64).expr() - cells.rw.expression.clone();
             constraints.push((
-                "read op",
+                "for read op: value == prev_value",
                 cond.clone()
                     * (cells.value.expression.clone() - cells.prev_value.expression.clone())
                     * is_read,
@@ -210,20 +260,20 @@ impl<F: FieldExt> GlobalOpChip<F> {
 
             // rw == 0 || rw == 1
             constraints.push((
-                "rw",
+                "rw = 0|1",
                 cond.clone()
                     * cells.rw.expression.clone()
                     * (cells.rw.expression.clone() - 1.expr()),
             ));
 
-            // for ops with same address/sd_index, gc must be great than prev_gc
+            // for ops with same address/sd_index/addr_ext0/addr_ext1, gc must be great than prev_gc
             // 1.constrain delta_invert: (a - b) * inverse(a - b) must be 1 or 0
-            // 2.lookup gc_table when address/sd_index is same with previous
-            // todo: take address_ext into consideration
+            // 2.lookup gc_table when address/sd_index/addr_ext0/addr_ext1 is same with previous
+
             let delt_address =
                 cells.address.expression.clone() - cells.prev_address.expression.clone();
             constraints.push((
-                "delt_invert_address",
+                "delt_invert_address: (a - b) * inverse(a - b) = 0|1",
                 cond.clone()
                     * delt_address.clone()
                     * (delt_address.clone() * cells.delta_invert_address.expression.clone()
@@ -232,23 +282,76 @@ impl<F: FieldExt> GlobalOpChip<F> {
             let delt_sd_index =
                 cells.sd_index.expression.clone() - cells.prev_sd_index.expression.clone();
             constraints.push((
-                "delt_invert_sd_index",
+                "delt_invert_sd_index: (a - b) * inverse(a - b) = 0|1",
                 cond.clone()
                     * delt_sd_index.clone()
                     * (delt_sd_index.clone() * cells.delta_invert_sd_index.expression.clone()
                         - 1.expr()),
             ));
+            let delt_addr_ext_0 = cells.address_ext_0.expression.clone()
+                - cells.prev_address_ext_0.expression.clone();
+            constraints.push((
+                "delt_invert_address_ext_0: (a - b) * inverse(a - b) = 0|1",
+                cond.clone()
+                    * delt_addr_ext_0.clone()
+                    * (delt_addr_ext_0.clone() * cells.delta_invert_addr_ext_0.expression.clone()
+                        - 1.expr()),
+            ));
+            let delt_addr_ext_1 = cells.address_ext_1.expression.clone()
+                - cells.prev_address_ext_1.expression.clone();
+            constraints.push((
+                "delt_invert_address_ext_1: (a - b) * inverse(a - b) = 0|1",
+                cond.clone()
+                    * delt_addr_ext_1.clone()
+                    * (delt_addr_ext_1.clone() * cells.delta_invert_addr_ext_1.expression.clone()
+                        - 1.expr()),
+            ));
             gc_lookups.push(
-                cond * (1.expr() - delt_address * cells.delta_invert_address.expression.clone())
-                    * (1.expr() - delt_sd_index * cells.delta_invert_sd_index.expression.clone())
+                cond.clone()
+                    * (1.expr()
+                        - delt_address.clone() * cells.delta_invert_address.expression.clone())
+                    * (1.expr()
+                        - delt_sd_index.clone() * cells.delta_invert_sd_index.expression.clone())
+                    * (1.expr()
+                        - delt_addr_ext_0.clone()
+                            * cells.delta_invert_addr_ext_0.expression.clone())
+                    * (1.expr()
+                        - delt_addr_ext_1.clone()
+                            * cells.delta_invert_addr_ext_1.expression.clone())
                     * (cells.gc.expression.clone() - cells.prev_gc.expression.clone()),
             );
 
+            // TODO: address part validation check
             // todo: address must belong to the address list?
             // todo: sd_index must belong to the sd_index list?
+            // address_ext_* range check
+            addr_ext0_lookups.push(cond.clone() * cells.address_ext_0.expression.clone());
+            addr_ext1_lookups.push(cond.clone() * cells.address_ext_1.expression.clone());
 
-            // todo: address must be great than or equal to prev_address
-            // todo: for same address, sd_index must be great than or equal to prev_sd_index
+            // TODO: address monotonic check.  should we make a common `gte` gadget instead of those lookup?
+            // -[ ] address must be great than or equal to prev_address?
+            // -[ ] for same address, sd_index must be great than or equal to prev_sd_index
+            // -[x] for same address/sd_index, must have `addr_ext_0 >= prev_addr_ext_0`
+            // -[x] for same address/sd_index/addr_ext0, must have `addr_ext_1 >= prev_addr_ext_1`
+
+            // if same address/sd_index, addr_ext_0 must be great than or equal to prev_addr_ext_0
+            addr_ext0_lookups.push(
+                cond.clone()
+                    * (1.expr()
+                        - delt_address.clone() * cells.delta_invert_address.expression.clone())
+                    * (1.expr()
+                        - delt_sd_index.clone() * cells.delta_invert_sd_index.expression.clone())
+                    * delt_addr_ext_0.clone(),
+            );
+            // if same address/sd_index/addr_ext_0, addr_ext_1 must be great than or equal to prev_addr_ext_1
+            addr_ext1_lookups.push(
+                cond * (1.expr() - delt_address * cells.delta_invert_address.expression.clone())
+                    * (1.expr() - delt_sd_index * cells.delta_invert_sd_index.expression.clone())
+                    * delt_addr_ext_0.clone()
+                    * (1.expr()
+                        - delt_addr_ext_0 * cells.delta_invert_addr_ext_0.expression.clone())
+                    * delt_addr_ext_1,
+            );
 
             // empty op
             constraints.push((
@@ -289,6 +392,15 @@ impl<F: FieldExt> GlobalOpChip<F> {
                 .cells
                 .sd_index
                 .assign(region, offset, Some(op.sd_index.0))?;
+            self.config
+                .cells
+                .address_ext_0
+                .assign(region, offset, Some(op.address_ext_0.0))?;
+
+            self.config
+                .cells
+                .address_ext_1
+                .assign(region, offset, Some(op.address_ext_1.0))?;
 
             self.config.cells.value.assign(region, offset, op.value.0)?;
         } else {
@@ -331,6 +443,25 @@ impl<F: FieldExt> GlobalOpChip<F> {
                 })?,
                 "sd_index",
             )?;
+            self.config.cells.address_ext_0.assign_equality(
+                region,
+                offset,
+                op.address_ext_0.1.clone().ok_or_else(|| {
+                    error!("address_ext_0 assigned cell is None");
+                    Error::Synthesis
+                })?,
+                "address_ext_0",
+            )?;
+
+            self.config.cells.address_ext_1.assign_equality(
+                region,
+                offset,
+                op.address_ext_1.1.clone().ok_or_else(|| {
+                    error!("address_ext_1 assigned cell is None");
+                    Error::Synthesis
+                })?,
+                "address_ext_1",
+            )?;
 
             self.config.cells.value.assign_equality(
                 region,
@@ -343,10 +474,16 @@ impl<F: FieldExt> GlobalOpChip<F> {
             )?;
         }
 
-        let (prev_address, prev_sd_index) = match prev_op {
-            None => (F::zero(), F::zero()),
-            Some(v) => (v.address.0, v.sd_index.0),
+        let (prev_address, prev_sd_index, prev_addr_ext_0, prev_addr_ext_1) = match prev_op {
+            None => (F::zero(), F::zero(), F::zero(), F::zero()),
+            Some(v) => (
+                v.address.0,
+                v.sd_index.0,
+                v.address_ext_0.0,
+                v.address_ext_1.0,
+            ),
         };
+
         self.config.cells.delta_invert_address.assign(
             region,
             offset,
@@ -356,6 +493,16 @@ impl<F: FieldExt> GlobalOpChip<F> {
             region,
             offset,
             op.sd_index.0.delta_invert(prev_sd_index),
+        )?;
+        self.config.cells.delta_invert_addr_ext_0.assign(
+            region,
+            offset,
+            op.address_ext_0.0.delta_invert(prev_addr_ext_0),
+        )?;
+        self.config.cells.delta_invert_addr_ext_1.assign(
+            region,
+            offset,
+            op.address_ext_1.0.delta_invert(prev_addr_ext_1),
         )?;
 
         let is_empty = if is_empty { F::one() } else { F::zero() };
@@ -370,7 +517,7 @@ impl<F: FieldExt> GlobalOpChip<F> {
     pub fn assign(
         &self,
         layouter: &mut impl Layouter<F>,
-        _circuit_config: &CircuitConfig,
+        circuit_config: &CircuitConfig,
         global_ops: Vec<ConvertedRWOperation<F>>,
         global_ops_num: usize,
     ) -> Option<AssignedCell<F, F>> {
@@ -434,6 +581,22 @@ impl<F: FieldExt> GlobalOpChip<F> {
                 )
                 .ok()?;
         }
+
+        // TODO: we should only need one addr_ext table. refactor this.
+        assign_index_table(
+            layouter,
+            "addr_ext0_table",
+            self.config.addr_ext_0_table,
+            circuit_config.word_size,
+        )
+        .ok()?;
+        assign_index_table(
+            layouter,
+            "addr_ext1_table",
+            self.config.addr_ext_1_table,
+            circuit_config.word_size,
+        )
+        .ok()?;
         last_global_counter
     }
 }

--- a/vm-circuit/src/chips/utilities.rs
+++ b/vm-circuit/src/chips/utilities.rs
@@ -1,9 +1,9 @@
 // Copyright (c) zkMove Authors
 
 use halo2_proofs::arithmetic::FieldExt;
-use halo2_proofs::circuit::Value as CircuitValue;
 use halo2_proofs::circuit::{AssignedCell, Region};
-use halo2_proofs::plonk::{Advice, Column, Error, Expression, VirtualCells};
+use halo2_proofs::circuit::{Layouter, Value as CircuitValue};
+use halo2_proofs::plonk::{Advice, Column, Error, Expression, TableColumn, VirtualCells};
 use halo2_proofs::poly::Rotation;
 use movelang::value::NUM_OF_BYTES_U128;
 use std::convert::TryInto;
@@ -135,4 +135,30 @@ impl<F: FieldExt> DeltaInvert<F> for F {
             delta.invert().into()
         }
     }
+}
+
+// a special table with solo column and the value same as index.
+// which is to garantuee value is among [0, max].
+pub(crate) fn assign_index_table<F: FieldExt>(
+    layouter: &mut impl Layouter<F>,
+    table_name: &str,
+    column: TableColumn,
+    max_row: usize,
+) -> Result<(), Error> {
+    layouter.assign_table(
+        || format!("{:?}", table_name),
+        |mut table_column| {
+            (0..=max_row)
+                .map(|i| {
+                    table_column.assign_cell(
+                        || format!("{}[{}]", table_name, i),
+                        column,
+                        i,
+                        || CircuitValue::known(F::from_u128(i as u128)),
+                    )
+                })
+                .fold(Ok(()), |acc, res| acc.and(res))
+        },
+    )?;
+    Ok(())
 }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -539,11 +539,11 @@ impl<F: FieldExt> Frame<F> {
                         let addr = interp.stack.pop_as_account_address(rw_operations)?;
                         let ty = resolver.get_struct_type(*sd_idx);
                         let value = interp.move_from(data_store, loader, addr, &ty)?;
-                        // TODO: how to represent the action of moving struct from global to to stack.
                         // in fact, after move_from, user cannot call move_from again, as the struct is already gone.
                         // If this limit is constrained by bytecode verifier, then circuit doesn't need to worry about this.
                         // But if not, we should write a Invalid to the global struct.
-                        let word_elem_num = globals::emit_globals_ops_for_word(
+                        // For now, we take a progressive action.
+                        let word_elem_num = globals::emit_ops_for_global_value(
                             addr,
                             *sd_idx,
                             value.clone(),
@@ -562,7 +562,7 @@ impl<F: FieldExt> Frame<F> {
                             .read_ref()?
                             .as_account_address()
                             .expect("address should not be None");
-                        let word_elem_num = globals::emit_globals_ops_for_word(
+                        let word_elem_num = globals::emit_ops_for_global_value(
                             addr,
                             *sd_idx,
                             resource.clone(),

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1,5 +1,6 @@
 // Copyright (c) zkMove Authors
 
+use crate::globals;
 use crate::interpreter::Interpreter;
 use crate::locals::Locals;
 use error::{RuntimeError, StatusCode, VmResult};
@@ -538,18 +539,18 @@ impl<F: FieldExt> Frame<F> {
                         let addr = interp.stack.pop_as_account_address(rw_operations)?;
                         let ty = resolver.get_struct_type(*sd_idx);
                         let value = interp.move_from(data_store, loader, addr, &ty)?;
-
-                        let global_op = GlobalOp {
-                            address: addr,
-                            sd_index: sd_idx.0 as usize,
-                            address_ext_0: 0,
-                            address_ext_1: 0,
-                            value: value.clone(),
-                            rw: RW::READ,
-                            gc: rw_operations.len(),
-                        };
-                        rw_operations.push(RWOperation::GlobalOp(global_op));
-
+                        // TODO: how to represent the action of moving struct from global to to stack.
+                        // in fact, after move_from, user cannot call move_from again, as the struct is already gone.
+                        // If this limit is constrained by bytecode verifier, then circuit doesn't need to worry about this.
+                        // But if not, we should write a Invalid to the global struct.
+                        let word_elem_num = globals::emit_globals_ops_for_word(
+                            addr,
+                            *sd_idx,
+                            value.clone(),
+                            RW::READ,
+                            rw_operations,
+                        )?;
+                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::MoveTo(sd_idx) => {
@@ -561,19 +562,16 @@ impl<F: FieldExt> Frame<F> {
                             .read_ref()?
                             .as_account_address()
                             .expect("address should not be None");
+                        let word_elem_num = globals::emit_globals_ops_for_word(
+                            addr,
+                            *sd_idx,
+                            resource.clone(),
+                            RW::WRITE,
+                            rw_operations,
+                        )?;
+                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+
                         let ty = resolver.get_struct_type(*sd_idx);
-
-                        let global_op = GlobalOp {
-                            address: addr,
-                            sd_index: sd_idx.0 as usize,
-                            address_ext_0: 0,
-                            address_ext_1: 0,
-                            value: resource.clone(),
-                            rw: RW::WRITE,
-                            gc: rw_operations.len(),
-                        };
-                        rw_operations.push(RWOperation::GlobalOp(global_op));
-
                         interp.move_to(data_store, loader, addr, &ty, resource)
                     }
                     Bytecode::ImmBorrowGlobal(sd_idx) | Bytecode::MutBorrowGlobal(sd_idx) => {

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -5,7 +5,7 @@ use movelang::account_address::AccountAddress;
 use movelang::value::{Value, ValueAddress};
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
-pub fn emit_globals_ops_for_word<F: FieldExt>(
+pub fn emit_ops_for_global_value<F: FieldExt>(
     addr: AccountAddress<F>,
     sd_index: StructDefinitionIndex,
     resource_value: Value<F>,
@@ -16,8 +16,8 @@ pub fn emit_globals_ops_for_word<F: FieldExt>(
     let addressed_value = resource_value.update_address(value_addr.clone());
     let word = addressed_value.flatten(value_addr)?;
     let word_len = word.len();
-    for (address_path, val) in word {
-        let locals_op = GlobalOp {
+    for (address_path, val) in word.clone() {
+        let op = GlobalOp {
             address: addr,
             sd_index: sd_index.0 as usize,
             address_ext_0: *address_path
@@ -32,7 +32,28 @@ pub fn emit_globals_ops_for_word<F: FieldExt>(
             rw: rw.clone(),
             gc: rw_operations.len(),
         };
-        rw_operations.push(RWOperation::GlobalOp(locals_op));
+        rw_operations.push(RWOperation::GlobalOp(op));
+    }
+    // if this is move_from, we need to write an invalid back.
+    if rw == RW::READ {
+        for (address_path, _) in word {
+            let op = GlobalOp {
+                address: addr,
+                sd_index: sd_index.0 as usize,
+                address_ext_0: *address_path
+                    .0
+                    .get(2)
+                    .expect("address_ext_0 should not be None"),
+                address_ext_1: *address_path
+                    .0
+                    .get(3)
+                    .expect("address_ext_1 should not be None"),
+                value: Value::Invalid,
+                rw: RW::WRITE,
+                gc: rw_operations.len(),
+            };
+            rw_operations.push(RWOperation::GlobalOp(op));
+        }
     }
     Ok(word_len)
 }

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -1,0 +1,38 @@
+use error::VmResult;
+use halo2_proofs::arithmetic::FieldExt;
+use move_binary_format::file_format::StructDefinitionIndex;
+use movelang::account_address::AccountAddress;
+use movelang::value::{Value, ValueAddress};
+use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
+
+pub fn emit_globals_ops_for_word<F: FieldExt>(
+    addr: AccountAddress<F>,
+    sd_index: StructDefinitionIndex,
+    resource_value: Value<F>,
+    rw: RW,
+    rw_operations: &mut Vec<RWOperation<F>>,
+) -> VmResult<usize> {
+    let value_addr = ValueAddress::Global(addr, sd_index);
+    let addressed_value = resource_value.update_address(value_addr.clone());
+    let word = addressed_value.flatten(value_addr)?;
+    let word_len = word.len();
+    for (address_path, val) in word {
+        let locals_op = GlobalOp {
+            address: addr,
+            sd_index: sd_index.0 as usize,
+            address_ext_0: *address_path
+                .0
+                .get(2)
+                .expect("address_ext_0 should not be None"),
+            address_ext_1: *address_path
+                .0
+                .get(3)
+                .expect("address_ext_1 should not be None"),
+            value: val,
+            rw: rw.clone(),
+            gc: rw_operations.len(),
+        };
+        rw_operations.push(RWOperation::GlobalOp(locals_op));
+    }
+    Ok(word_len)
+}

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,10 +1,10 @@
 // Copyright (c) zkMove Authors
 
 pub mod frame;
+pub mod globals;
 pub mod interpreter;
 pub mod locals;
 pub mod runtime;
 pub mod stack;
-
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
The PR implements move_to and move_from instructions using flattened struct introduced in #66 
