### PR TITLE
implement Deref trait and remove as_inner

### DIFF
--- a/movelang/src/argument.rs
+++ b/movelang/src/argument.rs
@@ -4,6 +4,7 @@ use anyhow::{Error, Result};
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use move_core_types::parser::parse_transaction_arguments;
+use std::ops::Deref;
 use std::str::FromStr;
 
 use crate::account_address::AccountAddress;
@@ -18,11 +19,15 @@ impl ScriptArguments {
     pub fn new(args: Vec<ScriptArgument>) -> Self {
         Self(args)
     }
-    pub fn as_inner(&self) -> &Vec<ScriptArgument> {
-        &self.0
-    }
     pub fn into_inner(self) -> Vec<ScriptArgument> {
         self.0
+    }
+}
+impl Deref for ScriptArguments {
+    type Target = Vec<ScriptArgument>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -9,7 +9,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Value as CircuitValue;
 use move_binary_format::file_format::StructDefinitionIndex;
 use std::convert::TryFrom;
-use std::ops::{Add, Div, Mul, Not, Rem, Sub};
+use std::ops::{Add, Deref, DerefMut, Div, Mul, Not, Rem, Sub};
 use std::{cell::RefCell, rc::Rc};
 
 pub const NUM_OF_BYTES_U8: usize = 1;
@@ -76,16 +76,10 @@ pub enum ValueAddress<F: FieldExt> {
 pub struct AddressPath(pub Vec<usize>);
 
 impl AddressPath {
-    pub fn into_inner(self) -> Vec<usize> {
-        self.0
-    }
-    pub fn as_inner(&self) -> &Vec<usize> {
-        &self.0
-    }
     pub fn extend(self, leaf: usize) -> Self {
-        let mut path = self.into_inner();
+        let mut path = self;
         path.push(leaf);
-        AddressPath(path)
+        AddressPath(path.to_vec())
     }
     pub fn len(&self) -> usize {
         self.0.len()
@@ -100,6 +94,18 @@ impl AddressPath {
             length = self.len();
         }
         self
+    }
+}
+
+impl Deref for AddressPath {
+    type Target = Vec<usize>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl DerefMut for AddressPath {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -123,16 +129,13 @@ impl<F: FieldExt> ValueAddress<F> {
 
     pub fn frame_index(&self) -> usize {
         let path = self.address_path().expect("should not reach here");
-        let res = path
-            .as_inner()
-            .get(0)
-            .expect("frame index should not be None");
+        let res = path.get(0).expect("frame index should not be None");
         *res
     }
 
     pub fn address(&self) -> usize {
         let path = self.address_path().expect("should not reach here");
-        let res = path.as_inner().get(1).expect("address should not be None");
+        let res = path.get(1).expect("address should not be None");
         *res
     }
     pub fn global_path(&self) -> Option<(AccountAddress<F>, StructDefinitionIndex)> {
@@ -694,7 +697,7 @@ impl<F: FieldExt> GlobalValue<F> {
 }
 
 #[derive(Clone, Debug)]
-pub enum Value<F: FieldExt> {
+pub enum Value<F: FieldExt + Clone> {
     Invalid,
     U8(U8<F>),
     U64(U64<F>),

--- a/vm-circuit/src/witness.rs
+++ b/vm-circuit/src/witness.rs
@@ -185,7 +185,7 @@ impl<F: FieldExt> fmt::Debug for Witness<F> {
         });
         writeln!(f)?;
         writeln!(f, "Bytecode table:")?;
-        self.bytecode_table.as_inner().iter().for_each(|bytecode| {
+        self.bytecode_table.iter().for_each(|bytecode| {
             writeln!(f, "{:?}", bytecode).unwrap();
         });
         writeln!(f)?;

--- a/vm-circuit/src/witness/bytecode_table.rs
+++ b/vm-circuit/src/witness/bytecode_table.rs
@@ -4,6 +4,7 @@ use crate::chips::execution_chip::opcode::Opcode;
 use halo2_proofs::arithmetic::FieldExt;
 use move_binary_format::file_format::{Bytecode, CompiledModule, CompiledScript};
 use std::convert::From;
+use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct BytecodeInfo {
@@ -174,11 +175,22 @@ impl BytecodeTable {
     pub fn new(bytecodes: Vec<BytecodeInfo>) -> Self {
         Self(bytecodes)
     }
-    pub fn as_inner(&self) -> &Vec<BytecodeInfo> {
-        &self.0
-    }
+
     pub fn into_inner(self) -> Vec<BytecodeInfo> {
         self.0
+    }
+}
+
+impl Deref for BytecodeTable {
+    type Target = Vec<BytecodeInfo>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl DerefMut for BytecodeTable {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -244,11 +256,11 @@ impl From<Vec<CompiledModule>> for BytecodeTable {
 
 impl From<(CompiledScript, Vec<CompiledModule>)> for BytecodeTable {
     fn from((script, modules): (CompiledScript, Vec<CompiledModule>)) -> BytecodeTable {
-        let script_bytecodes = BytecodeTable::from(script);
-        let modules_bytecodes = BytecodeTable::from(modules);
+        let mut script_bytecodes = BytecodeTable::from(script);
+        let mut modules_bytecodes = BytecodeTable::from(modules);
         let mut bytecodes = Vec::new();
-        bytecodes.append(&mut script_bytecodes.into_inner());
-        bytecodes.append(&mut modules_bytecodes.into_inner());
+        bytecodes.append(&mut *script_bytecodes);
+        bytecodes.append(&mut *modules_bytecodes);
         BytecodeTable(bytecodes)
     }
 }


### PR DESCRIPTION
As for the one element struct, Deref trait can simplify access to the inner element. 