### PR TITLE
refactor: new value system 

### DIFF
--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -31,19 +31,6 @@ pub struct U128<F: FieldExt>(pub F);
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Bool<F: FieldExt>(pub F);
 
-// /// A wrapper for account address
-// #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-// pub struct Address<F: FieldExt>(AccountAddress<F>);
-//
-// impl<F: FieldExt> Address<F> {
-//     pub fn account_address(self) -> AccountAddress<F> {
-//         self.0
-//     }
-//     pub fn value(&self) -> F {
-//         self.0.value()
-//     }
-// }
-
 /// Index of a frame
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FrameIndex(pub usize);
@@ -51,28 +38,6 @@ pub struct FrameIndex(pub usize);
 /// Index of a value in locals, or index of a member in the struct
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Index(pub usize);
-
-// /// An address of a zkMove value
-// #[derive(Clone, Debug)]
-// pub enum ValueAddress<F: FieldExt> {
-//     /// If the value lives in the eval stack, the address will be the
-//     /// index of the value in stack.
-//     Stack(Index),
-//     /// If the value lives in the locals of a frame, the address will be the
-//     /// combination of frame_index and the index of the value in locals.
-//     Locals(FrameIndex, Index),
-//     /// If the value lives in the global storage, the address will be the
-//     /// AccountAddress/StructDefinitionIndex of the value.
-//     Global(AccountAddress<F>, StructDefinitionIndex),
-//     /// If the value is a member of a Local or Global value, the address will be
-//     /// the index of the member, and the address of parent value.
-//     Member {
-//         index: Index,
-//         parent: Box<ValueAddress<F>>,
-//     },
-//     /// The value was just created and has not been stored yet.
-//     Unknown,
-// }
 
 #[derive(Clone, Debug)]
 //todo: use 'Field' instead of 'usize'?
@@ -112,516 +77,6 @@ impl<F: FieldExt> AddressPath<F> {
             length = self.len();
         }
         self
-    }
-    // pub fn flatten(self, address: ValueAddress<F>) -> VmResult<Vec<(AddressPath<F>, Value<F>)>> {
-    //     let values = self
-    //         .into_inner()
-    //         .iter()
-    //         .map(|v| Value::u64(*v as u64))
-    //         .collect();
-    //     let struct_ = Container::Struct(address, Rc::new(RefCell::new(values)));
-    //     struct_.flatten()
-    // }
-}
-
-// impl<F: FieldExt> ValueAddress<F> {
-//     pub fn address_path(&self) -> VmResult<AddressPath<F>> {
-//         match self {
-//             Self::Stack(index) => Ok(AddressPath(vec![0, index.0], PhantomData)),
-//             Self::Locals(frame_index, index) => {
-//                 Ok(AddressPath(vec![frame_index.0, index.0], PhantomData))
-//             }
-//             Self::Member { index, parent } => {
-//                 let path = parent.address_path()?;
-//                 Ok(path.extend(index.0))
-//             }
-//             Self::Global(addr, sd_index) => Ok(AddressPath(
-//                 vec![
-//                     // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
-//                     addr.value().get_lower_128() as usize,
-//                     sd_index.0 as usize,
-//                 ],
-//                 PhantomData,
-//             )),
-//             _ => unimplemented!(),
-//         }
-//     }
-//
-//     pub fn frame_index(&self) -> usize {
-//         let path = self.address_path().expect("should not reach here");
-//         let res = path
-//             .as_inner()
-//             .get(0)
-//             .expect("frame index should not be None");
-//         *res
-//     }
-//
-//     pub fn address(&self) -> usize {
-//         let path = self.address_path().expect("should not reach here");
-//         let res = path.as_inner().get(1).expect("address should not be None");
-//         *res
-//     }
-//     pub fn global_path(&self) -> Option<(AccountAddress<F>, StructDefinitionIndex)> {
-//         match self {
-//             Self::Global(addr, idx) => Some((*addr, *idx)),
-//             Self::Member { parent, .. } => parent.global_path(),
-//             _ => None,
-//         }
-//     }
-// }
-
-// /// A ContainerRef is a reference to a container, which could live either
-// /// in the frame or in global storage.
-// #[derive(Clone, Debug)]
-// pub enum ContainerRef<F: FieldExt> {
-//     Local(Container<F>),
-//     Global(Container<F>),
-// }
-
-// impl<F: FieldExt> ContainerRef<F> {
-//     fn container(&self) -> &Container<F> {
-//         match self {
-//             Self::Local(container) => container,
-//             Self::Global(container) => container,
-//         }
-//     }
-//
-//     fn read_ref(&self) -> VmResult<Value<F>> {
-//         Ok(Value::Container(self.container().copy_value()))
-//     }
-//
-//     fn write_ref(&mut self, value: Value<F>) -> VmResult<()> {
-//         match value {
-//             Value::Container(c) => match self.container() {
-//                 Container::Struct(_, struct_) => {
-//                     let r = match c {
-//                         Container::Struct(_, v) => v,
-//                         _ => {
-//                             return Err(RuntimeError::new(StatusCode::TypeMismatch)
-//                                 .with_message("failed to write ref".to_string()))
-//                         }
-//                     };
-//
-//                     debug_assert_eq!(Rc::strong_count(&r), 1);
-//                     let fields = match Rc::try_unwrap(r) {
-//                         Ok(cell) => Ok(cell.into_inner()),
-//                         Err(v) => Err(RuntimeError::new(
-//                             StatusCode::UnknownInvariantViolationError,
-//                         )
-//                         .with_message(format!("moving value {:?} with dangling references", v))),
-//                     };
-//                     *struct_.borrow_mut() = fields?;
-//                     Ok(())
-//                 }
-//                 Container::Locals(_, _) => Err(RuntimeError::new(StatusCode::TypeMismatch)
-//                     .with_message("cannot change Container::Locals".to_string())),
-//             },
-//             v => Err(
-//                 RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
-//                     "cannot write value {:?} to container ref {:?}",
-//                     v, self
-//                 )),
-//             ),
-//         }
-//     }
-//
-//     pub fn borrow_element(&self, element_idx: usize) -> VmResult<Value<F>> {
-//         let res = match self.container() {
-//             Container::Locals(_, _) => {
-//                 unreachable!("should not come here.")
-//             }
-//             Container::Struct(_, r) => {
-//                 let len = r.borrow().len();
-//                 if element_idx >= len {
-//                     return Err(
-//                         RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
-//                             "index out of bounds when borrowing container element: index: {}, length: {}",
-//                             element_idx, len
-//                         )),
-//                     );
-//                 }
-//                 let v = r.borrow();
-//                 match &v[element_idx] {
-//                     Value::Container(container) => {
-//                         let r = match self {
-//                             Self::Local(_) => Self::Local(container.copy_by_ref()),
-//                             Self::Global(_) => Self::Global(container.copy_by_ref()),
-//                         };
-//                         Value::ContainerRef(r)
-//                     }
-//                     _ => Value::IndexedRef(IndexedRef {
-//                         index: element_idx,
-//                         container_ref: self.copy_value(),
-//                     }),
-//                 }
-//             }
-//         };
-//
-//         Ok(res)
-//     }
-//
-//     fn copy_value(&self) -> Self {
-//         match self {
-//             Self::Local(container) => Self::Local(container.copy_by_ref()),
-//             Self::Global(container) => Self::Global(container.copy_by_ref()),
-//         }
-//     }
-//
-//     fn is_global(&self) -> bool {
-//         matches!(self, Self::Global(_)) // container holds global value
-//     }
-//
-//     fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
-//         match self {
-//             Self::Local(_) => unreachable!(),
-//             Self::Global(c) => match c {
-//                 Container::Locals(_, _) => unreachable!(),
-//                 Container::Struct(addr, _) => addr
-//                     .global_path()
-//                     .expect("expect global or member of global"),
-//             },
-//         }
-//     }
-//
-//     fn copy_global_value(&self) -> VmResult<Value<F>> {
-//         if self.is_global() {
-//             self.read_ref()
-//         } else {
-//             Err(RuntimeError::new(StatusCode::TypeMismatch)
-//                 .with_message("The value doesn't contain global value".to_string()))
-//         }
-//     }
-//
-//     fn container_index(&self) -> usize {
-//         self.container().index()
-//     }
-//
-//     fn container_frame_index(&self) -> usize {
-//         self.container().frame_index()
-//     }
-//
-//     fn value_address(&self) -> ValueAddress<F> {
-//         self.container().value_address()
-//     }
-// }
-
-// /// A reference pointing to an element in a container.
-// #[derive(Clone, Debug)]
-// pub struct IndexedRef<F: FieldExt> {
-//     pub index: usize,
-//     pub container_ref: ContainerRef<F>,
-// }
-//
-// impl<F: FieldExt> IndexedRef<F> {
-//     pub fn container(&self) -> &Container<F> {
-//         self.container_ref.container()
-//     }
-//     pub fn container_ref(&self) -> &ContainerRef<F> {
-//         &self.container_ref
-//     }
-//     fn read_ref(&self) -> VmResult<Value<F>> {
-//         let value = match &*self.container_ref.container() {
-//             Container::Locals(_, r) | Container::Struct(_, r) => {
-//                 r.borrow()[self.index].copy_value()
-//             }
-//         };
-//         Ok(value)
-//     }
-//     fn write_ref(&mut self, x: Value<F>) -> VmResult<()> {
-//         match &x {
-//             Value::IndexedRef(_)
-//             | Value::ContainerRef(_)
-//             | Value::Invalid
-//             | Value::Container(_) => return Err(RuntimeError::new(StatusCode::TypeMismatch)),
-//             _ => (),
-//         }
-//
-//         match (self.container_ref.container(), &x) {
-//             (Container::Locals(_, r), _) | (Container::Struct(_, r), _) => {
-//                 let mut v = r.borrow_mut();
-//                 v[self.index] = x;
-//             }
-//         }
-//         Ok(())
-//     }
-//     pub fn index(&self) -> usize {
-//         self.index
-//     }
-//     fn container_frame_index(&self) -> usize {
-//         self.container().frame_index()
-//     }
-//     fn copy_value(&self) -> Self {
-//         Self {
-//             index: self.index,
-//             container_ref: self.container_ref.copy_value(),
-//         }
-//     }
-//     pub fn borrow_element(&self, element_idx: usize) -> VmResult<Value<F>> {
-//         let res = match self.container() {
-//             Container::Locals(_, _) => {
-//                 unreachable!("should not come here.")
-//             }
-//             Container::Struct(_, r) => {
-//                 let len = r.borrow().len();
-//                 if element_idx >= len {
-//                     return Err(
-//                         RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
-//                             "index out of bounds when borrowing container element: index: {}, length: {}",
-//                             element_idx, len
-//                         )),
-//                     );
-//                 }
-//                 let v = r.borrow();
-//                 match &v[element_idx] {
-//                     Value::Container(container) => {
-//                         let r = match self.container_ref {
-//                             ContainerRef::Local(_) => ContainerRef::Local(container.copy_by_ref()),
-//                             ContainerRef::Global(_) => unreachable!(),
-//                         };
-//                         Value::ContainerRef(r)
-//                     }
-//                     _ => Value::IndexedRef(IndexedRef {
-//                         index: self.index,
-//                         container_ref: self.container_ref.copy_value(),
-//                     }),
-//                 }
-//             }
-//         };
-//
-//         Ok(res)
-//     }
-//
-//     fn is_global(&self) -> bool {
-//         self.container_ref().is_global()
-//     }
-//
-//     fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
-//         self.container_ref.global_path()
-//     }
-//
-//     fn copy_global_value(&self) -> VmResult<Value<F>> {
-//         if self.is_global() {
-//             self.container_ref().read_ref()
-//         } else {
-//             Err(RuntimeError::new(StatusCode::TypeMismatch)
-//                 .with_message("The value doesn't contain global value".to_string()))
-//         }
-//     }
-//
-//     fn value_address(&self) -> ValueAddress<F> {
-//         match self.container() {
-//             Container::Locals(frame_index, _) => {
-//                 ValueAddress::Locals(FrameIndex(frame_index.0), Index(self.index))
-//             }
-//             Container::Struct(address, _) => ValueAddress::Member {
-//                 index: Index(self.index),
-//                 parent: Box::new(address.clone()),
-//             },
-//         }
-//     }
-// }
-//
-// /// A wrapper to support read_ref and write_ref.
-// #[derive(Debug, Clone)]
-// pub enum Reference<F: FieldExt> {
-//     IndexedRef(IndexedRef<F>),
-//     ContainerRef(ContainerRef<F>),
-// }
-//
-// impl<F: FieldExt> Reference<F> {
-//     pub fn read_ref(&self) -> VmResult<Value<F>> {
-//         match self {
-//             Self::ContainerRef(r) => r.read_ref(),
-//             Self::IndexedRef(r) => r.read_ref(),
-//         }
-//     }
-//     pub fn write_ref(&mut self, x: Value<F>) -> VmResult<()> {
-//         match self {
-//             Self::ContainerRef(r) => r.write_ref(x),
-//             Self::IndexedRef(r) => r.write_ref(x),
-//         }
-//     }
-//     pub fn index(&self) -> usize {
-//         match self {
-//             Self::ContainerRef(r) => r.container_index(),
-//             Self::IndexedRef(r) => r.index(),
-//         }
-//     }
-//     pub fn container_frame_index(&self) -> usize {
-//         match self {
-//             Self::ContainerRef(r) => r.container_frame_index(),
-//             Self::IndexedRef(r) => r.container_frame_index(),
-//         }
-//     }
-//
-//     pub fn is_global(&self) -> bool {
-//         match self {
-//             Self::ContainerRef(r) => r.is_global(),
-//             Self::IndexedRef(r) => r.is_global(),
-//         }
-//     }
-//
-//     pub fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
-//         match self {
-//             Self::ContainerRef(r) => r.global_path(),
-//             Self::IndexedRef(r) => r.global_path(),
-//         }
-//     }
-//
-//     // For a reference pointing to a global value, return the global value
-//     // For a reference pointing to an element of a global value, return the global value
-//     pub fn copy_global_value(&self) -> VmResult<Value<F>> {
-//         match self {
-//             Self::ContainerRef(r) => r.copy_global_value(),
-//             Self::IndexedRef(r) => r.copy_global_value(),
-//         }
-//     }
-//
-//     pub fn value_address(&self) -> ValueAddress<F> {
-//         match self {
-//             Self::ContainerRef(r) => r.container().value_address(),
-//             Self::IndexedRef(r) => r.value_address(),
-//         }
-//     }
-// }
-//
-// /// A wrapper to support borrow_element
-// #[derive(Debug, Clone)]
-// pub struct StructRef<F: FieldExt>(pub ContainerRef<F>);
-//
-// impl<F: FieldExt> StructRef<F> {
-//     pub fn borrow_element(&self, field_idx: usize) -> VmResult<Value<F>> {
-//         self.0.borrow_element(field_idx)
-//     }
-//
-//     pub fn value_address(&self) -> ValueAddress<F> {
-//         self.0.value_address()
-//     }
-// }
-
-#[derive(Debug)]
-pub struct Struct<F: FieldExt> {
-    fields: Vec<Value<F>>,
-}
-
-impl<F: FieldExt> Struct<F> {
-    pub fn pack(values: Vec<Value<F>>) -> Self {
-        Self { fields: values }
-    }
-
-    pub fn unpack(self) -> VmResult<Vec<Value<F>>> {
-        Ok(self.fields)
-    }
-}
-
-// Clean - the value was only read.
-// Dirty - the value was possibly modified.
-#[derive(Debug, Clone, Copy)]
-pub enum GlobalDataStatus {
-    Clean,
-    Dirty,
-}
-
-#[derive(Debug, Clone)]
-pub enum GlobalValue<F: FieldExt> {
-    /// No resource resides in this slot or in storage.
-    None,
-    /// A resource has been published to this slot and it did not previously exist in storage.
-    Fresh { fields: Rc<RefCell<Vec<Value<F>>>> },
-    /// A resource resides in this slot and also in storage. The status flag indicates whether
-    /// it has potentially been altered.
-    Cached {
-        fields: Rc<RefCell<Vec<Value<F>>>>,
-        status: Rc<RefCell<GlobalDataStatus>>,
-    },
-    /// A resource used to exist in storage but has been deleted by the current transaction.
-    Deleted,
-}
-
-impl<F: FieldExt> GlobalValue<F> {
-    pub fn none() -> Self {
-        GlobalValue::None
-    }
-
-    fn fresh(val: Value<F>) -> VmResult<Self> {
-        match val {
-            Value::Container(Container(fields)) => Ok(Self::Fresh { fields }),
-            _ => Err(
-                RuntimeError::new(StatusCode::UnknownInvariantViolationError)
-                    .with_message("not a resource type".to_string()),
-            ),
-        }
-    }
-
-    fn cached(val: Value<F>, status: GlobalDataStatus) -> VmResult<Self> {
-        match val {
-            Value::Container(Container(fields)) => {
-                let status = Rc::new(RefCell::new(status));
-                Ok(Self::Cached { fields, status })
-            }
-            _ => Err(
-                RuntimeError::new(StatusCode::UnknownInvariantViolationError)
-                    .with_message("not a resource type".to_string()),
-            ),
-        }
-    }
-
-    pub fn move_from(&mut self) -> VmResult<Value<F>> {
-        let fields = match self {
-            Self::None | Self::Deleted => return Err(RuntimeError::new(StatusCode::MissingData)),
-            Self::Fresh { .. } => match std::mem::replace(self, Self::None) {
-                Self::Fresh { fields } => fields,
-                _ => unreachable!(),
-            },
-            Self::Cached { .. } => match std::mem::replace(self, Self::Deleted) {
-                Self::Cached { fields, .. } => fields,
-                _ => unreachable!(),
-            },
-        };
-        if Rc::strong_count(&fields) != 1 {
-            return Err(
-                RuntimeError::new(StatusCode::UnknownInvariantViolationError)
-                    .with_message("moving global resource with dangling reference".to_string()),
-            );
-        }
-        Ok(Value::Container(Container(fields)))
-    }
-
-    pub fn move_to(&mut self, val: Value<F>) -> VmResult<()> {
-        match self {
-            Self::Fresh { .. } | Self::Cached { .. } => {
-                return Err(RuntimeError::new(StatusCode::ResourceAlreadyExists))
-            }
-            Self::None => *self = Self::fresh(val)?,
-            Self::Deleted => *self = Self::cached(val, GlobalDataStatus::Dirty)?,
-        }
-        Ok(())
-    }
-
-    pub fn exists(&self) -> VmResult<bool> {
-        match self {
-            Self::Fresh { .. } | Self::Cached { .. } => Ok(true),
-            Self::None | Self::Deleted => Ok(false),
-        }
-    }
-
-    pub fn borrow_global(
-        &self,
-        address: AccountAddress<F>,
-        sd_index: StructDefinitionIndex,
-    ) -> VmResult<GlobalRef<F>> {
-        match self {
-            Self::None | Self::Deleted => Err(RuntimeError::new(StatusCode::MissingData)),
-            Self::Fresh { fields } => Ok(GlobalRef {
-                loc: GlobalLocation { address, sd_index },
-                refer: Container(Rc::clone(fields)),
-            }),
-
-            Self::Cached { fields, status: _ } => Ok(GlobalRef {
-                loc: GlobalLocation { address, sd_index },
-                refer: Container(Rc::clone(fields)),
-            }),
-        }
     }
 }
 
@@ -672,6 +127,72 @@ pub enum Value<F: FieldExt> {
 /// Container is just a wrapper of vec contains its fields.
 #[derive(Clone, Debug)]
 pub struct Container<F: FieldExt>(pub Rc<RefCell<Vec<Value<F>>>>);
+
+/// Location of global struct.
+#[derive(Clone, Copy, Debug)]
+pub struct GlobalLocation<F: FieldExt> {
+    pub address: AccountAddress<F>,
+    pub sd_index: StructDefinitionIndex,
+}
+
+/// Location of local values(simple values or containers)
+#[derive(Clone, Copy, Debug)]
+pub struct LocalLocation {
+    pub frame_index: FrameIndex,
+    pub index: u64,
+}
+
+/// Location of stack values (simple values or containers)
+#[derive(Clone, Copy, Debug)]
+pub struct StackLocation {
+    pub stack_index: usize,
+}
+
+/// Location of value stored in sub-fields of a container(in local or global, even in stack)
+/// IndexedValue doesn't actually fit in our value locations.
+/// we fake it as a location just to make value flatten easier.
+#[derive(Clone, Debug)]
+pub struct IndexedLocation<F: FieldExt> {
+    pub sub_indexes: Vec<usize>,
+    pub value_loc: ValueLocation<F>,
+}
+impl<F: FieldExt> IndexedLocation<F> {
+    pub fn new(root_location: ValueLocation<F>, sub_indexes: Vec<usize>) -> Self {
+        IndexedLocation {
+            sub_indexes,
+            value_loc: root_location,
+        }
+    }
+
+    /// keep it private so it cannot be abused
+    fn to_address_path(&self) -> AddressPath<F> {
+        self.value_loc
+            .to_address_path()
+            .with_subpath(self.sub_indexes.clone())
+    }
+}
+
+/// Location of value when it move/copy from one place to another place.
+#[derive(Clone, Debug)]
+pub enum ValueLocation<F: FieldExt> {
+    Stack(StackLocation),
+    Local(LocalLocation),
+    Global(GlobalLocation<F>),
+}
+impl<F: FieldExt> ValueLocation<F> {
+    fn to_address_path(&self) -> AddressPath<F> {
+        let indexes = match self {
+            ValueLocation::Stack(loc) => vec![0, loc.stack_index],
+            ValueLocation::Local(loc) => vec![loc.frame_index.0, loc.index as usize],
+            ValueLocation::Global(loc) => vec![
+                // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
+                loc.address.value().get_lower_128() as usize,
+                loc.sd_index.0 as usize,
+            ],
+        };
+        indexes.into()
+    }
+}
 impl<F: FieldExt> Container<F> {
     pub fn len(&self) -> usize {
         self.0.borrow().len()
@@ -688,9 +209,6 @@ impl<F: FieldExt> Container<F> {
     pub fn signer(x: AccountAddress<F>) -> Self {
         Container(Rc::new(RefCell::new(vec![Value::Address(x)])))
     }
-}
-
-impl<F: FieldExt> Container<F> {
     /// read_field return a deep_copy of the field.
     fn read_field(&self, element_idx: usize) -> VmResult<Value<F>> {
         let len = self.0.borrow().len();
@@ -722,7 +240,9 @@ impl<F: FieldExt> Container<F> {
         Ok(())
     }
 
-    pub(self) fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
+    /// cast_simples return a flattened vec contains all the simple values of the container
+    /// keep it private so it cannot be abused
+    fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
         let mut simples = Vec::new();
         for (idx, val) in self.0.borrow().iter().enumerate() {
             let mut sub_values = val.cast_simples();
@@ -846,12 +366,11 @@ impl<F: FieldExt> GlobalRef<F> {
         let c = match v {
             Value::Container(c) => c,
             _ => {
-                return Err(
-                    RuntimeError::new(StatusCode::UnknownInvariantViolationError)
-                        .with_message("failed to write_ref: container type mismatch".to_string()),
-                )
+                return Err(RuntimeError::new(StatusCode::TypeMismatch)
+                    .with_message("failed to write_ref: container type mismatch".to_string()))
             }
         };
+        debug_assert_eq!(Rc::strong_count(&c.0), 1);
         *self.refer.0.borrow_mut() = c.0.take();
         Ok(())
     }
@@ -880,10 +399,10 @@ pub struct LocalRef<F: FieldExt> {
 }
 
 impl<F: FieldExt> LocalRef<F> {
-    pub fn read_ref(&self) -> VmResult<Value<F>> {
+    fn read_ref(&self) -> VmResult<Value<F>> {
         Ok(self.refer.borrow().copy_value())
     }
-    pub fn write_ref(&self, v: Value<F>) -> VmResult<()> {
+    fn write_ref(&self, v: Value<F>) -> VmResult<()> {
         let mut this_value = self.refer.borrow_mut();
         match (this_value.deref_mut(), v) {
             (Value::Bool(t), Value::Bool(v)) => {
@@ -1018,69 +537,6 @@ impl<F: FieldExt> From<SimpleValue<F>> for Value<F> {
         }
     }
 }
-/// Location of global struct.
-#[derive(Clone, Copy, Debug)]
-pub struct GlobalLocation<F: FieldExt> {
-    pub address: AccountAddress<F>,
-    pub sd_index: StructDefinitionIndex,
-}
-
-/// Location of local values(simple values or containers)
-#[derive(Clone, Copy, Debug)]
-pub struct LocalLocation {
-    pub frame_index: FrameIndex,
-    pub index: u64,
-}
-
-/// Location of stack values (simple values or containers)
-#[derive(Clone, Copy, Debug)]
-pub struct StackLocation {
-    pub stack_index: usize,
-}
-
-/// Location of value stored in sub-fields of a container(in local or global, even in stack)
-/// IndexedValue doesn't actually fit in our value locations.
-/// we fake it as a location just to make value flatten easier.
-#[derive(Clone, Debug)]
-pub struct IndexedLocation<F: FieldExt> {
-    pub sub_indexes: Vec<usize>,
-    pub value_loc: ValueLocation<F>,
-}
-impl<F: FieldExt> IndexedLocation<F> {
-    pub fn new(root_location: ValueLocation<F>, sub_indexes: Vec<usize>) -> Self {
-        IndexedLocation {
-            sub_indexes,
-            value_loc: root_location,
-        }
-    }
-    pub(self) fn to_address_path(&self) -> AddressPath<F> {
-        self.value_loc
-            .to_address_path()
-            .with_subpath(self.sub_indexes.clone())
-    }
-}
-
-/// Location of value when it move/copy from one place to another place.
-#[derive(Clone, Debug)]
-pub enum ValueLocation<F: FieldExt> {
-    Stack(StackLocation),
-    Local(LocalLocation),
-    Global(GlobalLocation<F>),
-}
-impl<F: FieldExt> ValueLocation<F> {
-    pub(self) fn to_address_path(&self) -> AddressPath<F> {
-        let indexes = match self {
-            ValueLocation::Stack(loc) => vec![0, loc.stack_index],
-            ValueLocation::Local(loc) => vec![loc.frame_index.0, loc.index as usize],
-            ValueLocation::Global(loc) => vec![
-                // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
-                loc.address.value().get_lower_128() as usize,
-                loc.sd_index.0 as usize,
-            ],
-        };
-        indexes.into()
-    }
-}
 
 impl<F: FieldExt> SimpleValue<F> {
     pub fn bool(x: bool) -> Self {
@@ -1209,7 +665,7 @@ impl<F: FieldExt> Value<F> {
 
     /// Cast the value into simple value if it's simple
     /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
-    pub(self) fn cast_simple(&self) -> Option<SimpleValue<F>> {
+    fn cast_simple(&self) -> Option<SimpleValue<F>> {
         Some(match self {
             Value::U8(v) => SimpleValue::U8(*v),
             Value::U64(v) => SimpleValue::U64(*v),
@@ -1224,7 +680,7 @@ impl<F: FieldExt> Value<F> {
     /// the list is sorted by it paths.
     /// Such as: `[0] < [1,0] < [1,1,0] < [1,1,1] < [2]`
     /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
-    pub(self) fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
+    fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
         if let Some(simple_value) = self.cast_simple() {
             // simple value doesn't need subpaths.
             return vec![(vec![], simple_value)];
@@ -1277,9 +733,15 @@ impl<F: FieldExt> Value<F> {
             _ => unreachable!(),
         }
     }
-    pub fn flatten(&self, loc: ValueLocation<F>) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
-        let v_loc = loc.to_address_path().into_inner();
-        let mut values = self.cast_simples();
+}
+/// A located value
+#[derive(Debug)]
+pub struct LocatedValue<'v, L, V>(/* loc */ pub L, /* v */ pub &'v V);
+
+impl<'v, F: FieldExt> LocatedValue<'v, ValueLocation<F>, Value<F>> {
+    pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
+        let v_loc = self.0.to_address_path().into_inner();
+        let mut values = self.1.cast_simples();
         values.iter_mut().for_each(|(p, _)| {
             let mut new_loc = v_loc.clone();
             new_loc.append(p);
@@ -1293,30 +755,7 @@ impl<F: FieldExt> Value<F> {
     }
 }
 
-// /// A located value
-// #[derive(Debug)]
-// pub struct LocatedValue<F: FieldExt, V>(ValueLocation<F>, V);
-//
-// impl<F: FieldExt> LocatedValue<F, Value<F>> {
-//     pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
-//         let v_loc = self.0.to_address_path().into_inner();
-//         let mut values = self.1.cast_simples();
-//         values.iter_mut().for_each(|(p, _)| {
-//             let mut new_loc = v_loc.clone();
-//             new_loc.append(p);
-//             *p = new_loc;
-//         });
-//         values.into_iter().map(|(p, v)| (p.into(), v)).collect()
-//     }
-// }
-
-/// A indexed value is an inner value node of some outer struct.
-/// TODO: should we merge IndexedLocation into ValueLocation and merge this into LocatedValue.
-/// I keep it seperated to make things clear.
-#[derive(Debug)]
-pub struct IndexedValue<F: FieldExt, V>(pub IndexedLocation<F>, pub V);
-
-impl<F: FieldExt> IndexedValue<F, Value<F>> {
+impl<'v, F: FieldExt> LocatedValue<'v, IndexedLocation<F>, Value<F>> {
     pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
         let v_loc = self.0.to_address_path().into_inner();
         let mut values = self.1.cast_simples();
@@ -1823,6 +1262,132 @@ impl<F: FieldExt> Value<F> {
             Value::Address(address) => Ok(address),
             _ => Err(RuntimeError::new(StatusCode::ValueConversionError)
                 .with_message("the value can not be cast as AccountAddress".to_string())),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Struct<F: FieldExt> {
+    fields: Vec<Value<F>>,
+}
+
+impl<F: FieldExt> Struct<F> {
+    pub fn pack(values: Vec<Value<F>>) -> Self {
+        Self { fields: values }
+    }
+
+    pub fn unpack(self) -> VmResult<Vec<Value<F>>> {
+        Ok(self.fields)
+    }
+}
+
+// Clean - the value was only read.
+// Dirty - the value was possibly modified.
+#[derive(Debug, Clone, Copy)]
+pub enum GlobalDataStatus {
+    Clean,
+    Dirty,
+}
+
+#[derive(Debug, Clone)]
+pub enum GlobalValue<F: FieldExt> {
+    /// No resource resides in this slot or in storage.
+    None,
+    /// A resource has been published to this slot and it did not previously exist in storage.
+    Fresh { fields: Rc<RefCell<Vec<Value<F>>>> },
+    /// A resource resides in this slot and also in storage. The status flag indicates whether
+    /// it has potentially been altered.
+    Cached {
+        fields: Rc<RefCell<Vec<Value<F>>>>,
+        status: Rc<RefCell<GlobalDataStatus>>,
+    },
+    /// A resource used to exist in storage but has been deleted by the current transaction.
+    Deleted,
+}
+
+impl<F: FieldExt> GlobalValue<F> {
+    pub fn none() -> Self {
+        GlobalValue::None
+    }
+
+    fn fresh(val: Value<F>) -> VmResult<Self> {
+        match val {
+            Value::Container(Container(fields)) => Ok(Self::Fresh { fields }),
+            _ => Err(
+                RuntimeError::new(StatusCode::UnknownInvariantViolationError)
+                    .with_message("not a resource type".to_string()),
+            ),
+        }
+    }
+
+    fn cached(val: Value<F>, status: GlobalDataStatus) -> VmResult<Self> {
+        match val {
+            Value::Container(Container(fields)) => {
+                let status = Rc::new(RefCell::new(status));
+                Ok(Self::Cached { fields, status })
+            }
+            _ => Err(
+                RuntimeError::new(StatusCode::UnknownInvariantViolationError)
+                    .with_message("not a resource type".to_string()),
+            ),
+        }
+    }
+
+    pub fn move_from(&mut self) -> VmResult<Value<F>> {
+        let fields = match self {
+            Self::None | Self::Deleted => return Err(RuntimeError::new(StatusCode::MissingData)),
+            Self::Fresh { .. } => match std::mem::replace(self, Self::None) {
+                Self::Fresh { fields } => fields,
+                _ => unreachable!(),
+            },
+            Self::Cached { .. } => match std::mem::replace(self, Self::Deleted) {
+                Self::Cached { fields, .. } => fields,
+                _ => unreachable!(),
+            },
+        };
+        if Rc::strong_count(&fields) != 1 {
+            return Err(
+                RuntimeError::new(StatusCode::UnknownInvariantViolationError)
+                    .with_message("moving global resource with dangling reference".to_string()),
+            );
+        }
+        Ok(Value::Container(Container(fields)))
+    }
+
+    pub fn move_to(&mut self, val: Value<F>) -> VmResult<()> {
+        match self {
+            Self::Fresh { .. } | Self::Cached { .. } => {
+                return Err(RuntimeError::new(StatusCode::ResourceAlreadyExists))
+            }
+            Self::None => *self = Self::fresh(val)?,
+            Self::Deleted => *self = Self::cached(val, GlobalDataStatus::Dirty)?,
+        }
+        Ok(())
+    }
+
+    pub fn exists(&self) -> VmResult<bool> {
+        match self {
+            Self::Fresh { .. } | Self::Cached { .. } => Ok(true),
+            Self::None | Self::Deleted => Ok(false),
+        }
+    }
+
+    pub fn borrow_global(
+        &self,
+        address: AccountAddress<F>,
+        sd_index: StructDefinitionIndex,
+    ) -> VmResult<GlobalRef<F>> {
+        match self {
+            Self::None | Self::Deleted => Err(RuntimeError::new(StatusCode::MissingData)),
+            Self::Fresh { fields } => Ok(GlobalRef {
+                loc: GlobalLocation { address, sd_index },
+                refer: Container(Rc::clone(fields)),
+            }),
+
+            Self::Cached { fields, status: _ } => Ok(GlobalRef {
+                loc: GlobalLocation { address, sd_index },
+                refer: Container(Rc::clone(fields)),
+            }),
         }
     }
 }

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -8,9 +8,10 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Value as CircuitValue;
 use move_binary_format::file_format::StructDefinitionIndex;
+use move_core_types::account_address::AccountAddress as MoveAccountAddress;
 use std::convert::TryFrom;
 use std::marker::PhantomData;
-use std::ops::{Add, Div, Mul, Not, Rem, Sub};
+use std::ops::{Add, Deref, DerefMut, Div, Mul, Not, Rem, Sub};
 use std::{cell::RefCell, rc::Rc};
 
 pub const NUM_OF_BYTES_U8: usize = 1;
@@ -18,64 +19,69 @@ pub const NUM_OF_BYTES_U64: usize = 8;
 pub const NUM_OF_BYTES_U128: usize = 16;
 pub const DEPTH_OF_ADDRESS_PATH: usize = 4; // frame_index, index(address), address_ext_1, address_ext_1
 
-#[derive(Copy, Clone, Debug)]
-pub struct U8<F: FieldExt>(F);
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct U8<F: FieldExt>(pub F);
 
-#[derive(Copy, Clone, Debug)]
-pub struct U64<F: FieldExt>(F);
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct U64<F: FieldExt>(pub F);
 
-#[derive(Copy, Clone, Debug)]
-pub struct U128<F: FieldExt>(F);
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct U128<F: FieldExt>(pub F);
 
-#[derive(Copy, Clone, Debug)]
-pub struct Bool<F: FieldExt>(F);
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Bool<F: FieldExt>(pub F);
 
-/// A wrapper for account address
-#[derive(Copy, Clone, Debug)]
-pub struct Address<F: FieldExt>(AccountAddress<F>);
-
-impl<F: FieldExt> Address<F> {
-    pub fn account_address(self) -> AccountAddress<F> {
-        self.0
-    }
-    pub fn value(&self) -> F {
-        self.0.value()
-    }
-}
+// /// A wrapper for account address
+// #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+// pub struct Address<F: FieldExt>(AccountAddress<F>);
+//
+// impl<F: FieldExt> Address<F> {
+//     pub fn account_address(self) -> AccountAddress<F> {
+//         self.0
+//     }
+//     pub fn value(&self) -> F {
+//         self.0.value()
+//     }
+// }
 
 /// Index of a frame
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FrameIndex(pub usize);
 
 /// Index of a value in locals, or index of a member in the struct
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Index(pub usize);
 
-/// An address of a zkMove value
-#[derive(Clone, Debug)]
-pub enum ValueAddress<F: FieldExt> {
-    /// If the value lives in the eval stack, the address will be the
-    /// index of the value in stack.
-    Stack(Index),
-    /// If the value lives in the locals of a frame, the address will be the
-    /// combination of frame_index and the index of the value in locals.
-    Locals(FrameIndex, Index),
-    /// If the value lives in the global storage, the address will be the
-    /// AccountAddress/StructDefinitionIndex of the value.
-    Global(AccountAddress<F>, StructDefinitionIndex),
-    /// If the value is a member of a Local or Global value, the address will be
-    /// the index of the member, and the address of parent value.
-    Member {
-        index: Index,
-        parent: Box<ValueAddress<F>>,
-    },
-    /// The value was just created and has not been stored yet.
-    Unknown,
-}
+// /// An address of a zkMove value
+// #[derive(Clone, Debug)]
+// pub enum ValueAddress<F: FieldExt> {
+//     /// If the value lives in the eval stack, the address will be the
+//     /// index of the value in stack.
+//     Stack(Index),
+//     /// If the value lives in the locals of a frame, the address will be the
+//     /// combination of frame_index and the index of the value in locals.
+//     Locals(FrameIndex, Index),
+//     /// If the value lives in the global storage, the address will be the
+//     /// AccountAddress/StructDefinitionIndex of the value.
+//     Global(AccountAddress<F>, StructDefinitionIndex),
+//     /// If the value is a member of a Local or Global value, the address will be
+//     /// the index of the member, and the address of parent value.
+//     Member {
+//         index: Index,
+//         parent: Box<ValueAddress<F>>,
+//     },
+//     /// The value was just created and has not been stored yet.
+//     Unknown,
+// }
 
 #[derive(Clone, Debug)]
 //todo: use 'Field' instead of 'usize'?
 pub struct AddressPath<F: FieldExt>(pub Vec<usize>, PhantomData<F>);
+impl<F: FieldExt> From<Vec<usize>> for AddressPath<F> {
+    fn from(indexes: Vec<usize>) -> Self {
+        AddressPath(indexes, PhantomData)
+    }
+}
 
 impl<F: FieldExt> AddressPath<F> {
     pub fn into_inner(self) -> Vec<usize> {
@@ -88,6 +94,10 @@ impl<F: FieldExt> AddressPath<F> {
         let mut path = self.into_inner();
         path.push(leaf);
         AddressPath(path, PhantomData)
+    }
+    pub fn with_subpath(mut self, mut subpath: Vec<usize>) -> Self {
+        self.0.append(&mut subpath);
+        self
     }
     pub fn len(&self) -> usize {
         self.0.len()
@@ -103,493 +113,391 @@ impl<F: FieldExt> AddressPath<F> {
         }
         self
     }
-    pub fn flatten(self, address: ValueAddress<F>) -> VmResult<Vec<(AddressPath<F>, Value<F>)>> {
-        let values = self
-            .into_inner()
-            .iter()
-            .map(|v| Value::u64(*v as u64))
-            .collect();
-        let struct_ = Container::Struct(address, Rc::new(RefCell::new(values)));
-        struct_.flatten()
-    }
-}
-
-impl<F: FieldExt> ValueAddress<F> {
-    pub fn address_path(&self) -> VmResult<AddressPath<F>> {
-        match self {
-            Self::Stack(index) => Ok(AddressPath(vec![0, index.0], PhantomData)),
-            Self::Locals(frame_index, index) => {
-                Ok(AddressPath(vec![frame_index.0, index.0], PhantomData))
-            }
-            Self::Member { index, parent } => {
-                let path = parent.address_path()?;
-                Ok(path.extend(index.0))
-            }
-            Self::Global(addr, sd_index) => Ok(AddressPath(
-                vec![
-                    // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
-                    addr.value().get_lower_128() as usize,
-                    sd_index.0 as usize,
-                ],
-                PhantomData,
-            )),
-            _ => unimplemented!(),
-        }
-    }
-
-    pub fn frame_index(&self) -> usize {
-        let path = self.address_path().expect("should not reach here");
-        let res = path
-            .as_inner()
-            .get(0)
-            .expect("frame index should not be None");
-        *res
-    }
-
-    pub fn address(&self) -> usize {
-        let path = self.address_path().expect("should not reach here");
-        let res = path.as_inner().get(1).expect("address should not be None");
-        *res
-    }
-    pub fn global_path(&self) -> Option<(AccountAddress<F>, StructDefinitionIndex)> {
-        match self {
-            Self::Global(addr, idx) => Some((*addr, *idx)),
-            Self::Member { parent, .. } => parent.global_path(),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum Container<F: FieldExt> {
-    Locals(FrameIndex, Rc<RefCell<Vec<Value<F>>>>),
-    Struct(ValueAddress<F>, Rc<RefCell<Vec<Value<F>>>>),
-}
-
-impl<F: FieldExt> Container<F> {
-    pub fn len(&self) -> usize {
-        match self {
-            Self::Locals(_, r) => r.borrow().len(),
-            Self::Struct(_, r) => r.borrow().len(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Self::Locals(_, r) => r.borrow().is_empty(),
-            Self::Struct(_, r) => r.borrow().is_empty(),
-        }
-    }
-
-    pub fn rc_count(&self) -> usize {
-        match self {
-            Self::Locals(_, r) => Rc::strong_count(r),
-            Self::Struct(_, r) => Rc::strong_count(r),
-        }
-    }
-
-    // value of Container is recorded by RW_Ops.
-    // pub fn value(&self) -> F {
-    //     match self {
-    //         Self::Locals(_, _) => F::from_u128(FakeContainerValue::LOCALS as u128),
-    //         Self::Struct(_, _) => F::from_u128(FakeContainerValue::STRUCT as u128),
-    //     }
+    // pub fn flatten(self, address: ValueAddress<F>) -> VmResult<Vec<(AddressPath<F>, Value<F>)>> {
+    //     let values = self
+    //         .into_inner()
+    //         .iter()
+    //         .map(|v| Value::u64(*v as u64))
+    //         .collect();
+    //     let struct_ = Container::Struct(address, Rc::new(RefCell::new(values)));
+    //     struct_.flatten()
     // }
-
-    pub fn signer(x: AccountAddress<F>) -> Self {
-        Container::Struct(
-            ValueAddress::Unknown,
-            Rc::new(RefCell::new(vec![Value::Address(Address(x))])),
-        )
-    }
-
-    pub fn value_address(&self) -> ValueAddress<F> {
-        match self {
-            Self::Locals(_, _) => unreachable!(),
-            Self::Struct(address, _) => address.clone(),
-        }
-    }
-
-    pub fn frame_index(&self) -> usize {
-        match self {
-            Self::Locals(frame_index, _) => frame_index.0,
-            Self::Struct(address, _) => match address {
-                ValueAddress::Locals(frame_index, _index) => frame_index.0,
-                ValueAddress::Member { index: _, parent } => parent.frame_index(),
-                _ => unreachable!(),
-            },
-        }
-    }
-
-    pub fn index(&self) -> usize {
-        match self {
-            Self::Locals(_, _) => unreachable!(),
-            Self::Struct(address, _) => match address {
-                ValueAddress::Locals(_frame_index, index) => index.0,
-                ValueAddress::Member { index: _, parent } => parent.address(),
-
-                _ => unreachable!(),
-            },
-        }
-    }
-
-    pub fn flatten(&self) -> VmResult<Vec<(AddressPath<F>, Value<F>)>> {
-        let mut result = Vec::new();
-        match self {
-            Self::Struct(address, value) => {
-                let base_path = address.address_path()?;
-                for (i, val) in value.borrow().iter().map(|v| v.copy_value()).enumerate() {
-                    let path = base_path.clone().extend(i);
-                    match val {
-                        Value::U8(_)
-                        | Value::U64(_)
-                        | Value::U128(_)
-                        | Value::Bool(_)
-                        | Value::Address(_) => {
-                            result.push((path.fill_up(), val));
-                        }
-                        Value::Container(v) => {
-                            let mut flattened = v.flatten()?;
-                            result.append(&mut flattened);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-            }
-            Self::Locals(_, _) => unreachable!(),
-        }
-        Ok(result)
-    }
 }
 
-/// A ContainerRef is a reference to a container, which could live either
-/// in the frame or in global storage.
-#[derive(Clone, Debug)]
-pub enum ContainerRef<F: FieldExt> {
-    Local(Container<F>),
-    Global(Container<F>),
-}
+// impl<F: FieldExt> ValueAddress<F> {
+//     pub fn address_path(&self) -> VmResult<AddressPath<F>> {
+//         match self {
+//             Self::Stack(index) => Ok(AddressPath(vec![0, index.0], PhantomData)),
+//             Self::Locals(frame_index, index) => {
+//                 Ok(AddressPath(vec![frame_index.0, index.0], PhantomData))
+//             }
+//             Self::Member { index, parent } => {
+//                 let path = parent.address_path()?;
+//                 Ok(path.extend(index.0))
+//             }
+//             Self::Global(addr, sd_index) => Ok(AddressPath(
+//                 vec![
+//                     // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
+//                     addr.value().get_lower_128() as usize,
+//                     sd_index.0 as usize,
+//                 ],
+//                 PhantomData,
+//             )),
+//             _ => unimplemented!(),
+//         }
+//     }
+//
+//     pub fn frame_index(&self) -> usize {
+//         let path = self.address_path().expect("should not reach here");
+//         let res = path
+//             .as_inner()
+//             .get(0)
+//             .expect("frame index should not be None");
+//         *res
+//     }
+//
+//     pub fn address(&self) -> usize {
+//         let path = self.address_path().expect("should not reach here");
+//         let res = path.as_inner().get(1).expect("address should not be None");
+//         *res
+//     }
+//     pub fn global_path(&self) -> Option<(AccountAddress<F>, StructDefinitionIndex)> {
+//         match self {
+//             Self::Global(addr, idx) => Some((*addr, *idx)),
+//             Self::Member { parent, .. } => parent.global_path(),
+//             _ => None,
+//         }
+//     }
+// }
 
-impl<F: FieldExt> ContainerRef<F> {
-    fn container(&self) -> &Container<F> {
-        match self {
-            Self::Local(container) => container,
-            Self::Global(container) => container,
-        }
-    }
+// /// A ContainerRef is a reference to a container, which could live either
+// /// in the frame or in global storage.
+// #[derive(Clone, Debug)]
+// pub enum ContainerRef<F: FieldExt> {
+//     Local(Container<F>),
+//     Global(Container<F>),
+// }
 
-    fn read_ref(&self) -> VmResult<Value<F>> {
-        Ok(Value::Container(self.container().copy_value()))
-    }
+// impl<F: FieldExt> ContainerRef<F> {
+//     fn container(&self) -> &Container<F> {
+//         match self {
+//             Self::Local(container) => container,
+//             Self::Global(container) => container,
+//         }
+//     }
+//
+//     fn read_ref(&self) -> VmResult<Value<F>> {
+//         Ok(Value::Container(self.container().copy_value()))
+//     }
+//
+//     fn write_ref(&mut self, value: Value<F>) -> VmResult<()> {
+//         match value {
+//             Value::Container(c) => match self.container() {
+//                 Container::Struct(_, struct_) => {
+//                     let r = match c {
+//                         Container::Struct(_, v) => v,
+//                         _ => {
+//                             return Err(RuntimeError::new(StatusCode::TypeMismatch)
+//                                 .with_message("failed to write ref".to_string()))
+//                         }
+//                     };
+//
+//                     debug_assert_eq!(Rc::strong_count(&r), 1);
+//                     let fields = match Rc::try_unwrap(r) {
+//                         Ok(cell) => Ok(cell.into_inner()),
+//                         Err(v) => Err(RuntimeError::new(
+//                             StatusCode::UnknownInvariantViolationError,
+//                         )
+//                         .with_message(format!("moving value {:?} with dangling references", v))),
+//                     };
+//                     *struct_.borrow_mut() = fields?;
+//                     Ok(())
+//                 }
+//                 Container::Locals(_, _) => Err(RuntimeError::new(StatusCode::TypeMismatch)
+//                     .with_message("cannot change Container::Locals".to_string())),
+//             },
+//             v => Err(
+//                 RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
+//                     "cannot write value {:?} to container ref {:?}",
+//                     v, self
+//                 )),
+//             ),
+//         }
+//     }
+//
+//     pub fn borrow_element(&self, element_idx: usize) -> VmResult<Value<F>> {
+//         let res = match self.container() {
+//             Container::Locals(_, _) => {
+//                 unreachable!("should not come here.")
+//             }
+//             Container::Struct(_, r) => {
+//                 let len = r.borrow().len();
+//                 if element_idx >= len {
+//                     return Err(
+//                         RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+//                             "index out of bounds when borrowing container element: index: {}, length: {}",
+//                             element_idx, len
+//                         )),
+//                     );
+//                 }
+//                 let v = r.borrow();
+//                 match &v[element_idx] {
+//                     Value::Container(container) => {
+//                         let r = match self {
+//                             Self::Local(_) => Self::Local(container.copy_by_ref()),
+//                             Self::Global(_) => Self::Global(container.copy_by_ref()),
+//                         };
+//                         Value::ContainerRef(r)
+//                     }
+//                     _ => Value::IndexedRef(IndexedRef {
+//                         index: element_idx,
+//                         container_ref: self.copy_value(),
+//                     }),
+//                 }
+//             }
+//         };
+//
+//         Ok(res)
+//     }
+//
+//     fn copy_value(&self) -> Self {
+//         match self {
+//             Self::Local(container) => Self::Local(container.copy_by_ref()),
+//             Self::Global(container) => Self::Global(container.copy_by_ref()),
+//         }
+//     }
+//
+//     fn is_global(&self) -> bool {
+//         matches!(self, Self::Global(_)) // container holds global value
+//     }
+//
+//     fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
+//         match self {
+//             Self::Local(_) => unreachable!(),
+//             Self::Global(c) => match c {
+//                 Container::Locals(_, _) => unreachable!(),
+//                 Container::Struct(addr, _) => addr
+//                     .global_path()
+//                     .expect("expect global or member of global"),
+//             },
+//         }
+//     }
+//
+//     fn copy_global_value(&self) -> VmResult<Value<F>> {
+//         if self.is_global() {
+//             self.read_ref()
+//         } else {
+//             Err(RuntimeError::new(StatusCode::TypeMismatch)
+//                 .with_message("The value doesn't contain global value".to_string()))
+//         }
+//     }
+//
+//     fn container_index(&self) -> usize {
+//         self.container().index()
+//     }
+//
+//     fn container_frame_index(&self) -> usize {
+//         self.container().frame_index()
+//     }
+//
+//     fn value_address(&self) -> ValueAddress<F> {
+//         self.container().value_address()
+//     }
+// }
 
-    fn write_ref(&mut self, value: Value<F>) -> VmResult<()> {
-        match value {
-            Value::Container(c) => match self.container() {
-                Container::Struct(_, struct_) => {
-                    let r = match c {
-                        Container::Struct(_, v) => v,
-                        _ => {
-                            return Err(RuntimeError::new(StatusCode::TypeMismatch)
-                                .with_message("failed to write ref".to_string()))
-                        }
-                    };
-
-                    debug_assert_eq!(Rc::strong_count(&r), 1);
-                    let fields = match Rc::try_unwrap(r) {
-                        Ok(cell) => Ok(cell.into_inner()),
-                        Err(v) => Err(RuntimeError::new(
-                            StatusCode::UnknownInvariantViolationError,
-                        )
-                        .with_message(format!("moving value {:?} with dangling references", v))),
-                    };
-                    *struct_.borrow_mut() = fields?;
-                    Ok(())
-                }
-                Container::Locals(_, _) => Err(RuntimeError::new(StatusCode::TypeMismatch)
-                    .with_message("cannot change Container::Locals".to_string())),
-            },
-            v => Err(
-                RuntimeError::new(StatusCode::TypeMismatch).with_message(format!(
-                    "cannot write value {:?} to container ref {:?}",
-                    v, self
-                )),
-            ),
-        }
-    }
-
-    pub fn borrow_element(&self, element_idx: usize) -> VmResult<Value<F>> {
-        let res = match self.container() {
-            Container::Locals(_, _) => {
-                unreachable!("should not come here.")
-            }
-            Container::Struct(_, r) => {
-                let len = r.borrow().len();
-                if element_idx >= len {
-                    return Err(
-                        RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
-                            "index out of bounds when borrowing container element: index: {}, length: {}",
-                            element_idx, len
-                        )),
-                    );
-                }
-                let v = r.borrow();
-                match &v[element_idx] {
-                    Value::Container(container) => {
-                        let r = match self {
-                            Self::Local(_) => Self::Local(container.copy_by_ref()),
-                            Self::Global(_) => Self::Global(container.copy_by_ref()),
-                        };
-                        Value::ContainerRef(r)
-                    }
-                    _ => Value::IndexedRef(IndexedRef {
-                        index: element_idx,
-                        container_ref: self.copy_value(),
-                    }),
-                }
-            }
-        };
-
-        Ok(res)
-    }
-
-    fn copy_value(&self) -> Self {
-        match self {
-            Self::Local(container) => Self::Local(container.copy_by_ref()),
-            Self::Global(container) => Self::Global(container.copy_by_ref()),
-        }
-    }
-
-    fn is_global(&self) -> bool {
-        matches!(self, Self::Global(_)) // container holds global value
-    }
-
-    fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
-        match self {
-            Self::Local(_) => unreachable!(),
-            Self::Global(c) => match c {
-                Container::Locals(_, _) => unreachable!(),
-                Container::Struct(addr, _) => addr
-                    .global_path()
-                    .expect("expect global or member of global"),
-            },
-        }
-    }
-
-    fn copy_global_value(&self) -> VmResult<Value<F>> {
-        if self.is_global() {
-            self.read_ref()
-        } else {
-            Err(RuntimeError::new(StatusCode::TypeMismatch)
-                .with_message("The value doesn't contain global value".to_string()))
-        }
-    }
-
-    fn container_index(&self) -> usize {
-        self.container().index()
-    }
-
-    fn container_frame_index(&self) -> usize {
-        self.container().frame_index()
-    }
-
-    fn value_address(&self) -> ValueAddress<F> {
-        self.container().value_address()
-    }
-}
-
-/// A reference pointing to an element in a container.
-#[derive(Clone, Debug)]
-pub struct IndexedRef<F: FieldExt> {
-    pub index: usize,
-    pub container_ref: ContainerRef<F>,
-}
-
-impl<F: FieldExt> IndexedRef<F> {
-    pub fn container(&self) -> &Container<F> {
-        self.container_ref.container()
-    }
-    pub fn container_ref(&self) -> &ContainerRef<F> {
-        &self.container_ref
-    }
-    fn read_ref(&self) -> VmResult<Value<F>> {
-        let value = match &*self.container_ref.container() {
-            Container::Locals(_, r) | Container::Struct(_, r) => {
-                r.borrow()[self.index].copy_value()
-            }
-        };
-        Ok(value)
-    }
-    fn write_ref(&mut self, x: Value<F>) -> VmResult<()> {
-        match &x {
-            Value::IndexedRef(_)
-            | Value::ContainerRef(_)
-            | Value::Invalid
-            | Value::Container(_) => return Err(RuntimeError::new(StatusCode::TypeMismatch)),
-            _ => (),
-        }
-
-        match (self.container_ref.container(), &x) {
-            (Container::Locals(_, r), _) | (Container::Struct(_, r), _) => {
-                let mut v = r.borrow_mut();
-                v[self.index] = x;
-            }
-        }
-        Ok(())
-    }
-    pub fn index(&self) -> usize {
-        self.index
-    }
-    fn container_frame_index(&self) -> usize {
-        self.container().frame_index()
-    }
-    fn copy_value(&self) -> Self {
-        Self {
-            index: self.index,
-            container_ref: self.container_ref.copy_value(),
-        }
-    }
-    pub fn borrow_element(&self, element_idx: usize) -> VmResult<Value<F>> {
-        let res = match self.container() {
-            Container::Locals(_, _) => {
-                unreachable!("should not come here.")
-            }
-            Container::Struct(_, r) => {
-                let len = r.borrow().len();
-                if element_idx >= len {
-                    return Err(
-                        RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
-                            "index out of bounds when borrowing container element: index: {}, length: {}",
-                            element_idx, len
-                        )),
-                    );
-                }
-                let v = r.borrow();
-                match &v[element_idx] {
-                    Value::Container(container) => {
-                        let r = match self.container_ref {
-                            ContainerRef::Local(_) => ContainerRef::Local(container.copy_by_ref()),
-                            ContainerRef::Global(_) => unreachable!(),
-                        };
-                        Value::ContainerRef(r)
-                    }
-                    _ => Value::IndexedRef(IndexedRef {
-                        index: self.index,
-                        container_ref: self.container_ref.copy_value(),
-                    }),
-                }
-            }
-        };
-
-        Ok(res)
-    }
-
-    fn is_global(&self) -> bool {
-        self.container_ref().is_global()
-    }
-
-    fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
-        self.container_ref.global_path()
-    }
-
-    fn copy_global_value(&self) -> VmResult<Value<F>> {
-        if self.is_global() {
-            self.container_ref().read_ref()
-        } else {
-            Err(RuntimeError::new(StatusCode::TypeMismatch)
-                .with_message("The value doesn't contain global value".to_string()))
-        }
-    }
-
-    fn value_address(&self) -> ValueAddress<F> {
-        match self.container() {
-            Container::Locals(frame_index, _) => {
-                ValueAddress::Locals(FrameIndex(frame_index.0), Index(self.index))
-            }
-            Container::Struct(address, _) => ValueAddress::Member {
-                index: Index(self.index),
-                parent: Box::new(address.clone()),
-            },
-        }
-    }
-}
-
-/// A wrapper to support read_ref and write_ref.
-#[derive(Debug, Clone)]
-pub enum Reference<F: FieldExt> {
-    IndexedRef(IndexedRef<F>),
-    ContainerRef(ContainerRef<F>),
-}
-
-impl<F: FieldExt> Reference<F> {
-    pub fn read_ref(&self) -> VmResult<Value<F>> {
-        match self {
-            Self::ContainerRef(r) => r.read_ref(),
-            Self::IndexedRef(r) => r.read_ref(),
-        }
-    }
-    pub fn write_ref(&mut self, x: Value<F>) -> VmResult<()> {
-        match self {
-            Self::ContainerRef(r) => r.write_ref(x),
-            Self::IndexedRef(r) => r.write_ref(x),
-        }
-    }
-    pub fn index(&self) -> usize {
-        match self {
-            Self::ContainerRef(r) => r.container_index(),
-            Self::IndexedRef(r) => r.index(),
-        }
-    }
-    pub fn container_frame_index(&self) -> usize {
-        match self {
-            Self::ContainerRef(r) => r.container_frame_index(),
-            Self::IndexedRef(r) => r.container_frame_index(),
-        }
-    }
-
-    pub fn is_global(&self) -> bool {
-        match self {
-            Self::ContainerRef(r) => r.is_global(),
-            Self::IndexedRef(r) => r.is_global(),
-        }
-    }
-
-    pub fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
-        match self {
-            Self::ContainerRef(r) => r.global_path(),
-            Self::IndexedRef(r) => r.global_path(),
-        }
-    }
-
-    // For a reference pointing to a global value, return the global value
-    // For a reference pointing to an element of a global value, return the global value
-    pub fn copy_global_value(&self) -> VmResult<Value<F>> {
-        match self {
-            Self::ContainerRef(r) => r.copy_global_value(),
-            Self::IndexedRef(r) => r.copy_global_value(),
-        }
-    }
-
-    pub fn value_address(&self) -> ValueAddress<F> {
-        match self {
-            Self::ContainerRef(r) => r.container().value_address(),
-            Self::IndexedRef(r) => r.value_address(),
-        }
-    }
-}
-
-/// A wrapper to support borrow_element
-#[derive(Debug, Clone)]
-pub struct StructRef<F: FieldExt>(pub ContainerRef<F>);
-
-impl<F: FieldExt> StructRef<F> {
-    pub fn borrow_element(&self, field_idx: usize) -> VmResult<Value<F>> {
-        self.0.borrow_element(field_idx)
-    }
-
-    pub fn value_address(&self) -> ValueAddress<F> {
-        self.0.value_address()
-    }
-}
+// /// A reference pointing to an element in a container.
+// #[derive(Clone, Debug)]
+// pub struct IndexedRef<F: FieldExt> {
+//     pub index: usize,
+//     pub container_ref: ContainerRef<F>,
+// }
+//
+// impl<F: FieldExt> IndexedRef<F> {
+//     pub fn container(&self) -> &Container<F> {
+//         self.container_ref.container()
+//     }
+//     pub fn container_ref(&self) -> &ContainerRef<F> {
+//         &self.container_ref
+//     }
+//     fn read_ref(&self) -> VmResult<Value<F>> {
+//         let value = match &*self.container_ref.container() {
+//             Container::Locals(_, r) | Container::Struct(_, r) => {
+//                 r.borrow()[self.index].copy_value()
+//             }
+//         };
+//         Ok(value)
+//     }
+//     fn write_ref(&mut self, x: Value<F>) -> VmResult<()> {
+//         match &x {
+//             Value::IndexedRef(_)
+//             | Value::ContainerRef(_)
+//             | Value::Invalid
+//             | Value::Container(_) => return Err(RuntimeError::new(StatusCode::TypeMismatch)),
+//             _ => (),
+//         }
+//
+//         match (self.container_ref.container(), &x) {
+//             (Container::Locals(_, r), _) | (Container::Struct(_, r), _) => {
+//                 let mut v = r.borrow_mut();
+//                 v[self.index] = x;
+//             }
+//         }
+//         Ok(())
+//     }
+//     pub fn index(&self) -> usize {
+//         self.index
+//     }
+//     fn container_frame_index(&self) -> usize {
+//         self.container().frame_index()
+//     }
+//     fn copy_value(&self) -> Self {
+//         Self {
+//             index: self.index,
+//             container_ref: self.container_ref.copy_value(),
+//         }
+//     }
+//     pub fn borrow_element(&self, element_idx: usize) -> VmResult<Value<F>> {
+//         let res = match self.container() {
+//             Container::Locals(_, _) => {
+//                 unreachable!("should not come here.")
+//             }
+//             Container::Struct(_, r) => {
+//                 let len = r.borrow().len();
+//                 if element_idx >= len {
+//                     return Err(
+//                         RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+//                             "index out of bounds when borrowing container element: index: {}, length: {}",
+//                             element_idx, len
+//                         )),
+//                     );
+//                 }
+//                 let v = r.borrow();
+//                 match &v[element_idx] {
+//                     Value::Container(container) => {
+//                         let r = match self.container_ref {
+//                             ContainerRef::Local(_) => ContainerRef::Local(container.copy_by_ref()),
+//                             ContainerRef::Global(_) => unreachable!(),
+//                         };
+//                         Value::ContainerRef(r)
+//                     }
+//                     _ => Value::IndexedRef(IndexedRef {
+//                         index: self.index,
+//                         container_ref: self.container_ref.copy_value(),
+//                     }),
+//                 }
+//             }
+//         };
+//
+//         Ok(res)
+//     }
+//
+//     fn is_global(&self) -> bool {
+//         self.container_ref().is_global()
+//     }
+//
+//     fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
+//         self.container_ref.global_path()
+//     }
+//
+//     fn copy_global_value(&self) -> VmResult<Value<F>> {
+//         if self.is_global() {
+//             self.container_ref().read_ref()
+//         } else {
+//             Err(RuntimeError::new(StatusCode::TypeMismatch)
+//                 .with_message("The value doesn't contain global value".to_string()))
+//         }
+//     }
+//
+//     fn value_address(&self) -> ValueAddress<F> {
+//         match self.container() {
+//             Container::Locals(frame_index, _) => {
+//                 ValueAddress::Locals(FrameIndex(frame_index.0), Index(self.index))
+//             }
+//             Container::Struct(address, _) => ValueAddress::Member {
+//                 index: Index(self.index),
+//                 parent: Box::new(address.clone()),
+//             },
+//         }
+//     }
+// }
+//
+// /// A wrapper to support read_ref and write_ref.
+// #[derive(Debug, Clone)]
+// pub enum Reference<F: FieldExt> {
+//     IndexedRef(IndexedRef<F>),
+//     ContainerRef(ContainerRef<F>),
+// }
+//
+// impl<F: FieldExt> Reference<F> {
+//     pub fn read_ref(&self) -> VmResult<Value<F>> {
+//         match self {
+//             Self::ContainerRef(r) => r.read_ref(),
+//             Self::IndexedRef(r) => r.read_ref(),
+//         }
+//     }
+//     pub fn write_ref(&mut self, x: Value<F>) -> VmResult<()> {
+//         match self {
+//             Self::ContainerRef(r) => r.write_ref(x),
+//             Self::IndexedRef(r) => r.write_ref(x),
+//         }
+//     }
+//     pub fn index(&self) -> usize {
+//         match self {
+//             Self::ContainerRef(r) => r.container_index(),
+//             Self::IndexedRef(r) => r.index(),
+//         }
+//     }
+//     pub fn container_frame_index(&self) -> usize {
+//         match self {
+//             Self::ContainerRef(r) => r.container_frame_index(),
+//             Self::IndexedRef(r) => r.container_frame_index(),
+//         }
+//     }
+//
+//     pub fn is_global(&self) -> bool {
+//         match self {
+//             Self::ContainerRef(r) => r.is_global(),
+//             Self::IndexedRef(r) => r.is_global(),
+//         }
+//     }
+//
+//     pub fn global_path(&self) -> (AccountAddress<F>, StructDefinitionIndex) {
+//         match self {
+//             Self::ContainerRef(r) => r.global_path(),
+//             Self::IndexedRef(r) => r.global_path(),
+//         }
+//     }
+//
+//     // For a reference pointing to a global value, return the global value
+//     // For a reference pointing to an element of a global value, return the global value
+//     pub fn copy_global_value(&self) -> VmResult<Value<F>> {
+//         match self {
+//             Self::ContainerRef(r) => r.copy_global_value(),
+//             Self::IndexedRef(r) => r.copy_global_value(),
+//         }
+//     }
+//
+//     pub fn value_address(&self) -> ValueAddress<F> {
+//         match self {
+//             Self::ContainerRef(r) => r.container().value_address(),
+//             Self::IndexedRef(r) => r.value_address(),
+//         }
+//     }
+// }
+//
+// /// A wrapper to support borrow_element
+// #[derive(Debug, Clone)]
+// pub struct StructRef<F: FieldExt>(pub ContainerRef<F>);
+//
+// impl<F: FieldExt> StructRef<F> {
+//     pub fn borrow_element(&self, field_idx: usize) -> VmResult<Value<F>> {
+//         self.0.borrow_element(field_idx)
+//     }
+//
+//     pub fn value_address(&self) -> ValueAddress<F> {
+//         self.0.value_address()
+//     }
+// }
 
 #[derive(Debug)]
 pub struct Struct<F: FieldExt> {
@@ -637,7 +545,7 @@ impl<F: FieldExt> GlobalValue<F> {
 
     fn fresh(val: Value<F>) -> VmResult<Self> {
         match val {
-            Value::Container(Container::Struct(_address, fields)) => Ok(Self::Fresh { fields }),
+            Value::Container(Container(fields)) => Ok(Self::Fresh { fields }),
             _ => Err(
                 RuntimeError::new(StatusCode::UnknownInvariantViolationError)
                     .with_message("not a resource type".to_string()),
@@ -647,7 +555,7 @@ impl<F: FieldExt> GlobalValue<F> {
 
     fn cached(val: Value<F>, status: GlobalDataStatus) -> VmResult<Self> {
         match val {
-            Value::Container(Container::Struct(_address, fields)) => {
+            Value::Container(Container(fields)) => {
                 let status = Rc::new(RefCell::new(status));
                 Ok(Self::Cached { fields, status })
             }
@@ -676,10 +584,7 @@ impl<F: FieldExt> GlobalValue<F> {
                     .with_message("moving global resource with dangling reference".to_string()),
             );
         }
-        Ok(Value::Container(Container::Struct(
-            ValueAddress::Unknown,
-            fields,
-        )))
+        Ok(Value::Container(Container(fields)))
     }
 
     pub fn move_to(&mut self, val: Value<F>) -> VmResult<()> {
@@ -704,44 +609,480 @@ impl<F: FieldExt> GlobalValue<F> {
         &self,
         address: AccountAddress<F>,
         sd_index: StructDefinitionIndex,
-    ) -> VmResult<Value<F>> {
+    ) -> VmResult<GlobalRef<F>> {
         match self {
             Self::None | Self::Deleted => Err(RuntimeError::new(StatusCode::MissingData)),
-            Self::Fresh { fields } => Ok(Value::ContainerRef(ContainerRef::Global(
-                Container::Struct(ValueAddress::Global(address, sd_index), Rc::clone(fields)),
-            ))),
-            Self::Cached { fields, status: _ } => Ok(Value::ContainerRef(ContainerRef::Global(
-                Container::Struct(ValueAddress::Global(address, sd_index), Rc::clone(fields)),
-            ))),
+            Self::Fresh { fields } => Ok(GlobalRef {
+                loc: GlobalLocation { address, sd_index },
+                refer: Container(Rc::clone(fields)),
+            }),
+
+            Self::Cached { fields, status: _ } => Ok(GlobalRef {
+                loc: GlobalLocation { address, sd_index },
+                refer: Container(Rc::clone(fields)),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SimpleValue<F: FieldExt> {
+    U8(U8<F>),
+    U64(U64<F>),
+    U128(U128<F>),
+    Bool(Bool<F>),
+    Address(AccountAddress<F>),
+}
+
+impl<F: FieldExt> From<SimpleValue<F>> for MoveValue {
+    fn from(value: SimpleValue<F>) -> MoveValue {
+        match value {
+            SimpleValue::U8(field) => MoveValue::U8(field.0.get_lower_128() as u8),
+            SimpleValue::U64(field) => MoveValue::U64(field.0.get_lower_128() as u64),
+            SimpleValue::U128(field) => MoveValue::U128(field.0.get_lower_128()),
+            SimpleValue::Bool(field) => MoveValue::Bool(field.0 == F::one()),
+            SimpleValue::Address(field) => {
+                // FIXME: f -> bytes for address
+                let mut bytes = 0u128.to_be_bytes().to_vec();
+                bytes.append(&mut field.value().get_lower_128().to_be_bytes().to_vec());
+                MoveValue::Address(MoveAccountAddress::from_bytes(bytes).unwrap())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Value<F: FieldExt> {
+    Invalid,
+    /// The following is simple value
+    U8(U8<F>),
+    U64(U64<F>),
+    U128(U128<F>),
+    Bool(Bool<F>),
+    Address(AccountAddress<F>),
+    /// struct representation
+    Container(Container<F>),
+    /// borrow global
+    GlobalRef(GlobalRef<F>),
+    /// borrow local
+    LocalRef(LocalRef<F>),
+    /// borrow field of a container
+    IndexedRef(IndexedRef<F>),
+}
+/// Container is just a wrapper of vec contains its fields.
+#[derive(Clone, Debug)]
+pub struct Container<F: FieldExt>(pub Rc<RefCell<Vec<Value<F>>>>);
+impl<F: FieldExt> Container<F> {
+    pub fn len(&self) -> usize {
+        self.0.borrow().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.borrow().is_empty()
+    }
+
+    pub fn rc_count(&self) -> usize {
+        Rc::strong_count(&self.0)
+    }
+
+    pub fn signer(x: AccountAddress<F>) -> Self {
+        Container(Rc::new(RefCell::new(vec![Value::Address(x)])))
+    }
+}
+
+impl<F: FieldExt> Container<F> {
+    /// read_field return a deep_copy of the field.
+    fn read_field(&self, element_idx: usize) -> VmResult<Value<F>> {
+        let len = self.0.borrow().len();
+        if element_idx >= len {
+            return Err(
+                RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+                    "index out of bounds when get container element: index: {}, length: {}",
+                    element_idx, len
+                )),
+            );
+        }
+        let v = self.0.borrow();
+        let e = &v[element_idx];
+        Ok(e.copy_value())
+    }
+    /// write_field write a value into the field of element_idx
+    fn write_field(&self, element_idx: usize, v: Value<F>) -> VmResult<()> {
+        let len = self.0.borrow().len();
+        if element_idx >= len {
+            return Err(
+                RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+                    "index out of bounds when write container element: index: {}, length: {}",
+                    element_idx, len
+                )),
+            );
+        }
+        let mut c = self.0.borrow_mut();
+        c[element_idx] = v;
+        Ok(())
+    }
+
+    pub(self) fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
+        let mut simples = Vec::new();
+        for (idx, val) in self.0.borrow().iter().enumerate() {
+            let mut sub_values = val.cast_simples();
+            sub_values.iter_mut().for_each(|(v, _)| {
+                // prepend value idx to the sub-struct
+                v.insert(0, idx);
+            });
+            simples.append(&mut sub_values);
+        }
+        simples
+    }
+}
+
+impl<F: FieldExt> From<LocalRef<F>> for Value<F> {
+    fn from(v: LocalRef<F>) -> Self {
+        Value::LocalRef(v)
+    }
+}
+impl<F: FieldExt> From<GlobalRef<F>> for Value<F> {
+    fn from(v: GlobalRef<F>) -> Self {
+        Value::GlobalRef(v)
+    }
+}
+impl<F: FieldExt> From<IndexedRef<F>> for Value<F> {
+    fn from(v: IndexedRef<F>) -> Self {
+        Value::IndexedRef(v)
+    }
+}
+/// ContainerRef contains reference location of the underlying container.
+/// It can also distinguish whether the container is local or global.
+#[derive(Clone, Debug)]
+pub enum ContainerRef<F: FieldExt> {
+    Global(GlobalLocation<F>, Container<F>),
+    Local(LocalLocation, Container<F>),
+}
+impl<F: FieldExt> ContainerRef<F> {
+    pub fn location(&self) -> ValueLocation<F> {
+        match self {
+            ContainerRef::Global(loc, _) => ValueLocation::Global(*loc),
+            ContainerRef::Local(loc, _) => ValueLocation::Local(*loc),
+        }
+    }
+    pub fn container(&self) -> Container<F> {
+        match self {
+            ContainerRef::Global(_, c) => c.clone(),
+            ContainerRef::Local(_, c) => c.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Reference<F: FieldExt> {
+    /// borrow global
+    GlobalRef(GlobalRef<F>),
+    /// borrow local
+    LocalRef(LocalRef<F>),
+    /// borrow field of a container
+    IndexedRef(IndexedRef<F>),
+}
+impl<F: FieldExt> From<Reference<F>> for Value<F> {
+    fn from(r: Reference<F>) -> Self {
+        match r {
+            Reference::GlobalRef(g) => Value::GlobalRef(g),
+            Reference::LocalRef(l) => Value::LocalRef(l),
+            Reference::IndexedRef(i) => Value::IndexedRef(i),
+        }
+    }
+}
+
+impl<F: FieldExt> Reference<F> {
+    /// return address_path of the value which is referenced by this ref
+    /// NOTICE: returned address_path is not filled up.
+    pub fn value_address_path(&self) -> AddressPath<F> {
+        match self {
+            Self::GlobalRef(g) => ValueLocation::Global(g.loc).to_address_path(),
+            Self::LocalRef(l) => ValueLocation::Local(l.loc).to_address_path(),
+            Self::IndexedRef(i) => IndexedLocation {
+                sub_indexes: i.sub_indexes.clone(),
+                value_loc: i.container_ref.location(),
+            }
+            .to_address_path(),
+        }
+    }
+    /// read_ref returns a deep_copyed value
+    pub fn read_ref(&self) -> VmResult<Value<F>> {
+        Ok(match self {
+            Reference::GlobalRef(g) => Value::Container(g.read_ref()?),
+            Reference::LocalRef(l) => l.read_ref()?,
+            Reference::IndexedRef(l) => l.read_ref()?,
+        })
+    }
+    /// write_ref write a value to the reference.
+    pub fn write_ref(&self, v: Value<F>) -> VmResult<()> {
+        match self {
+            Reference::GlobalRef(g) => g.write_ref(v),
+            Reference::LocalRef(l) => l.write_ref(v),
+            Reference::IndexedRef(l) => l.write_ref(v),
+        }
+    }
+    /// try_borrow_field will trait reference as a struct ref, and try to borrow it's field.
+    pub fn try_borrow_field(&self, element_idx: usize) -> VmResult<IndexedRef<F>> {
+        match self {
+            Reference::GlobalRef(g) => g.try_borrow_field(element_idx),
+            Reference::LocalRef(l) => l.try_borrow_field(element_idx),
+            Reference::IndexedRef(l) => l.try_borrow_field(element_idx),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GlobalRef<F: FieldExt> {
+    pub loc: GlobalLocation<F>,
+    pub refer: Container<F>,
+}
+
+impl<F: FieldExt> GlobalRef<F> {
+    fn read_ref(&self) -> VmResult<Container<F>> {
+        Ok(self.refer.copy_value())
+    }
+    fn write_ref(&self, v: Value<F>) -> VmResult<()> {
+        let c = match v {
+            Value::Container(c) => c,
+            _ => {
+                return Err(
+                    RuntimeError::new(StatusCode::UnknownInvariantViolationError)
+                        .with_message("failed to write_ref: container type mismatch".to_string()),
+                )
+            }
+        };
+        *self.refer.0.borrow_mut() = c.0.take();
+        Ok(())
+    }
+
+    fn try_borrow_field(&self, element_idx: usize) -> VmResult<IndexedRef<F>> {
+        let len = self.refer.0.borrow().len();
+        if element_idx >= len {
+            return Err(
+                RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+                    "index out of bounds when borrowing container element: index: {}, length: {}",
+                    element_idx, len
+                )),
+            );
+        }
+        Ok(IndexedRef {
+            sub_indexes: vec![element_idx],
+            container_ref: ContainerRef::Global(self.loc, self.refer.clone()),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalRef<F: FieldExt> {
+    pub loc: LocalLocation,
+    pub refer: Rc<RefCell<Value<F>>>,
+}
+
+impl<F: FieldExt> LocalRef<F> {
+    pub fn read_ref(&self) -> VmResult<Value<F>> {
+        Ok(self.refer.borrow().copy_value())
+    }
+    pub fn write_ref(&self, v: Value<F>) -> VmResult<()> {
+        let mut this_value = self.refer.borrow_mut();
+        match (this_value.deref_mut(), v) {
+            (Value::Bool(t), Value::Bool(v)) => {
+                *t = v;
+            }
+            (Value::U8(t), Value::U8(v)) => {
+                *t = v;
+            }
+            (Value::U64(t), Value::U64(v)) => {
+                *t = v;
+            }
+            (Value::U128(t), Value::U128(v)) => {
+                *t = v;
+            }
+            (Value::Address(t), Value::Address(v)) => {
+                *t = v;
+            }
+            (Value::Container(t), Value::Container(v)) => {
+                *t.0.borrow_mut() = v.0.take();
+            }
+            // TODO: support write a reference?
+            _ => return Err(RuntimeError::new(StatusCode::TypeMismatch)),
+        }
+        Ok(())
+    }
+
+    fn try_borrow_field(&self, element_idx: usize) -> VmResult<IndexedRef<F>> {
+        let v = self.refer.borrow();
+        match v.deref() {
+            Value::Container(c) => {
+                let len = c.0.borrow().len();
+                if element_idx >= len {
+                    return Err(
+                        RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+                            "index out of bounds when borrowing container element: index: {}, length: {}",
+                            element_idx, len
+                        )),
+                    );
+                }
+                Ok(IndexedRef {
+                    sub_indexes: vec![element_idx],
+                    container_ref: ContainerRef::Local(self.loc, c.clone()),
+                })
+            }
+            _ => Err(RuntimeError::new(StatusCode::TypeMismatch).with_message(
+                "cannot borrow field from a reference to non container value".to_string(),
+            )),
         }
     }
 }
 
 #[derive(Clone, Debug)]
-pub enum Value<F: FieldExt> {
-    Invalid,
-    U8(U8<F>),
-    U64(U64<F>),
-    U128(U128<F>),
-    Bool(Bool<F>),
-    Address(Address<F>),
-    Container(Container<F>),
-    ContainerRef(ContainerRef<F>),
-    IndexedRef(IndexedRef<F>),
+pub struct IndexedRef<F: FieldExt> {
+    pub sub_indexes: Vec<usize>,
+    pub container_ref: ContainerRef<F>,
 }
 
-impl<F: FieldExt> Value<F> {
-    pub fn new(value: F, ty: MoveValueType) -> VmResult<Self> {
-        match ty {
-            MoveValueType::U8 => Ok(Value::U8(U8(value))),
-            MoveValueType::U64 => Ok(Value::U64(U64(value))),
-            MoveValueType::U128 => Ok(Value::U128(U128(value))),
-            MoveValueType::Bool => Ok(Value::Bool(Bool(value))),
-            MoveValueType::Signer => Ok(Value::signer(AccountAddress::new(value))),
-            MoveValueType::Address => Ok(Value::address(AccountAddress::new(value))),
-            _ => unimplemented!(),
+impl<F: FieldExt> IndexedRef<F> {
+    fn try_borrow_field(&self, element_idx: usize) -> VmResult<IndexedRef<F>> {
+        let this_value = self.read_ref()?;
+
+        match this_value {
+            Value::Container(c) => {
+                let len = c.0.borrow().len();
+                if element_idx >= len {
+                    return Err(
+                        RuntimeError::new(StatusCode::OutOfBounds).with_message(format!(
+                            "index out of bounds when borrowing container element: index: {}, length: {}",
+                            element_idx, len
+                        )),
+                    );
+                }
+                Ok(IndexedRef {
+                    sub_indexes: {
+                        let mut idxes = self.sub_indexes.clone();
+                        idxes.push(element_idx);
+                        idxes
+                    },
+                    container_ref: self.container_ref.clone(),
+                })
+            }
+            _ => Err(RuntimeError::new(StatusCode::TypeMismatch).with_message(
+                "cannot borrow field from a reference to non container value".to_string(),
+            )),
         }
     }
+
+    /// read_ref return the value which is a deep copy
+    fn read_ref(&self) -> VmResult<Value<F>> {
+        let mut cur_value = self.container_ref.container();
+        debug_assert_ne!(self.sub_indexes.len(), 0);
+        let (last, prev) = self.sub_indexes.split_last().unwrap();
+        for idx in prev {
+            let field = cur_value.read_field(*idx)?;
+            match field {
+                Value::Container(c) => cur_value = c,
+                _ => return Err(RuntimeError::new(StatusCode::TypeMismatch)),
+            }
+        }
+        cur_value.read_field(*last)
+    }
+
+    fn write_ref(&self, v: Value<F>) -> VmResult<()> {
+        let mut cur_value = self.container_ref.container();
+        debug_assert_ne!(self.sub_indexes.len(), 0);
+        let (last, prev) = self.sub_indexes.split_last().unwrap();
+        for idx in prev {
+            cur_value = {
+                let v = cur_value.0.borrow();
+                let v = v
+                    .get(*idx)
+                    .ok_or_else(|| RuntimeError::new(StatusCode::OutOfBounds))?;
+
+                match v {
+                    Value::Container(c) => c.clone(),
+                    _ => return Err(RuntimeError::new(StatusCode::TypeMismatch)),
+                }
+            };
+        }
+        cur_value.write_field(*last, v)
+    }
+}
+
+impl<F: FieldExt> From<SimpleValue<F>> for Value<F> {
+    fn from(simple: SimpleValue<F>) -> Self {
+        match simple {
+            SimpleValue::U8(v) => Value::U8(v),
+            SimpleValue::U64(v) => Value::U64(v),
+            SimpleValue::U128(v) => Value::U128(v),
+            SimpleValue::Bool(v) => Value::Bool(v),
+            SimpleValue::Address(v) => Value::Address(v),
+        }
+    }
+}
+/// Location of global struct.
+#[derive(Clone, Copy, Debug)]
+pub struct GlobalLocation<F: FieldExt> {
+    pub address: AccountAddress<F>,
+    pub sd_index: StructDefinitionIndex,
+}
+
+/// Location of local values(simple values or containers)
+#[derive(Clone, Copy, Debug)]
+pub struct LocalLocation {
+    pub frame_index: FrameIndex,
+    pub index: u64,
+}
+
+/// Location of stack values (simple values or containers)
+#[derive(Clone, Copy, Debug)]
+pub struct StackLocation {
+    pub stack_index: usize,
+}
+
+/// Location of value stored in sub-fields of a container(in local or global, even in stack)
+/// IndexedValue doesn't actually fit in our value locations.
+/// we fake it as a location just to make value flatten easier.
+#[derive(Clone, Debug)]
+pub struct IndexedLocation<F: FieldExt> {
+    pub sub_indexes: Vec<usize>,
+    pub value_loc: ValueLocation<F>,
+}
+impl<F: FieldExt> IndexedLocation<F> {
+    pub fn new(root_location: ValueLocation<F>, sub_indexes: Vec<usize>) -> Self {
+        IndexedLocation {
+            sub_indexes,
+            value_loc: root_location,
+        }
+    }
+    pub(self) fn to_address_path(&self) -> AddressPath<F> {
+        self.value_loc
+            .to_address_path()
+            .with_subpath(self.sub_indexes.clone())
+    }
+}
+
+/// Location of value when it move/copy from one place to another place.
+#[derive(Clone, Debug)]
+pub enum ValueLocation<F: FieldExt> {
+    Stack(StackLocation),
+    Local(LocalLocation),
+    Global(GlobalLocation<F>),
+}
+impl<F: FieldExt> ValueLocation<F> {
+    pub(self) fn to_address_path(&self) -> AddressPath<F> {
+        let indexes = match self {
+            ValueLocation::Stack(loc) => vec![0, loc.stack_index],
+            ValueLocation::Local(loc) => vec![loc.frame_index.0, loc.index as usize],
+            ValueLocation::Global(loc) => vec![
+                // FIXME: change this once we determine what to use in witness(finite field or plain value ?).
+                loc.address.value().get_lower_128() as usize,
+                loc.sd_index.0 as usize,
+            ],
+        };
+        indexes.into()
+    }
+}
+
+impl<F: FieldExt> SimpleValue<F> {
     pub fn bool(x: bool) -> Self {
         let value = if x { F::one() } else { F::zero() };
         Self::Bool(Bool(value))
@@ -759,46 +1100,67 @@ impl<F: FieldExt> Value<F> {
         Self::U128(U128(value))
     }
     pub fn address(x: AccountAddress<F>) -> Self {
-        Self::Address(Address(x))
+        Self::Address(x)
+    }
+
+    pub fn value(&self) -> Option<F> {
+        match self {
+            Self::U8(v) => Some(v.0),
+            Self::U64(v) => Some(v.0),
+            Self::U128(v) => Some(v.0),
+            Self::Bool(v) => Some(v.0),
+            Self::Address(addr) => Some(addr.value()),
+        }
+    }
+
+    pub fn ty(&self) -> MoveValueType {
+        match self {
+            Self::U8(_) => MoveValueType::U8,
+            Self::U64(_) => MoveValueType::U64,
+            Self::U128(_) => MoveValueType::U128,
+            Self::Bool(_) => MoveValueType::Bool,
+            Self::Address(_) => MoveValueType::Address,
+        }
+    }
+}
+impl<F: FieldExt> Value<F> {
+    pub fn new(value: F, ty: MoveValueType) -> VmResult<Self> {
+        match ty {
+            MoveValueType::U8 => Ok(Self::U8(U8(value))),
+            MoveValueType::U64 => Ok(Self::U64(U64(value))),
+            MoveValueType::U128 => Ok(Self::U128(U128(value))),
+            MoveValueType::Bool => Ok(Self::Bool(Bool(value))),
+            MoveValueType::Signer => Ok(Self::signer(AccountAddress::new(value))),
+            MoveValueType::Address => Ok(Self::address(AccountAddress::new(value))),
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn bool(x: bool) -> Self {
+        let value = if x { F::one() } else { F::zero() };
+        Self::Bool(Bool(value))
+    }
+    pub fn u8(x: u8) -> Self {
+        let value = F::from_u128(x as u128);
+        Self::U8(U8(value))
+    }
+    pub fn u64(x: u64) -> Self {
+        let value = F::from_u128(x as u128);
+        Self::U64(U64(value))
+    }
+    pub fn u128(x: u128) -> Self {
+        let value = F::from_u128(x);
+        Self::U128(U128(value))
+    }
+    pub fn address(x: AccountAddress<F>) -> Self {
+        Self::Address(x)
     }
 
     pub fn signer(x: AccountAddress<F>) -> Self {
         Self::Container(Container::signer(x))
     }
-
-    pub fn struct_(values: Vec<Value<F>>, address: ValueAddress<F>) -> Self {
-        let mut new_values: Vec<Value<F>> = Vec::new();
-        for (i, value) in values.into_iter().enumerate() {
-            let val = value.update_address(ValueAddress::Member {
-                index: Index(i),
-                parent: Box::new(address.clone()),
-            });
-            new_values.push(val);
-        }
-
-        Self::Container(Container::Struct(
-            address,
-            Rc::new(RefCell::new(new_values)),
-        ))
-    }
-
-    pub fn update_address(self, address: ValueAddress<F>) -> Value<F> {
-        match self {
-            // only struct container need filling address
-            Value::Container(Container::Struct(_, struct_)) => {
-                let mut values = Vec::new();
-                // todo: is it safe? what if there is a reference to this struct?
-                for (i, val) in struct_.borrow().iter().map(|v| v.copy_value()).enumerate() {
-                    values.push(val.update_address(ValueAddress::Member {
-                        index: Index(i),
-                        parent: Box::new(address.clone()),
-                    }));
-                }
-
-                Value::Container(Container::Struct(address, Rc::new(RefCell::new(values))))
-            }
-            v => v,
-        }
+    pub fn struct_(values: Vec<Value<F>>) -> Self {
+        Self::Container(Container(Rc::new(RefCell::new(values))))
     }
 
     pub fn value(&self) -> Option<F> {
@@ -809,7 +1171,9 @@ impl<F: FieldExt> Value<F> {
             Self::U128(v) => Some(v.0),
             Self::Bool(v) => Some(v.0),
             Self::Address(addr) => Some(addr.value()),
-            Self::IndexedRef(_) | Self::ContainerRef(_) | Self::Container(_) => unreachable!(),
+            Self::GlobalRef(_) | Self::IndexedRef(_) | Self::LocalRef(_) | Self::Container(_) => {
+                unreachable!()
+            }
         }
     }
 
@@ -826,59 +1190,280 @@ impl<F: FieldExt> Value<F> {
         }
     }
 
-    pub fn flatten(&self, address: ValueAddress<F>) -> VmResult<Vec<(AddressPath<F>, Value<F>)>> {
+    /// a quick method for value::cast_simples().len()
+    pub fn word_element_count(&self) -> usize {
         match self {
             Self::U8(_)
             | Self::U64(_)
             | Self::U128(_)
             | Self::Bool(_)
             | Self::Address(_)
-            | Self::Invalid => match address {
-                ValueAddress::Stack(index) => Ok(vec![(
-                    AddressPath(vec![0, index.0, 0, 0], PhantomData),
-                    self.clone(),
-                )]),
-                ValueAddress::Locals(frame_index, index) => Ok(vec![(
-                    AddressPath(vec![frame_index.0, index.0, 0, 0], PhantomData),
-                    self.clone(),
-                )]),
-                ValueAddress::Member {
-                    index: _,
-                    parent: _,
-                } => {
-                    let base_path = address.address_path()?;
-                    Ok(vec![(base_path.fill_up(), self.clone())])
-                }
-                _ => unreachable!(),
-            },
-            Self::IndexedRef(r) => {
-                let address_path = r.value_address().address_path()?;
-                address_path.fill_up().flatten(address)
-            }
-            Self::ContainerRef(r) => {
-                let address_path = r.value_address().address_path()?;
-                address_path.fill_up().flatten(address)
-            }
-            Self::Container(c) => c.flatten(),
-        }
-    }
-
-    pub fn word_element_count(&self) -> VmResult<usize> {
-        match self {
-            Self::U8(_)
-            | Self::U64(_)
-            | Self::U128(_)
-            | Self::Bool(_)
-            | Self::Address(_)
-            | Self::Invalid => Ok(1),
-            Self::IndexedRef(_) | Self::ContainerRef(_) => Ok(DEPTH_OF_ADDRESS_PATH),
+            | Self::Invalid => 1,
+            Self::GlobalRef(_) | Self::IndexedRef(_) | Self::LocalRef(_) => DEPTH_OF_ADDRESS_PATH,
             Self::Container(c) => {
-                let word = c.flatten()?;
-                Ok(word.len())
+                let word = c.cast_simples();
+                word.len()
             }
         }
     }
 
+    /// Cast the value into simple value if it's simple
+    /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
+    pub(self) fn cast_simple(&self) -> Option<SimpleValue<F>> {
+        Some(match self {
+            Value::U8(v) => SimpleValue::U8(*v),
+            Value::U64(v) => SimpleValue::U64(*v),
+            Value::U128(v) => SimpleValue::U128(*v),
+            Value::Bool(v) => SimpleValue::Bool(*v),
+            Value::Address(v) => SimpleValue::Address(*v),
+            _ => return None,
+        })
+    }
+
+    /// Cast value into a sorted list of pair of (paths -> leaf value)
+    /// the list is sorted by it paths.
+    /// Such as: `[0] < [1,0] < [1,1,0] < [1,1,1] < [2]`
+    /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
+    pub(self) fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
+        if let Some(simple_value) = self.cast_simple() {
+            // simple value doesn't need subpaths.
+            return vec![(vec![], simple_value)];
+        }
+        match self {
+            Value::Container(container) => container.cast_simples(),
+            // treat reference as a container which contains location of ref-ed value.
+            Value::GlobalRef(GlobalRef { loc, .. }) => {
+                // NOTICE: here, we fillup address_path for reference, as reference needs fillup-ed values.
+                let ref_pathes = ValueLocation::Global(*loc)
+                    .to_address_path()
+                    .fill_up()
+                    .into_inner();
+                ref_pathes
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, v)| (vec![i], SimpleValue::U64(U64(F::from_u128(v as u128)))))
+                    .collect()
+            }
+            Value::LocalRef(LocalRef { loc, .. }) => {
+                // NOTICE: here, we fillup address_path for reference, as reference needs fillup-ed values.
+                let ref_pathes = ValueLocation::<F>::Local(*loc)
+                    .to_address_path()
+                    .fill_up()
+                    .into_inner();
+                ref_pathes
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, v)| (vec![i], SimpleValue::U64(U64(F::from_u128(v as u128)))))
+                    .collect()
+            }
+            Value::IndexedRef(IndexedRef {
+                sub_indexes,
+                container_ref,
+            }) => {
+                // NOTICE: here, we fillup address_path for reference, as reference needs fillup-ed values.
+                let ref_pathes = IndexedLocation {
+                    sub_indexes: sub_indexes.clone(),
+                    value_loc: container_ref.location(),
+                }
+                .to_address_path()
+                .fill_up()
+                .into_inner();
+                ref_pathes
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, v)| (vec![i], SimpleValue::U64(U64(F::from_u128(v as u128)))))
+                    .collect()
+            }
+            _ => unreachable!(),
+        }
+    }
+    pub fn flatten(&self, loc: ValueLocation<F>) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
+        let v_loc = loc.to_address_path().into_inner();
+        let mut values = self.cast_simples();
+        values.iter_mut().for_each(|(p, _)| {
+            let mut new_loc = v_loc.clone();
+            new_loc.append(p);
+            *p = new_loc;
+        });
+        // in flatten, returned address_path should be filled up.
+        values
+            .into_iter()
+            .map(|(p, v)| (AddressPath::from(p).fill_up(), v))
+            .collect()
+    }
+}
+
+// /// A located value
+// #[derive(Debug)]
+// pub struct LocatedValue<F: FieldExt, V>(ValueLocation<F>, V);
+//
+// impl<F: FieldExt> LocatedValue<F, Value<F>> {
+//     pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
+//         let v_loc = self.0.to_address_path().into_inner();
+//         let mut values = self.1.cast_simples();
+//         values.iter_mut().for_each(|(p, _)| {
+//             let mut new_loc = v_loc.clone();
+//             new_loc.append(p);
+//             *p = new_loc;
+//         });
+//         values.into_iter().map(|(p, v)| (p.into(), v)).collect()
+//     }
+// }
+
+/// A indexed value is an inner value node of some outer struct.
+/// TODO: should we merge IndexedLocation into ValueLocation and merge this into LocatedValue.
+/// I keep it seperated to make things clear.
+#[derive(Debug)]
+pub struct IndexedValue<F: FieldExt, V>(pub IndexedLocation<F>, pub V);
+
+impl<F: FieldExt> IndexedValue<F, Value<F>> {
+    pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
+        let v_loc = self.0.to_address_path().into_inner();
+        let mut values = self.1.cast_simples();
+        values.iter_mut().for_each(|(p, _)| {
+            let mut new_loc = v_loc.clone();
+            new_loc.append(p);
+            *p = new_loc;
+        });
+        values
+            .into_iter()
+            .map(|(p, v)| (AddressPath::from(p).fill_up(), v))
+            .collect()
+    }
+}
+
+impl<F: FieldExt> PartialEq for Value<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(other)
+    }
+}
+
+impl<F: FieldExt> Eq for Value<F> {}
+
+impl<F: FieldExt> Add for Value<F> {
+    type Output = VmResult<Self>;
+
+    fn add(self, b: Value<F>) -> Self::Output {
+        // implement add based on checked_add API to check arithmetic overflow
+        // let value = self.value().and_then(|a| b.value().map(|b| a + b));
+        let lhs = self.value().unwrap().get_lower_128();
+        let rhs = b.value().unwrap().get_lower_128();
+        let value = match (self.ty(), b.ty()) {
+            (MoveValueType::U8, MoveValueType::U8) => F::from_u128(
+                u8::checked_add(lhs as u8, rhs as u8).expect("arithmetic error found") as u128,
+            ),
+            (MoveValueType::U64, MoveValueType::U64) => F::from_u128(
+                u64::checked_add(lhs as u64, rhs as u64).expect("arithmetic error found") as u128,
+            ),
+            (MoveValueType::U128, MoveValueType::U128) => {
+                F::from_u128(u128::checked_add(lhs, rhs).expect("arithmetic error found"))
+            }
+            (_, _) => unimplemented!(),
+        };
+        let c = Value::new(value, self.ty())?;
+        Ok(c)
+    }
+}
+
+impl<F: FieldExt> Sub for Value<F> {
+    type Output = VmResult<Self>;
+
+    fn sub(self, b: Value<F>) -> Self::Output {
+        // implement sub based on checked_sub API to check arithmetic overflow
+        // let value = self.value().and_then(|a| b.value().map(|b| a - b));
+        let lhs = self.value().unwrap().get_lower_128();
+        let rhs = b.value().unwrap().get_lower_128();
+        let value = match (self.ty(), b.ty()) {
+            (MoveValueType::U8, MoveValueType::U8) => F::from_u128(
+                u8::checked_sub(lhs as u8, rhs as u8).expect("arithmetic error found") as u128,
+            ),
+            (MoveValueType::U64, MoveValueType::U64) => F::from_u128(
+                u64::checked_sub(lhs as u64, rhs as u64).expect("arithmetic error found") as u128,
+            ),
+            (MoveValueType::U128, MoveValueType::U128) => {
+                F::from_u128(u128::checked_sub(lhs, rhs).expect("arithmetic error found"))
+            }
+            (_, _) => unimplemented!(),
+        };
+        let c = Value::new(value, self.ty())?;
+        Ok(c)
+    }
+}
+
+impl<F: FieldExt> Mul for Value<F> {
+    type Output = VmResult<Self>;
+
+    fn mul(self, b: Value<F>) -> Self::Output {
+        // implement mul based on checked_mul API to check arithmetic overflow
+        // let value = self.value().and_then(|a| b.value().map(|b| a * b));
+        let lhs = self.value().unwrap().get_lower_128();
+        let rhs = b.value().unwrap().get_lower_128();
+        let value = match (self.ty(), b.ty()) {
+            (MoveValueType::U8, MoveValueType::U8) => F::from_u128(
+                u8::checked_mul(lhs as u8, rhs as u8).expect("arithmetic error found") as u128,
+            ),
+            (MoveValueType::U64, MoveValueType::U64) => F::from_u128(
+                u64::checked_mul(lhs as u64, rhs as u64).expect("arithmetic error found") as u128,
+            ),
+            (MoveValueType::U128, MoveValueType::U128) => {
+                F::from_u128(u128::checked_mul(lhs, rhs).expect("arithmetic error found"))
+            }
+            (_, _) => unimplemented!(),
+        };
+        let c = Value::new(value, self.ty())?;
+        Ok(c)
+    }
+}
+
+impl<F: FieldExt> Div for Value<F> {
+    type Output = VmResult<Self>;
+
+    fn div(self, b: Value<F>) -> Self::Output {
+        let l_move: Option<MoveValue> = self.cast_simple().map(Into::into);
+        let r_move: Option<MoveValue> = b.into();
+        match (l_move, r_move) {
+            (Some(l), Some(r)) => {
+                let quo = move_div(l, r)?;
+                let v = convert_to_field::<F>(quo);
+                let value = Value::new(v, self.ty())?;
+                Ok(value)
+            }
+            _ => Err(RuntimeError::new(StatusCode::ValueConversionError)
+                .with_message("Move value should not be None".to_string())),
+        }
+    }
+}
+
+impl<F: FieldExt> Rem for Value<F> {
+    type Output = VmResult<Self>;
+
+    fn rem(self, b: Value<F>) -> Self::Output {
+        let l_move: Option<MoveValue> = self.cast_simple().map(Into::into);
+        let r_move: Option<MoveValue> = b.into();
+        match (l_move, r_move) {
+            (Some(l), Some(r)) => {
+                let rem = move_rem(l, r)?;
+                let v = convert_to_field::<F>(rem);
+                let value = Value::new(v, self.ty())?;
+                Ok(value)
+            }
+            _ => Err(RuntimeError::new(StatusCode::ValueConversionError)
+                .with_message("Move value should not be None".to_string())),
+        }
+    }
+}
+
+impl<F: FieldExt> Not for Value<F> {
+    type Output = VmResult<Self>;
+
+    fn not(self) -> Self::Output {
+        let value = if self.is_zero() { F::one() } else { F::zero() };
+        let c = Value::new(value, MoveValueType::Bool)?;
+        Ok(c)
+    }
+}
+
+impl<F: FieldExt> Value<F> {
     pub fn equals(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Invalid, Self::Invalid) => true,
@@ -998,7 +1583,7 @@ impl<F: FieldExt> Value<F> {
     }
 
     pub fn div_rem(&self, other: Value<F>) -> VmResult<(Value<F>, Value<F>)> {
-        let l_move: Option<MoveValue> = self.clone().into();
+        let l_move: Option<MoveValue> = self.cast_simple().map(Into::into);
         let r_move: Option<MoveValue> = other.into();
         match (l_move, r_move) {
             (Some(l), Some(r)) => {
@@ -1014,140 +1599,7 @@ impl<F: FieldExt> Value<F> {
                 .with_message("Move value should not be None".to_string())),
         }
     }
-}
 
-impl<F: FieldExt> PartialEq for Value<F> {
-    fn eq(&self, other: &Self) -> bool {
-        self.equals(other)
-    }
-}
-
-impl<F: FieldExt> Eq for Value<F> {}
-
-impl<F: FieldExt> Add for Value<F> {
-    type Output = VmResult<Self>;
-
-    fn add(self, b: Value<F>) -> Self::Output {
-        // implement add based on checked_add API to check arithmetic overflow
-        // let value = self.value().and_then(|a| b.value().map(|b| a + b));
-        let lhs = self.value().unwrap().get_lower_128();
-        let rhs = b.value().unwrap().get_lower_128();
-        let value = match (self.ty(), b.ty()) {
-            (MoveValueType::U8, MoveValueType::U8) => F::from_u128(
-                u8::checked_add(lhs as u8, rhs as u8).expect("arithmetic error found") as u128,
-            ),
-            (MoveValueType::U64, MoveValueType::U64) => F::from_u128(
-                u64::checked_add(lhs as u64, rhs as u64).expect("arithmetic error found") as u128,
-            ),
-            (MoveValueType::U128, MoveValueType::U128) => {
-                F::from_u128(u128::checked_add(lhs, rhs).expect("arithmetic error found"))
-            }
-            (_, _) => unimplemented!(),
-        };
-        let c = Value::new(value, self.ty())?;
-        Ok(c)
-    }
-}
-
-impl<F: FieldExt> Sub for Value<F> {
-    type Output = VmResult<Self>;
-
-    fn sub(self, b: Value<F>) -> Self::Output {
-        // implement sub based on checked_sub API to check arithmetic overflow
-        // let value = self.value().and_then(|a| b.value().map(|b| a - b));
-        let lhs = self.value().unwrap().get_lower_128();
-        let rhs = b.value().unwrap().get_lower_128();
-        let value = match (self.ty(), b.ty()) {
-            (MoveValueType::U8, MoveValueType::U8) => F::from_u128(
-                u8::checked_sub(lhs as u8, rhs as u8).expect("arithmetic error found") as u128,
-            ),
-            (MoveValueType::U64, MoveValueType::U64) => F::from_u128(
-                u64::checked_sub(lhs as u64, rhs as u64).expect("arithmetic error found") as u128,
-            ),
-            (MoveValueType::U128, MoveValueType::U128) => {
-                F::from_u128(u128::checked_sub(lhs, rhs).expect("arithmetic error found"))
-            }
-            (_, _) => unimplemented!(),
-        };
-        let c = Value::new(value, self.ty())?;
-        Ok(c)
-    }
-}
-
-impl<F: FieldExt> Mul for Value<F> {
-    type Output = VmResult<Self>;
-
-    fn mul(self, b: Value<F>) -> Self::Output {
-        // implement mul based on checked_mul API to check arithmetic overflow
-        // let value = self.value().and_then(|a| b.value().map(|b| a * b));
-        let lhs = self.value().unwrap().get_lower_128();
-        let rhs = b.value().unwrap().get_lower_128();
-        let value = match (self.ty(), b.ty()) {
-            (MoveValueType::U8, MoveValueType::U8) => F::from_u128(
-                u8::checked_mul(lhs as u8, rhs as u8).expect("arithmetic error found") as u128,
-            ),
-            (MoveValueType::U64, MoveValueType::U64) => F::from_u128(
-                u64::checked_mul(lhs as u64, rhs as u64).expect("arithmetic error found") as u128,
-            ),
-            (MoveValueType::U128, MoveValueType::U128) => {
-                F::from_u128(u128::checked_mul(lhs, rhs).expect("arithmetic error found"))
-            }
-            (_, _) => unimplemented!(),
-        };
-        let c = Value::new(value, self.ty())?;
-        Ok(c)
-    }
-}
-
-impl<F: FieldExt> Div for Value<F> {
-    type Output = VmResult<Self>;
-
-    fn div(self, b: Value<F>) -> Self::Output {
-        let l_move: Option<MoveValue> = self.clone().into();
-        let r_move: Option<MoveValue> = b.into();
-        match (l_move, r_move) {
-            (Some(l), Some(r)) => {
-                let quo = move_div(l, r)?;
-                let v = convert_to_field::<F>(quo);
-                let value = Value::new(v, self.ty())?;
-                Ok(value)
-            }
-            _ => Err(RuntimeError::new(StatusCode::ValueConversionError)
-                .with_message("Move value should not be None".to_string())),
-        }
-    }
-}
-
-impl<F: FieldExt> Rem for Value<F> {
-    type Output = VmResult<Self>;
-
-    fn rem(self, b: Value<F>) -> Self::Output {
-        let l_move: Option<MoveValue> = self.clone().into();
-        let r_move: Option<MoveValue> = b.into();
-        match (l_move, r_move) {
-            (Some(l), Some(r)) => {
-                let rem = move_rem(l, r)?;
-                let v = convert_to_field::<F>(rem);
-                let value = Value::new(v, self.ty())?;
-                Ok(value)
-            }
-            _ => Err(RuntimeError::new(StatusCode::ValueConversionError)
-                .with_message("Move value should not be None".to_string())),
-        }
-    }
-}
-
-impl<F: FieldExt> Not for Value<F> {
-    type Output = VmResult<Self>;
-
-    fn not(self) -> Self::Output {
-        let value = if self.is_zero() { F::one() } else { F::zero() };
-        let c = Value::new(value, MoveValueType::Bool)?;
-        Ok(c)
-    }
-}
-
-impl<F: FieldExt> Value<F> {
     pub fn eq(a: Value<F>, b: Value<F>) -> VmResult<Value<F>> {
         let value = match (a.value(), b.value()) {
             (Some(a), Some(b)) => {
@@ -1320,19 +1772,7 @@ impl<F: FieldExt> Value<F> {
 
 impl<F: FieldExt> From<Value<F>> for Option<MoveValue> {
     fn from(value: Value<F>) -> Option<MoveValue> {
-        match value.value() {
-            Some(field) => {
-                let value = match value.ty() {
-                    MoveValueType::U8 => MoveValue::U8(field.get_lower_128() as u8),
-                    MoveValueType::U64 => MoveValue::U64(field.get_lower_128() as u64),
-                    MoveValueType::U128 => MoveValue::U128(field.get_lower_128()),
-                    MoveValueType::Bool => MoveValue::Bool(field == F::one()),
-                    _ => unimplemented!(),
-                };
-                Some(value)
-            }
-            None => None,
-        }
+        value.cast_simple().map(Into::into)
     }
 }
 
@@ -1346,12 +1786,10 @@ impl<F: FieldExt> From<Value<F>> for CircuitValue<F> {
 }
 
 impl<F: FieldExt> Value<F> {
-    /// We have two methods to "copy" a value - copy_value() and clone(). copy_value() is
-    /// a "shallow" copy, only the stack data is copied; clone() is a "deep" copy, not only
-    /// the stack data but also the referenced data in locals is copied.
-    ///
-    /// For example, copy_value() of ContainerRef returns a ref pointing to the original
-    /// container, but clone() of ContainerRef returns a ref pointing to a copied container.
+    /// A deep copy.
+    /// - For simple value, it copy the value.
+    /// - For reference, it copy the pointer, and ref the container.
+    /// - For container, it does a deep copy of all the underlying values.
     pub fn copy_value(&self) -> Self {
         match self {
             Self::Invalid => Self::Invalid,
@@ -1359,71 +1797,32 @@ impl<F: FieldExt> Value<F> {
             Self::U64(v) => Self::U64(*v),
             Self::U128(v) => Self::U128(*v),
             Self::Bool(v) => Self::Bool(*v),
+
+            Self::GlobalRef(r) => Self::GlobalRef(r.clone()),
+            Self::LocalRef(r) => Self::LocalRef(r.clone()),
+            Self::IndexedRef(r) => Self::IndexedRef(r.clone()),
+
             Self::Address(addr) => Self::Address(*addr),
             Self::Container(c) => Self::Container(c.copy_value()),
-            Self::ContainerRef(r) => Self::ContainerRef(r.copy_value()),
-            Self::IndexedRef(r) => Self::IndexedRef(r.copy_value()),
         }
     }
 }
+
 impl<F: FieldExt> Container<F> {
-    /// A "shallow" copy, only the stack data is copied.
+    /// A deep copy
     pub fn copy_value(&self) -> Self {
-        match self {
-            Self::Struct(address, r) => {
-                let struct_ = Rc::new(RefCell::new(
-                    r.borrow().iter().map(|v| v.copy_value()).collect(),
-                ));
-                Self::Struct(address.clone(), struct_)
-            }
-            // locals is copied by ref
-            Self::Locals(frame_index, l) => Self::Locals(frame_index.clone(), Rc::clone(l)),
-        }
-    }
-
-    pub fn copy_by_ref(&self) -> Self {
-        match self {
-            Self::Struct(address, r) => Self::Struct(address.clone(), Rc::clone(r)),
-            Self::Locals(frame_index, r) => Self::Locals(frame_index.clone(), Rc::clone(r)),
-        }
-    }
-}
-
-impl<F: FieldExt> Clone for Container<F> {
-    /// A "deep" copy, not only the stack data but also the referenced data in locals is copied.
-    fn clone(&self) -> Self {
-        match self {
-            Self::Struct(address, r) => {
-                let struct_ = Rc::new(RefCell::new(
-                    r.borrow().iter().map(|v| v.copy_value()).collect(),
-                ));
-                Self::Struct(address.clone(), struct_)
-            }
-            Self::Locals(frame_index, l) => {
-                let locals = Rc::new(RefCell::new(
-                    l.borrow().iter().map(|v| v.copy_value()).collect(),
-                ));
-                Self::Locals(frame_index.clone(), locals)
-            }
-        }
+        Self(Rc::new(RefCell::new(
+            self.0.borrow().iter().map(|v| v.copy_value()).collect(),
+        )))
     }
 }
 
 impl<F: FieldExt> Value<F> {
-    pub fn as_account_address(self) -> VmResult<AccountAddress<F>> {
+    pub fn into_account_address(self) -> VmResult<AccountAddress<F>> {
         match self {
-            Value::Address(address) => Ok(address.account_address()),
+            Value::Address(address) => Ok(address),
             _ => Err(RuntimeError::new(StatusCode::ValueConversionError)
                 .with_message("the value can not be cast as AccountAddress".to_string())),
-        }
-    }
-
-    pub fn as_reference(self) -> VmResult<Reference<F>> {
-        match self {
-            Value::ContainerRef(r) => Ok(Reference::ContainerRef(r)),
-            Value::IndexedRef(r) => Ok(Reference::IndexedRef(r)),
-            v => Err(RuntimeError::new(StatusCode::TypeMismatch)
-                .with_message(format!("cannot convert {:?} to reference", v))),
         }
     }
 }

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -81,7 +81,7 @@ impl<F: FieldExt> AddressPath<F> {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum SimpleValue<F: FieldExt> {
+pub enum PrimitiveValue<F: FieldExt> {
     U8(U8<F>),
     U64(U64<F>),
     U128(U128<F>),
@@ -89,14 +89,14 @@ pub enum SimpleValue<F: FieldExt> {
     Address(AccountAddress<F>),
 }
 
-impl<F: FieldExt> From<SimpleValue<F>> for MoveValue {
-    fn from(value: SimpleValue<F>) -> MoveValue {
+impl<F: FieldExt> From<PrimitiveValue<F>> for MoveValue {
+    fn from(value: PrimitiveValue<F>) -> MoveValue {
         match value {
-            SimpleValue::U8(field) => MoveValue::U8(field.0.get_lower_128() as u8),
-            SimpleValue::U64(field) => MoveValue::U64(field.0.get_lower_128() as u64),
-            SimpleValue::U128(field) => MoveValue::U128(field.0.get_lower_128()),
-            SimpleValue::Bool(field) => MoveValue::Bool(field.0 == F::one()),
-            SimpleValue::Address(field) => {
+            PrimitiveValue::U8(field) => MoveValue::U8(field.0.get_lower_128() as u8),
+            PrimitiveValue::U64(field) => MoveValue::U64(field.0.get_lower_128() as u64),
+            PrimitiveValue::U128(field) => MoveValue::U128(field.0.get_lower_128()),
+            PrimitiveValue::Bool(field) => MoveValue::Bool(field.0 == F::one()),
+            PrimitiveValue::Address(field) => {
                 // FIXME: f -> bytes for address
                 let mut bytes = 0u128.to_be_bytes().to_vec();
                 bytes.append(&mut field.value().get_lower_128().to_be_bytes().to_vec());
@@ -242,7 +242,7 @@ impl<F: FieldExt> Container<F> {
 
     /// cast_simples return a flattened vec contains all the simple values of the container
     /// keep it private so it cannot be abused
-    fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
+    fn cast_simples(&self) -> Vec<(Vec<usize>, PrimitiveValue<F>)> {
         let mut simples = Vec::new();
         for (idx, val) in self.0.borrow().iter().enumerate() {
             let mut sub_values = val.cast_simples();
@@ -526,19 +526,19 @@ impl<F: FieldExt> IndexedRef<F> {
     }
 }
 
-impl<F: FieldExt> From<SimpleValue<F>> for Value<F> {
-    fn from(simple: SimpleValue<F>) -> Self {
+impl<F: FieldExt> From<PrimitiveValue<F>> for Value<F> {
+    fn from(simple: PrimitiveValue<F>) -> Self {
         match simple {
-            SimpleValue::U8(v) => Value::U8(v),
-            SimpleValue::U64(v) => Value::U64(v),
-            SimpleValue::U128(v) => Value::U128(v),
-            SimpleValue::Bool(v) => Value::Bool(v),
-            SimpleValue::Address(v) => Value::Address(v),
+            PrimitiveValue::U8(v) => Value::U8(v),
+            PrimitiveValue::U64(v) => Value::U64(v),
+            PrimitiveValue::U128(v) => Value::U128(v),
+            PrimitiveValue::Bool(v) => Value::Bool(v),
+            PrimitiveValue::Address(v) => Value::Address(v),
         }
     }
 }
 
-impl<F: FieldExt> SimpleValue<F> {
+impl<F: FieldExt> PrimitiveValue<F> {
     pub fn bool(x: bool) -> Self {
         let value = if x { F::one() } else { F::zero() };
         Self::Bool(Bool(value))
@@ -665,13 +665,13 @@ impl<F: FieldExt> Value<F> {
 
     /// Cast the value into simple value if it's simple
     /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
-    fn cast_simple(&self) -> Option<SimpleValue<F>> {
+    fn cast_simple(&self) -> Option<PrimitiveValue<F>> {
         Some(match self {
-            Value::U8(v) => SimpleValue::U8(*v),
-            Value::U64(v) => SimpleValue::U64(*v),
-            Value::U128(v) => SimpleValue::U128(*v),
-            Value::Bool(v) => SimpleValue::Bool(*v),
-            Value::Address(v) => SimpleValue::Address(*v),
+            Value::U8(v) => PrimitiveValue::U8(*v),
+            Value::U64(v) => PrimitiveValue::U64(*v),
+            Value::U128(v) => PrimitiveValue::U128(*v),
+            Value::Bool(v) => PrimitiveValue::Bool(*v),
+            Value::Address(v) => PrimitiveValue::Address(*v),
             _ => return None,
         })
     }
@@ -680,7 +680,7 @@ impl<F: FieldExt> Value<F> {
     /// the list is sorted by it paths.
     /// Such as: `[0] < [1,0] < [1,1,0] < [1,1,1] < [2]`
     /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
-    fn cast_simples(&self) -> Vec<(Vec<usize>, SimpleValue<F>)> {
+    fn cast_simples(&self) -> Vec<(Vec<usize>, PrimitiveValue<F>)> {
         if let Some(simple_value) = self.cast_simple() {
             // simple value doesn't need subpaths.
             return vec![(vec![], simple_value)];
@@ -697,7 +697,7 @@ impl<F: FieldExt> Value<F> {
                 ref_pathes
                     .into_iter()
                     .enumerate()
-                    .map(|(i, v)| (vec![i], SimpleValue::U64(U64(F::from_u128(v as u128)))))
+                    .map(|(i, v)| (vec![i], PrimitiveValue::U64(U64(F::from_u128(v as u128)))))
                     .collect()
             }
             Value::LocalRef(LocalRef { loc, .. }) => {
@@ -709,7 +709,7 @@ impl<F: FieldExt> Value<F> {
                 ref_pathes
                     .into_iter()
                     .enumerate()
-                    .map(|(i, v)| (vec![i], SimpleValue::U64(U64(F::from_u128(v as u128)))))
+                    .map(|(i, v)| (vec![i], PrimitiveValue::U64(U64(F::from_u128(v as u128)))))
                     .collect()
             }
             Value::IndexedRef(IndexedRef {
@@ -727,7 +727,7 @@ impl<F: FieldExt> Value<F> {
                 ref_pathes
                     .into_iter()
                     .enumerate()
-                    .map(|(i, v)| (vec![i], SimpleValue::U64(U64(F::from_u128(v as u128)))))
+                    .map(|(i, v)| (vec![i], PrimitiveValue::U64(U64(F::from_u128(v as u128)))))
                     .collect()
             }
             _ => unreachable!(),
@@ -739,7 +739,7 @@ impl<F: FieldExt> Value<F> {
 pub struct LocatedValue<'v, L, V>(/* loc */ pub L, /* v */ pub &'v V);
 
 impl<'v, F: FieldExt> LocatedValue<'v, ValueLocation<F>, Value<F>> {
-    pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
+    pub fn flatten(&self) -> Vec<(AddressPath<F>, PrimitiveValue<F>)> {
         let v_loc = self.0.to_address_path().into_inner();
         let mut values = self.1.cast_simples();
         values.iter_mut().for_each(|(p, _)| {
@@ -756,7 +756,7 @@ impl<'v, F: FieldExt> LocatedValue<'v, ValueLocation<F>, Value<F>> {
 }
 
 impl<'v, F: FieldExt> LocatedValue<'v, IndexedLocation<F>, Value<F>> {
-    pub fn flatten(&self) -> Vec<(AddressPath<F>, SimpleValue<F>)> {
+    pub fn flatten(&self) -> Vec<(AddressPath<F>, PrimitiveValue<F>)> {
         let v_loc = self.0.to_address_path().into_inner();
         let mut values = self.1.cast_simples();
         values.iter_mut().for_each(|(p, _)| {
@@ -1225,7 +1225,7 @@ impl<F: FieldExt> From<Value<F>> for CircuitValue<F> {
 }
 
 impl<F: FieldExt> Value<F> {
-    /// A deep copy.
+    /// copy value
     /// - For simple value, it copy the value.
     /// - For reference, it copy the pointer, and ref the container.
     /// - For container, it does a deep copy of all the underlying values.
@@ -1248,7 +1248,6 @@ impl<F: FieldExt> Value<F> {
 }
 
 impl<F: FieldExt> Container<F> {
-    /// A deep copy
     pub fn copy_value(&self) -> Self {
         Self(Rc::new(RefCell::new(
             self.0.borrow().iter().map(|v| v.copy_value()).collect(),

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -12,7 +12,7 @@ use halo2_proofs::pasta::Fp;
 use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
-use movelang::value::Value;
+use movelang::value::{SimpleValue, Value};
 
 #[test]
 fn test_fake_rw_operation() -> VmResult<()> {
@@ -118,7 +118,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -126,7 +126,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -134,7 +134,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -142,7 +142,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -150,7 +150,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -158,7 +158,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: READ,
         gc: 5,
     });
@@ -167,7 +167,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         index: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: WRITE,
         gc: 6,
     });
@@ -302,7 +302,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: WRITE,
         gc: 0,
     };
@@ -310,7 +310,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: WRITE,
         gc: 1,
     };
@@ -318,7 +318,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: READ,
         gc: 2,
     };
@@ -326,7 +326,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: READ,
         gc: 3,
     };
@@ -334,7 +334,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: WRITE,
         gc: 4,
     };
@@ -342,7 +342,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: READ,
         gc: 5,
     };

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -12,7 +12,7 @@ use halo2_proofs::pasta::Fp;
 use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
-use movelang::value::{SimpleValue, Value};
+use movelang::value::{PrimitiveValue, Value};
 
 #[test]
 fn test_fake_rw_operation() -> VmResult<()> {
@@ -118,7 +118,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -126,7 +126,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -134,7 +134,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -142,7 +142,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -150,7 +150,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -158,7 +158,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: READ,
         gc: 5,
     });
@@ -167,7 +167,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         index: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: WRITE,
         gc: 6,
     });
@@ -302,7 +302,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: WRITE,
         gc: 0,
     };
@@ -310,7 +310,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: WRITE,
         gc: 1,
     };
@@ -318,7 +318,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: READ,
         gc: 2,
     };
@@ -326,7 +326,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: READ,
         gc: 3,
     };
@@ -334,7 +334,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: WRITE,
         gc: 4,
     };
@@ -342,7 +342,7 @@ fn test_rw_operation_with_wrong_gc() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: READ,
         gc: 5,
     };

--- a/vm-circuit/src/witness/rw_operations.rs
+++ b/vm-circuit/src/witness/rw_operations.rs
@@ -5,7 +5,7 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::AssignedCell;
 use movelang::account_address::AccountAddress;
-use movelang::value::Value;
+use movelang::value::{SimpleValue, Value};
 use std::cmp::Ordering;
 use std::convert::From;
 
@@ -111,7 +111,7 @@ pub struct LocalsOp<F: FieldExt> {
     pub address_ext_1: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Value<F>,
+    pub value: Option<SimpleValue<F>>,
 }
 
 impl<F: FieldExt> LocalsOp<F> {
@@ -123,7 +123,7 @@ impl<F: FieldExt> LocalsOp<F> {
             address_ext_1: 0,
             gc: 0,
             rw: RW::READ,
-            value: Value::u64(0),
+            value: Some(SimpleValue::u64(0)),
         }
     }
 }
@@ -157,8 +157,8 @@ impl<F: FieldExt> Ord for LocalsOp<F> {
 impl<F: FieldExt> From<&LocalsOp<F>> for ConvertedRWOperation<F> {
     fn from(rw_op: &LocalsOp<F>) -> ConvertedRWOperation<F> {
         let value = match rw_op.value {
-            Value::Invalid => Some(F::zero()), // todo: how to distinguish with Value::Constant(0)
-            _ => rw_op.value.value(),
+            None => Some(F::zero()), // todo: how to distinguish with Value::Constant(0)
+            Some(v) => v.value(),
         };
         ConvertedRWOperation {
             gc: (F::from_u128(rw_op.gc as u128), None),
@@ -181,7 +181,7 @@ pub struct StackOp<F: FieldExt> {
     pub address_ext_1: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Value<F>,
+    pub value: Option<SimpleValue<F>>,
 }
 
 impl<F: FieldExt> StackOp<F> {
@@ -190,7 +190,7 @@ impl<F: FieldExt> StackOp<F> {
             address: 0,
             address_ext_0: 0,
             address_ext_1: 0,
-            value: Value::u64(0),
+            value: Some(SimpleValue::u64(0)),
             rw: RW::READ,
             gc: 0,
         }
@@ -224,8 +224,8 @@ impl<F: FieldExt> Ord for StackOp<F> {
 impl<F: FieldExt> From<&StackOp<F>> for ConvertedRWOperation<F> {
     fn from(rw_op: &StackOp<F>) -> ConvertedRWOperation<F> {
         let value = match rw_op.value {
-            Value::Invalid => Some(F::zero()), // todo: how to distinguish with Value::Constant(0)
-            _ => rw_op.value.value(),
+            None => Some(F::zero()), // todo: how to distinguish with Value::Constant(0)
+            Some(v) => v.value(),
         };
         ConvertedRWOperation {
             gc: (F::from_u128(rw_op.gc as u128), None),
@@ -249,7 +249,7 @@ pub struct GlobalOp<F: FieldExt> {
     pub address_ext_1: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Value<F>,
+    pub value: Option<SimpleValue<F>>,
 }
 
 impl<F: FieldExt> GlobalOp<F> {
@@ -259,7 +259,7 @@ impl<F: FieldExt> GlobalOp<F> {
             sd_index: 0,
             address_ext_0: 0,
             address_ext_1: 0,
-            value: Value::u64(0),
+            value: Some(SimpleValue::u64(0)),
             rw: RW::READ,
             gc: 0,
         }
@@ -295,8 +295,8 @@ impl<F: FieldExt> Ord for GlobalOp<F> {
 impl<F: FieldExt> From<&GlobalOp<F>> for ConvertedRWOperation<F> {
     fn from(rw_op: &GlobalOp<F>) -> ConvertedRWOperation<F> {
         let value = match rw_op.value {
-            Value::Invalid => Some(F::zero()), // todo: how to distinguish with Value::Constant(0)
-            _ => rw_op.value.value(),
+            None => Some(F::zero()), // todo: how to distinguish with Value::Constant(0)
+            Some(v) => v.value(),
         };
         ConvertedRWOperation {
             gc: (F::from_u128(rw_op.gc as u128), None),
@@ -365,11 +365,12 @@ impl<F: FieldExt> RWOperation<F> {
     }
 
     pub fn value(&self) -> Value<F> {
-        match self {
-            Self::StackOp(op) => op.value.clone(),
-            Self::LocalsOp(op) => op.value.clone(),
-            Self::GlobalOp(op) => op.value.clone(),
-        }
+        let v = match self {
+            Self::StackOp(op) => op.value,
+            Self::LocalsOp(op) => op.value,
+            Self::GlobalOp(op) => op.value,
+        };
+        v.map(Into::into).unwrap_or_else(|| Value::Invalid)
     }
 
     pub fn sd_index(&self) -> usize {

--- a/vm-circuit/src/witness/rw_operations.rs
+++ b/vm-circuit/src/witness/rw_operations.rs
@@ -5,7 +5,7 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::AssignedCell;
 use movelang::account_address::AccountAddress;
-use movelang::value::{SimpleValue, Value};
+use movelang::value::{PrimitiveValue, Value};
 use std::cmp::Ordering;
 use std::convert::From;
 
@@ -111,7 +111,7 @@ pub struct LocalsOp<F: FieldExt> {
     pub address_ext_1: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Option<SimpleValue<F>>,
+    pub value: Option<PrimitiveValue<F>>,
 }
 
 impl<F: FieldExt> LocalsOp<F> {
@@ -123,7 +123,7 @@ impl<F: FieldExt> LocalsOp<F> {
             address_ext_1: 0,
             gc: 0,
             rw: RW::READ,
-            value: Some(SimpleValue::u64(0)),
+            value: Some(PrimitiveValue::u64(0)),
         }
     }
 }
@@ -181,7 +181,7 @@ pub struct StackOp<F: FieldExt> {
     pub address_ext_1: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Option<SimpleValue<F>>,
+    pub value: Option<PrimitiveValue<F>>,
 }
 
 impl<F: FieldExt> StackOp<F> {
@@ -190,7 +190,7 @@ impl<F: FieldExt> StackOp<F> {
             address: 0,
             address_ext_0: 0,
             address_ext_1: 0,
-            value: Some(SimpleValue::u64(0)),
+            value: Some(PrimitiveValue::u64(0)),
             rw: RW::READ,
             gc: 0,
         }
@@ -249,7 +249,7 @@ pub struct GlobalOp<F: FieldExt> {
     pub address_ext_1: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Option<SimpleValue<F>>,
+    pub value: Option<PrimitiveValue<F>>,
 }
 
 impl<F: FieldExt> GlobalOp<F> {
@@ -259,7 +259,7 @@ impl<F: FieldExt> GlobalOp<F> {
             sd_index: 0,
             address_ext_0: 0,
             address_ext_1: 0,
-            value: Some(SimpleValue::u64(0)),
+            value: Some(PrimitiveValue::u64(0)),
             rw: RW::READ,
             gc: 0,
         }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -12,7 +12,7 @@ use movelang::loader::MoveLoader;
 use movelang::state::StateStore;
 use movelang::utility::MoveValueType;
 use movelang::value::{
-    ContainerRef, GlobalRef, IndexedLocation, IndexedRef, IndexedValue, IntegerType, LocalRef,
+    ContainerRef, GlobalRef, IndexedLocation, IndexedRef, IntegerType, LocalRef, LocatedValue,
     Reference, Value, ValueLocation,
 };
 use std::convert::TryFrom;
@@ -214,7 +214,8 @@ impl<F: FieldExt> Frame<F> {
                         match reference {
                             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                                 let (account_addr, sd_index) = (loc.address, loc.sd_index);
-                                let word = value.flatten(ValueLocation::Global(loc));
+                                let word =
+                                    LocatedValue(ValueLocation::Global(loc), &value).flatten();
                                 let word_element_count = word.len();
                                 execution_step.auxiliary_1 = Some(Value::bool(true)); // global
                                 execution_step.auxiliary_2 = Some(Value::Address(account_addr));
@@ -232,7 +233,8 @@ impl<F: FieldExt> Frame<F> {
                             Reference::LocalRef(LocalRef { loc, .. }) => {
                                 let frame_index = loc.frame_index;
                                 let index = loc.index;
-                                let word = value.flatten(ValueLocation::Local(loc));
+                                let word =
+                                    LocatedValue(ValueLocation::Local(loc), &value).flatten();
                                 let word_element_count = word.len();
                                 execution_step.locals_index = index as usize;
                                 execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
@@ -249,12 +251,12 @@ impl<F: FieldExt> Frame<F> {
                                     ContainerRef::Global(vloc, _) => {
                                         let (account_addr, sd_index) =
                                             (vloc.address, vloc.sd_index);
-                                        let indexed_value = IndexedValue(
+                                        let indexed_value = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Global(vloc),
                                             },
-                                            value.clone(), // clone is ok, it's a one-time usage.
+                                            &value,
                                         );
                                         let word = indexed_value.flatten();
                                         let word_element_count = word.len();
@@ -276,12 +278,12 @@ impl<F: FieldExt> Frame<F> {
                                     ContainerRef::Local(vloc, _) => {
                                         let frame_index = vloc.frame_index;
                                         let index = vloc.index;
-                                        let indexed_value = IndexedValue(
+                                        let indexed_value = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Local(vloc),
                                             },
-                                            value.clone(), // clone is ok, it's a one-time usage.
+                                            &value,
                                         );
                                         let word = indexed_value.flatten();
                                         let word_element_count = word.len();
@@ -311,7 +313,8 @@ impl<F: FieldExt> Frame<F> {
 
                         match reference {
                             Reference::LocalRef(LocalRef { loc, .. }) => {
-                                let word = value.flatten(ValueLocation::Local(loc));
+                                let word =
+                                    LocatedValue(ValueLocation::Local(loc), &value).flatten();
                                 let word_element_count = value.word_element_count();
                                 execution_step.locals_index = loc.index as usize;
                                 execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
@@ -323,7 +326,8 @@ impl<F: FieldExt> Frame<F> {
                             }
                             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                                 let (account_addr, sd_idx) = (loc.address, loc.sd_index);
-                                let word = value.flatten(ValueLocation::Global(loc));
+                                let word =
+                                    LocatedValue(ValueLocation::Global(loc), &value).flatten();
 
                                 execution_step.auxiliary_1 = Some(Value::bool(true)); // is global
                                 execution_step.auxiliary_2 = Some(Value::address(account_addr));
@@ -343,12 +347,12 @@ impl<F: FieldExt> Frame<F> {
                             }) => {
                                 match container_ref {
                                     ContainerRef::Local(vloc, _) => {
-                                        let word = IndexedValue(
+                                        let word = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Local(vloc),
                                             },
-                                            value.clone(), // clone is ok, it's a one-time usage.
+                                            &value,
                                         )
                                         .flatten();
                                         let word_element_count = value.word_element_count();
@@ -366,12 +370,12 @@ impl<F: FieldExt> Frame<F> {
                                     }
                                     ContainerRef::Global(vloc, _) => {
                                         let (account_addr, sd_idx) = (vloc.address, vloc.sd_index);
-                                        let word = IndexedValue(
+                                        let word = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Global(vloc),
                                             },
-                                            value.clone(), // clone is ok, it's a one-time usage.
+                                            &value,
                                         )
                                         .flatten();
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -12,7 +12,8 @@ use movelang::loader::MoveLoader;
 use movelang::state::StateStore;
 use movelang::utility::MoveValueType;
 use movelang::value::{
-    ContainerRef, Index, IndexedRef, IntegerType, Reference, Value, ValueAddress,
+    ContainerRef, GlobalRef, IndexedLocation, IndexedRef, IndexedValue, IntegerType, LocalRef,
+    Reference, Value, ValueLocation,
 };
 use std::convert::TryFrom;
 use std::ops::{Add, Div, Mul, Not, Rem, Sub};
@@ -110,7 +111,7 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::Pop => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = value.word_element_count()?;
+                        let word_element_count = value.word_element_count();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         Ok(())
                     }
@@ -171,14 +172,14 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::CopyLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.copy(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = value.word_element_count()?;
+                        let word_element_count = value.word_element_count();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::StLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = value.word_element_count()?;
+                        let word_element_count = value.word_element_count();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         self.locals
                             .store(*v as usize, value, frame_index, rw_operations)
@@ -186,19 +187,20 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::MoveLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.move_(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = value.word_element_count()?;
+                        let word_element_count = value.word_element_count();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::ImmBorrowLoc(v) | Bytecode::MutBorrowLoc(v) => {
                         execution_step.locals_index = *v as usize;
-                        let value =
+                        let local_ref =
                             self.locals
                                 .borrow_locals(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = self.locals.word_element_count(*v as usize)?;
+                        let word_element_count = local_ref.refer.borrow().word_element_count();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
-                        interp.stack.push(value, rw_operations)
+                        interp.stack.push(local_ref.into(), rw_operations)
                     }
+
                     Bytecode::ReadRef => {
                         // | instr | u8/bool/address | container |
                         // | --- | --- | --- |
@@ -209,78 +211,187 @@ impl<F: FieldExt> Frame<F> {
 
                         let reference = interp.stack.pop_as_reference(rw_operations)?;
                         let value = reference.read_ref()?;
-                        let value_address = reference.value_address();
-                        match &reference {
-                            Reference::ContainerRef(ContainerRef::Local(container))
-                            | Reference::IndexedRef(IndexedRef {
-                                index: _,
-                                container_ref: ContainerRef::Local(container),
-                            }) => {
-                                let frame_index = container.frame_index();
-                                let index = value_address.address();
-                                execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
-                                execution_step.auxiliary_2 = Some(Value::u64(frame_index as u64));
-                                execution_step.locals_index = index;
-                                let word = value.flatten(value_address.clone())?;
-                                execution_step.auxiliary_3 = Some(Value::u64(word.len() as u64)); // word_elem_count
-                                Locals::emit_locals_ops_for_word(word, RW::READ, rw_operations);
-                            }
-                            Reference::ContainerRef(ContainerRef::Global(_))
-                            | Reference::IndexedRef(IndexedRef {
-                                index: _,
-                                container_ref: ContainerRef::Global(_),
-                            }) => {
-                                let (account_addr, sd_index) = reference.global_path();
+                        match reference {
+                            Reference::GlobalRef(GlobalRef { loc, .. }) => {
+                                let (account_addr, sd_index) = (loc.address, loc.sd_index);
+                                let word = value.flatten(ValueLocation::Global(loc));
+                                let word_element_count = word.len();
                                 execution_step.auxiliary_1 = Some(Value::bool(true)); // global
-                                execution_step.auxiliary_2 = Some(Value::address(account_addr));
+                                execution_step.auxiliary_2 = Some(Value::Address(account_addr));
+                                execution_step.auxiliary_3 =
+                                    Some(Value::u64(word_element_count as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_index.0 as u128));
-                                let word = value.flatten(value_address.clone())?;
-                                execution_step.auxiliary_3 = Some(Value::u64(word.len() as u64)); // word_elem_count
                                 globals::emit_global_ops_for_word(
-                                    word.clone(),
+                                    word,
                                     account_addr,
                                     sd_index,
                                     RW::READ,
                                     rw_operations,
                                 );
                             }
-                        };
-
+                            Reference::LocalRef(LocalRef { loc, .. }) => {
+                                let frame_index = loc.frame_index;
+                                let index = loc.index;
+                                let word = value.flatten(ValueLocation::Local(loc));
+                                let word_element_count = word.len();
+                                execution_step.locals_index = index as usize;
+                                execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
+                                execution_step.auxiliary_2 = Some(Value::u64(frame_index.0 as u64));
+                                execution_step.auxiliary_3 =
+                                    Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                Locals::emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                            }
+                            Reference::IndexedRef(IndexedRef {
+                                sub_indexes,
+                                container_ref,
+                            }) => {
+                                match container_ref {
+                                    ContainerRef::Global(vloc, _) => {
+                                        let (account_addr, sd_index) =
+                                            (vloc.address, vloc.sd_index);
+                                        let indexed_value = IndexedValue(
+                                            IndexedLocation {
+                                                sub_indexes,
+                                                value_loc: ValueLocation::Global(vloc),
+                                            },
+                                            value.clone(), // clone is ok, it's a one-time usage.
+                                        );
+                                        let word = indexed_value.flatten();
+                                        let word_element_count = word.len();
+                                        execution_step.auxiliary_1 = Some(Value::bool(true)); // global
+                                        execution_step.auxiliary_2 =
+                                            Some(Value::Address(account_addr));
+                                        execution_step.auxiliary_3 =
+                                            Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                        execution_step.auxiliary_4 =
+                                            Some(Value::u128(sd_index.0 as u128));
+                                        globals::emit_global_ops_for_word(
+                                            word,
+                                            account_addr,
+                                            sd_index,
+                                            RW::READ,
+                                            rw_operations,
+                                        );
+                                    }
+                                    ContainerRef::Local(vloc, _) => {
+                                        let frame_index = vloc.frame_index;
+                                        let index = vloc.index;
+                                        let indexed_value = IndexedValue(
+                                            IndexedLocation {
+                                                sub_indexes,
+                                                value_loc: ValueLocation::Local(vloc),
+                                            },
+                                            value.clone(), // clone is ok, it's a one-time usage.
+                                        );
+                                        let word = indexed_value.flatten();
+                                        let word_element_count = word.len();
+                                        execution_step.locals_index = index as usize;
+                                        execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
+                                        execution_step.auxiliary_2 =
+                                            Some(Value::u64(frame_index.0 as u64));
+                                        execution_step.auxiliary_3 =
+                                            Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                        Locals::emit_locals_ops_for_word(
+                                            word,
+                                            RW::READ,
+                                            rw_operations,
+                                        );
+                                    }
+                                }
+                            }
+                        }
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::WriteRef => {
-                        let mut reference = interp.stack.pop_as_reference(rw_operations)?;
+                        let reference = interp.stack.pop_as_reference(rw_operations)?;
                         let value = interp.stack.pop(rw_operations)?;
                         reference.write_ref(value)?; // must write ref first, then record local_op
-                        let value = reference.read_ref()?; // read back
-                        let value_address = reference.value_address();
+                        let value = reference.read_ref()?; // read back, it's a deep copy of origin value
+                                                           //let value_address = reference.value_address();
 
-                        if !reference.is_global() {
-                            let container_frame_index = value_address.frame_index();
-                            execution_step.locals_index = value_address.address();
-                            execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
-                            execution_step.auxiliary_2 =
-                                Some(Value::u64(container_frame_index as u64));
-                            let word_element_count = value.word_element_count()?;
-                            execution_step.auxiliary_3 =
-                                Some(Value::u64(word_element_count as u64));
-                            let word = value.flatten(value_address.clone())?;
-                            Locals::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
-                        } else {
-                            execution_step.auxiliary_1 = Some(Value::bool(true)); // is global
-                            let (account_addr, sd_idx) = reference.global_path();
-                            let _global_value = reference.copy_global_value()?;
-                            execution_step.auxiliary_2 = Some(Value::address(account_addr));
-                            let word = value.flatten(value_address.clone())?;
-                            execution_step.auxiliary_3 = Some(Value::u64(word.len() as u64)); // word_elem_count
-                            execution_step.auxiliary_4 = Some(Value::u128(sd_idx.0 as u128));
-                            globals::emit_global_ops_for_word(
-                                word.clone(),
-                                account_addr,
-                                sd_idx,
-                                RW::WRITE,
-                                rw_operations,
-                            );
+                        match reference {
+                            Reference::LocalRef(LocalRef { loc, .. }) => {
+                                let word = value.flatten(ValueLocation::Local(loc));
+                                let word_element_count = value.word_element_count();
+                                execution_step.locals_index = loc.index as usize;
+                                execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
+                                execution_step.auxiliary_2 =
+                                    Some(Value::u64(loc.frame_index.0 as u64));
+                                execution_step.auxiliary_3 =
+                                    Some(Value::u64(word_element_count as u64));
+                                Locals::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
+                            }
+                            Reference::GlobalRef(GlobalRef { loc, .. }) => {
+                                let (account_addr, sd_idx) = (loc.address, loc.sd_index);
+                                let word = value.flatten(ValueLocation::Global(loc));
+
+                                execution_step.auxiliary_1 = Some(Value::bool(true)); // is global
+                                execution_step.auxiliary_2 = Some(Value::address(account_addr));
+                                execution_step.auxiliary_3 = Some(Value::u64(word.len() as u64)); // word_elem_count
+                                execution_step.auxiliary_4 = Some(Value::u128(sd_idx.0 as u128));
+                                globals::emit_global_ops_for_word(
+                                    word.clone(),
+                                    account_addr,
+                                    sd_idx,
+                                    RW::WRITE,
+                                    rw_operations,
+                                );
+                            }
+                            Reference::IndexedRef(IndexedRef {
+                                sub_indexes,
+                                container_ref,
+                            }) => {
+                                match container_ref {
+                                    ContainerRef::Local(vloc, _) => {
+                                        let word = IndexedValue(
+                                            IndexedLocation {
+                                                sub_indexes,
+                                                value_loc: ValueLocation::Local(vloc),
+                                            },
+                                            value.clone(), // clone is ok, it's a one-time usage.
+                                        )
+                                        .flatten();
+                                        let word_element_count = value.word_element_count();
+                                        execution_step.locals_index = vloc.index as usize;
+                                        execution_step.auxiliary_1 = Some(Value::bool(false)); // is not global
+                                        execution_step.auxiliary_2 =
+                                            Some(Value::u64(vloc.frame_index.0 as u64));
+                                        execution_step.auxiliary_3 =
+                                            Some(Value::u64(word_element_count as u64));
+                                        Locals::emit_locals_ops_for_word(
+                                            word,
+                                            RW::WRITE,
+                                            rw_operations,
+                                        );
+                                    }
+                                    ContainerRef::Global(vloc, _) => {
+                                        let (account_addr, sd_idx) = (vloc.address, vloc.sd_index);
+                                        let word = IndexedValue(
+                                            IndexedLocation {
+                                                sub_indexes,
+                                                value_loc: ValueLocation::Global(vloc),
+                                            },
+                                            value.clone(), // clone is ok, it's a one-time usage.
+                                        )
+                                        .flatten();
+
+                                        execution_step.auxiliary_1 = Some(Value::bool(true)); // is global
+                                        execution_step.auxiliary_2 =
+                                            Some(Value::address(account_addr));
+                                        execution_step.auxiliary_3 =
+                                            Some(Value::u64(word.len() as u64)); // word_elem_count
+                                        execution_step.auxiliary_4 =
+                                            Some(Value::u128(sd_idx.0 as u128));
+                                        globals::emit_global_ops_for_word(
+                                            word.clone(),
+                                            account_addr,
+                                            sd_idx,
+                                            RW::WRITE,
+                                            rw_operations,
+                                        );
+                                    }
+                                }
+                            }
                         }
                         Ok(())
                     }
@@ -291,14 +402,14 @@ impl<F: FieldExt> Frame<F> {
                         Ok(())
                     }
                     Bytecode::ImmBorrowField(fh_idx) | Bytecode::MutBorrowField(fh_idx) => {
-                        execution_step.auxiliary_1 = Some(Value::u64(fh_idx.0 as u64));
-                        let reference = interp.stack.pop_as_struct_ref(rw_operations)?;
-                        let word_element_count = reference.value_address().address_path()?.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let reference = interp.stack.pop_as_reference(rw_operations)?;
+                        let word_element_count = reference.value_address_path().len();
                         let field_offset = resolver.field_offset(*fh_idx);
-                        let field_ref = reference.borrow_element(field_offset)?;
+                        let field_ref = reference.try_borrow_field(field_offset)?;
+                        execution_step.auxiliary_1 = Some(Value::u64(fh_idx.0 as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(field_offset as u64));
-                        interp.stack.push(field_ref, rw_operations)
+                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        interp.stack.push(field_ref.into(), rw_operations)
                     }
                     Bytecode::LdTrue => {
                         let constant = F::one();
@@ -439,9 +550,8 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_1 = Some(Value::u64(field_count as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
-                        let value =
-                            Value::struct_(args, ValueAddress::Stack(Index(interp.stack.size())));
-                        let word_element_count = value.word_element_count()?;
+                        let value = Value::struct_(args);
+                        let word_element_count = value.word_element_count();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -484,12 +594,13 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::MoveTo(sd_idx) => {
                         let resource = interp.stack.pop(rw_operations)?;
-                        let signer_reference = interp.stack.pop_as_struct_ref(rw_operations)?;
-                        let addr = signer_reference
-                            .borrow_element(0)?
-                            .as_reference()?
-                            .read_ref()?
-                            .as_account_address()
+                        let signer_reference = interp.stack.pop_as_reference(rw_operations)?;
+                        let addr_value =
+                            Reference::IndexedRef(signer_reference.try_borrow_field(0)?)
+                                .read_ref()?;
+
+                        let addr = addr_value
+                            .into_account_address()
                             .expect("address should not be None");
                         let word_elem_num = globals::emit_ops_for_global_value(
                             addr,
@@ -502,20 +613,19 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
 
                         let ty = resolver.get_struct_type(*sd_idx);
-                        let resource = resource.update_address(ValueAddress::Global(addr, *sd_idx));
                         interp.move_to(data_store, loader, addr, &ty, resource)
                     }
                     Bytecode::ImmBorrowGlobal(sd_idx) | Bytecode::MutBorrowGlobal(sd_idx) => {
                         let addr = interp.stack.pop_as_account_address(rw_operations)?;
                         let ty = resolver.get_struct_type(*sd_idx);
-                        let value = interp.borrow_global(data_store, loader, addr, &ty, *sd_idx)?;
-
-                        let global_value =
-                            value.copy_value().as_reference()?.copy_global_value()?;
+                        let global_ref = Reference::GlobalRef(
+                            interp.borrow_global(data_store, loader, addr, &ty, *sd_idx)?,
+                        );
+                        let global_value = global_ref.read_ref()?;
                         let word_elem_num = globals::emit_ops_for_global_value(
                             addr,
                             *sd_idx,
-                            global_value.clone(),
+                            global_value,
                             RW::READ,
                             false,
                             rw_operations,
@@ -523,7 +633,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_1 = Some(Value::u64(sd_idx.0 as u64));
                         execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
 
-                        interp.stack.push(value, rw_operations)
+                        interp.stack.push(global_ref.into(), rw_operations)
                     }
                     _ => unreachable!(),
                 }?;

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -2,11 +2,11 @@ use error::VmResult;
 use halo2_proofs::arithmetic::FieldExt;
 use move_binary_format::file_format::StructDefinitionIndex;
 use movelang::account_address::AccountAddress;
-use movelang::value::{AddressPath, Value, ValueAddress};
+use movelang::value::{AddressPath, GlobalLocation, SimpleValue, Value, ValueLocation};
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_ops_for_word<F: FieldExt>(
-    word: Vec<(AddressPath<F>, Value<F>)>,
+    word: Vec<(AddressPath<F>, SimpleValue<F>)>,
     addr: AccountAddress<F>,
     sd_index: StructDefinitionIndex,
     rw: RW,
@@ -24,7 +24,7 @@ pub fn emit_global_ops_for_word<F: FieldExt>(
                 .0
                 .get(3)
                 .expect("address_ext_1 should not be None"),
-            value: val,
+            value: Some(val),
             rw: rw.clone(),
             gc: rw_operations.len(),
         };
@@ -39,9 +39,11 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
     write_invalid: bool,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) -> VmResult<usize> {
-    let value_addr = ValueAddress::Global(addr, sd_index);
-    let addressed_value = resource_value.update_address(value_addr.clone());
-    let word = addressed_value.flatten(value_addr)?;
+    let value_addr = GlobalLocation {
+        address: addr,
+        sd_index,
+    };
+    let word = resource_value.flatten(ValueLocation::Global(value_addr));
     let word_len = word.len();
     for (address_path, val) in word.clone() {
         let op = GlobalOp {
@@ -55,7 +57,7 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
                 .0
                 .get(3)
                 .expect("address_ext_1 should not be None"),
-            value: val,
+            value: Some(val),
             rw: rw.clone(),
             gc: rw_operations.len(),
         };
@@ -75,7 +77,7 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
                     .0
                     .get(3)
                     .expect("address_ext_1 should not be None"),
-                value: Value::Invalid,
+                value: None,
                 rw: RW::WRITE,
                 gc: rw_operations.len(),
             };

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -3,12 +3,12 @@ use halo2_proofs::arithmetic::FieldExt;
 use move_binary_format::file_format::StructDefinitionIndex;
 use movelang::account_address::AccountAddress;
 use movelang::value::{
-    AddressPath, GlobalLocation, LocatedValue, SimpleValue, Value, ValueLocation,
+    AddressPath, GlobalLocation, LocatedValue, PrimitiveValue, Value, ValueLocation,
 };
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_ops_for_word<F: FieldExt>(
-    word: Vec<(AddressPath<F>, SimpleValue<F>)>,
+    word: Vec<(AddressPath<F>, PrimitiveValue<F>)>,
     addr: AccountAddress<F>,
     sd_index: StructDefinitionIndex,
     rw: RW,

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -2,7 +2,9 @@ use error::VmResult;
 use halo2_proofs::arithmetic::FieldExt;
 use move_binary_format::file_format::StructDefinitionIndex;
 use movelang::account_address::AccountAddress;
-use movelang::value::{AddressPath, GlobalLocation, SimpleValue, Value, ValueLocation};
+use movelang::value::{
+    AddressPath, GlobalLocation, LocatedValue, SimpleValue, Value, ValueLocation,
+};
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_ops_for_word<F: FieldExt>(
@@ -43,7 +45,7 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
         address: addr,
         sd_index,
     };
-    let word = resource_value.flatten(ValueLocation::Global(value_addr));
+    let word = LocatedValue(ValueLocation::Global(value_addr), &resource_value).flatten();
     let word_len = word.len();
     for (address_path, val) in word.clone() {
         let op = GlobalOp {

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -14,7 +14,7 @@ use movelang::argument::{argument_type, convert_from, ScriptArguments, Signer};
 use movelang::loader::MoveLoader;
 use movelang::state::StateStore;
 use movelang::utility::MoveValueType;
-use movelang::value::{GlobalValue, Value};
+use movelang::value::{GlobalRef, GlobalValue, Value};
 use std::sync::Arc;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::witness::arith_operations::ArithOperation;
@@ -334,7 +334,7 @@ impl<F: FieldExt> Interpreter<F> {
         addr: AccountAddress<F>,
         ty: &Type,
         sd_index: StructDefinitionIndex,
-    ) -> VmResult<Value<F>> {
+    ) -> VmResult<GlobalRef<F>> {
         Self::load_resource(data_store, loader, addr, ty)?.borrow_global(addr, sd_index)
     }
 }

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -3,7 +3,7 @@
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::value::{
-    AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, SimpleValue, Value,
+    AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, PrimitiveValue, Value,
     ValueLocation,
 };
 use std::ops::Deref;
@@ -24,7 +24,7 @@ impl<F: FieldExt> Locals<F> {
     }
 
     pub fn emit_locals_ops_for_word(
-        word: Vec<(AddressPath<F>, SimpleValue<F>)>,
+        word: Vec<(AddressPath<F>, PrimitiveValue<F>)>,
         rw: RW,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) {

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -3,21 +3,27 @@
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::value::{
-    AddressPath, Container, ContainerRef, FrameIndex, Index, IndexedRef, Value, ValueAddress,
+    AddressPath, FrameIndex, LocalLocation, LocalRef, SimpleValue, Value, ValueLocation,
 };
+use std::ops::Deref;
 use std::{cell::RefCell, rc::Rc};
 use vm_circuit::witness::rw_operations::{LocalsOp, RWOperation, RW};
 
 #[derive(Clone)]
-pub struct Locals<F: FieldExt>(Rc<RefCell<Vec<Value<F>>>>);
+pub struct Locals<F: FieldExt>(Vec<Rc<RefCell<Value<F>>>>);
 
 impl<F: FieldExt> Locals<F> {
     pub fn new(size: usize) -> Self {
-        Self(Rc::new(RefCell::new(vec![Value::Invalid; size])))
+        Self(
+            vec![Value::Invalid; size]
+                .into_iter()
+                .map(|v| Rc::new(RefCell::new(v)))
+                .collect(),
+        )
     }
 
     pub fn emit_locals_ops_for_word(
-        word: Vec<(AddressPath<F>, Value<F>)>,
+        word: Vec<(AddressPath<F>, SimpleValue<F>)>,
         rw: RW,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) {
@@ -36,7 +42,7 @@ impl<F: FieldExt> Locals<F> {
                     .0
                     .get(3)
                     .expect("address_ext_1 should not be None"),
-                value: val,
+                value: Some(val),
                 rw: rw.clone(),
                 gc: rw_operations.len(),
             };
@@ -49,14 +55,20 @@ impl<F: FieldExt> Locals<F> {
         frame_index: usize,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<Value<F>> {
-        let values = self.0.borrow();
-        match values.get(index) {
-            Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::CopyLocalError)),
+        match self.0.get(index) {
             Some(v) => {
-                let word =
-                    v.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
-                Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
-                Ok(v.copy_value())
+                if matches!(&*v.borrow(), Value::Invalid) {
+                    Err(RuntimeError::new(StatusCode::CopyLocalError))
+                } else {
+                    let copied_value = v.borrow().copy_value();
+                    let word = copied_value.flatten(ValueLocation::Local(LocalLocation {
+                        frame_index: FrameIndex(frame_index),
+                        index: index as u64,
+                    }));
+
+                    Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                    Ok(copied_value)
+                }
             }
             None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
         }
@@ -69,16 +81,9 @@ impl<F: FieldExt> Locals<F> {
         frame_index: usize,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<()> {
-        let value = Value::update_address(
-            value,
-            ValueAddress::Locals(FrameIndex(frame_index), Index(index)),
-        );
-        let word = value.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
-
-        let mut values = self.0.borrow_mut();
-        match values.get_mut(index) {
+        match self.0.get(index) {
             Some(v) => {
-                if let Value::Container(c) = v {
+                if let Value::Container(c) = &*v.borrow() {
                     if c.rc_count() > 1 {
                         return Err(
                             RuntimeError::new(StatusCode::UnknownInvariantViolationError)
@@ -88,10 +93,12 @@ impl<F: FieldExt> Locals<F> {
                         );
                     }
                 }
-
+                let word = value.flatten(ValueLocation::Local(LocalLocation {
+                    frame_index: FrameIndex(frame_index),
+                    index: index as u64,
+                }));
                 Self::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
-
-                values[index] = value;
+                *v.borrow_mut() = value;
                 Ok(())
             }
             None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
@@ -104,17 +111,20 @@ impl<F: FieldExt> Locals<F> {
         frame_index: usize,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<Value<F>> {
-        let value_copy = self.0.borrow().get(index).cloned().unwrap();
-        let mut values = self.0.borrow_mut();
-        match values.get_mut(index) {
-            Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::MoveLocalError)),
-            Some(v) => {
-                let word = value_copy
-                    .flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
+        let value_cell = self
+            .0
+            .get(index)
+            .ok_or_else(|| RuntimeError::new(StatusCode::OutOfBounds))?;
+        let old_value = value_cell.replace(Value::Invalid); // Invalidate Local
+        match old_value {
+            Value::Invalid => Err(RuntimeError::new(StatusCode::MoveLocalError)),
+            v => {
+                let word = v.flatten(ValueLocation::Local(LocalLocation {
+                    frame_index: FrameIndex(frame_index),
+                    index: index as u64,
+                }));
                 // LocalsOP Read
                 Self::emit_locals_ops_for_word(word.clone(), RW::READ, rw_operations);
-                // Invalid value
-                let ret = std::mem::replace(v, Value::Invalid);
                 // LocalsOP Write
                 for (address_path, _) in word {
                     let locals_op_2 = LocalsOp {
@@ -131,16 +141,15 @@ impl<F: FieldExt> Locals<F> {
                             .0
                             .get(3)
                             .expect("address_ext_1 should not be None"),
-                        value: Value::Invalid,
+                        value: None,
                         rw: RW::WRITE,
                         gc: rw_operations.len(),
                     };
                     rw_operations.push(RWOperation::LocalsOp(locals_op_2));
                 }
 
-                Ok(ret)
+                Ok(v)
             }
-            None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
         }
     }
 
@@ -149,36 +158,33 @@ impl<F: FieldExt> Locals<F> {
         index: usize,
         frame_index: usize,
         rw_operations: &mut Vec<RWOperation<F>>,
-    ) -> VmResult<Value<F>> {
-        let values = self.0.borrow();
-        match values.get(index) {
-            Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::MutBorrowLocalError)),
-            Some(v) => match v {
-                Value::U8(_)
-                | Value::U64(_)
-                | Value::U128(_)
-                | Value::Bool(_)
-                | Value::Address(_) => {
-                    let word =
-                        v.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
-                    Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
-                    Ok(Value::IndexedRef(IndexedRef {
-                        index,
-                        container_ref: ContainerRef::Local(Container::Locals(
-                            FrameIndex(frame_index),
-                            Rc::clone(&self.0),
-                        )),
-                    }))
-                }
-                Value::Container(c) => {
-                    let word =
-                        v.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
-                    Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
-                    Ok(Value::ContainerRef(ContainerRef::Local(c.copy_by_ref())))
-                }
-                _ => unimplemented!(),
-            },
-            None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
+    ) -> VmResult<LocalRef<F>> {
+        let value_cell = self
+            .0
+            .get(index)
+            .ok_or_else(|| RuntimeError::new(StatusCode::OutOfBounds))?;
+        let value_ref = value_cell.borrow();
+        let v = value_ref.deref();
+        match v {
+            Value::Invalid => Err(RuntimeError::new(StatusCode::MutBorrowLocalError)),
+            Value::U8(_)
+            | Value::U64(_)
+            | Value::U128(_)
+            | Value::Bool(_)
+            | Value::Address(_)
+            | Value::Container(_) => {
+                let loc = LocalLocation {
+                    frame_index: FrameIndex(frame_index),
+                    index: index as u64,
+                };
+                let word = v.flatten(ValueLocation::Local(loc));
+                Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                Ok(LocalRef {
+                    loc,
+                    refer: value_cell.clone(),
+                })
+            }
+            _ => unimplemented!(),
         }
     }
 
@@ -188,55 +194,51 @@ impl<F: FieldExt> Locals<F> {
         frame_index: usize,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<Value<F>> {
-        let values = self.0.borrow();
-        match values.get(index) {
-            Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
-            Some(v) => {
-                let word =
-                    v.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
+        let value_cell = self
+            .0
+            .get(index)
+            .ok_or_else(|| RuntimeError::new(StatusCode::OutOfBounds))?;
+        let loc = LocalLocation {
+            frame_index: FrameIndex(frame_index),
+            index: index as u64,
+        };
+        match &*value_cell.borrow() {
+            Value::Invalid => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
+            v => {
+                let word = v.flatten(ValueLocation::Local(loc));
                 Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
-                Ok(v.clone())
+                Ok(v.copy_value())
             }
-            None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
         }
     }
 
-    pub fn write_ref(
-        &self,
-        index: usize,
-        value: Value<F>,
-        frame_index: usize,
-        rw_operations: &mut Vec<RWOperation<F>>,
-    ) -> VmResult<()> {
-        let word = value.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
-        let mut values = self.0.borrow_mut();
-        match values.get_mut(index) {
-            Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
-            Some(_v) => {
-                Self::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
-                values[index] = value;
-                Ok(())
-            }
-            None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
-        }
-    }
-
-    pub fn word_element_count(&self, index: usize) -> VmResult<usize> {
-        let values = self.0.borrow();
-        match values.get(index) {
-            Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
-            Some(v) => v.word_element_count(),
-            None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
-        }
-    }
+    // pub fn write_ref(
+    //     &self,
+    //     index: usize,
+    //     value: Value<F>,
+    //     frame_index: usize,
+    //     rw_operations: &mut Vec<RWOperation<F>>,
+    // ) -> VmResult<()> {
+    //     let word = value.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
+    //     let mut values = self.0.borrow_mut();
+    //     match values.get_mut(index) {
+    //         Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
+    //         Some(_v) => {
+    //             Self::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
+    //             values[index] = value;
+    //             Ok(())
+    //         }
+    //         None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
+    //     }
+    // }
 }
 
 impl<F: FieldExt> Locals<F> {
     pub fn len(&self) -> usize {
-        self.0.borrow().len()
+        self.0.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.borrow().is_empty()
+        self.0.is_empty()
     }
 }

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -224,26 +224,6 @@ impl<F: FieldExt> Locals<F> {
             }
         }
     }
-
-    // pub fn write_ref(
-    //     &self,
-    //     index: usize,
-    //     value: Value<F>,
-    //     frame_index: usize,
-    //     rw_operations: &mut Vec<RWOperation<F>>,
-    // ) -> VmResult<()> {
-    //     let word = value.flatten(ValueAddress::Locals(FrameIndex(frame_index), Index(index)))?;
-    //     let mut values = self.0.borrow_mut();
-    //     match values.get_mut(index) {
-    //         Some(Value::Invalid) => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
-    //         Some(_v) => {
-    //             Self::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
-    //             values[index] = value;
-    //             Ok(())
-    //         }
-    //         None => Err(RuntimeError::new(StatusCode::OutOfBounds)),
-    //     }
-    // }
 }
 
 impl<F: FieldExt> Locals<F> {

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -3,7 +3,8 @@
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::value::{
-    AddressPath, FrameIndex, LocalLocation, LocalRef, SimpleValue, Value, ValueLocation,
+    AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, SimpleValue, Value,
+    ValueLocation,
 };
 use std::ops::Deref;
 use std::{cell::RefCell, rc::Rc};
@@ -61,10 +62,14 @@ impl<F: FieldExt> Locals<F> {
                     Err(RuntimeError::new(StatusCode::CopyLocalError))
                 } else {
                     let copied_value = v.borrow().copy_value();
-                    let word = copied_value.flatten(ValueLocation::Local(LocalLocation {
-                        frame_index: FrameIndex(frame_index),
-                        index: index as u64,
-                    }));
+                    let word = LocatedValue(
+                        ValueLocation::Local(LocalLocation {
+                            frame_index: FrameIndex(frame_index),
+                            index: index as u64,
+                        }),
+                        &copied_value,
+                    )
+                    .flatten();
 
                     Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
                     Ok(copied_value)
@@ -93,10 +98,14 @@ impl<F: FieldExt> Locals<F> {
                         );
                     }
                 }
-                let word = value.flatten(ValueLocation::Local(LocalLocation {
-                    frame_index: FrameIndex(frame_index),
-                    index: index as u64,
-                }));
+                let word = LocatedValue(
+                    ValueLocation::Local(LocalLocation {
+                        frame_index: FrameIndex(frame_index),
+                        index: index as u64,
+                    }),
+                    &value,
+                )
+                .flatten();
                 Self::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
                 *v.borrow_mut() = value;
                 Ok(())
@@ -119,10 +128,14 @@ impl<F: FieldExt> Locals<F> {
         match old_value {
             Value::Invalid => Err(RuntimeError::new(StatusCode::MoveLocalError)),
             v => {
-                let word = v.flatten(ValueLocation::Local(LocalLocation {
-                    frame_index: FrameIndex(frame_index),
-                    index: index as u64,
-                }));
+                let word = LocatedValue(
+                    ValueLocation::Local(LocalLocation {
+                        frame_index: FrameIndex(frame_index),
+                        index: index as u64,
+                    }),
+                    &v,
+                )
+                .flatten();
                 // LocalsOP Read
                 Self::emit_locals_ops_for_word(word.clone(), RW::READ, rw_operations);
                 // LocalsOP Write
@@ -177,7 +190,7 @@ impl<F: FieldExt> Locals<F> {
                     frame_index: FrameIndex(frame_index),
                     index: index as u64,
                 };
-                let word = v.flatten(ValueLocation::Local(loc));
+                let word = LocatedValue(ValueLocation::Local(loc), v).flatten();
                 Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
                 Ok(LocalRef {
                     loc,
@@ -205,7 +218,7 @@ impl<F: FieldExt> Locals<F> {
         match &*value_cell.borrow() {
             Value::Invalid => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
             v => {
-                let word = v.flatten(ValueLocation::Local(loc));
+                let word = LocatedValue(ValueLocation::Local(loc), v).flatten();
                 Self::emit_locals_ops_for_word(word, RW::READ, rw_operations);
                 Ok(v.copy_value())
             }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -5,7 +5,7 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::account_address::AccountAddress;
 use movelang::value::{
-    AddressPath, Container, Index, Reference, Struct, StructRef, Value, ValueAddress,
+    AddressPath, Container, Reference, SimpleValue, StackLocation, Struct, Value, ValueLocation,
 };
 use std::rc::Rc;
 use vm_circuit::witness::rw_operations::{RWOperation, StackOp, RW};
@@ -21,7 +21,7 @@ impl<F: FieldExt> EvalStack<F> {
     }
 
     pub fn emit_stack_ops_for_word(
-        word: Vec<(AddressPath<F>, Value<F>)>,
+        word: Vec<(AddressPath<F>, SimpleValue<F>)>,
         rw: RW,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) {
@@ -36,7 +36,7 @@ impl<F: FieldExt> EvalStack<F> {
                     .0
                     .get(3)
                     .expect("address_ext_1 should not be None"),
-                value: val,
+                value: Some(val),
                 rw: rw.clone(),
                 gc: rw_operations.len(),
             };
@@ -50,9 +50,9 @@ impl<F: FieldExt> EvalStack<F> {
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<()> {
         if self.0.len() < EVAL_STACK_SIZE {
-            // Container in locals need to update address before bing pushed to stack
-            let value = Value::update_address(value, ValueAddress::Stack(Index(self.0.len())));
-            let word = value.flatten(ValueAddress::Stack(Index(self.0.len())))?;
+            let word = value.flatten(ValueLocation::Stack(StackLocation {
+                stack_index: self.0.len(),
+            }));
             Self::emit_stack_ops_for_word(word, RW::WRITE, rw_operations);
 
             self.0.push(value);
@@ -67,8 +67,9 @@ impl<F: FieldExt> EvalStack<F> {
             Err(RuntimeError::new(StatusCode::StackUnderflow))
         } else {
             let value = self.0.pop().unwrap();
-
-            let word = value.flatten(ValueAddress::Stack(Index(self.0.len())))?;
+            let word = value.flatten(ValueLocation::Stack(StackLocation {
+                stack_index: self.0.len(),
+            }));
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             Ok(value)
@@ -88,7 +89,9 @@ impl<F: FieldExt> EvalStack<F> {
         let values = self.0.split_off(remaining_stack_size);
 
         for (i, value) in values.iter().enumerate() {
-            let word = value.flatten(ValueAddress::Stack(Index(remaining_stack_size + i)))?;
+            let word = value.flatten(ValueLocation::Stack(StackLocation {
+                stack_index: (remaining_stack_size + i),
+            }));
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
         }
 
@@ -104,13 +107,15 @@ impl<F: FieldExt> EvalStack<F> {
             Err(RuntimeError::new(StatusCode::StackUnderflow))
         } else {
             let value = self.0.pop().unwrap();
-
-            let word = value.flatten(ValueAddress::Stack(Index(self.0.len())))?;
+            let loc = StackLocation {
+                stack_index: self.0.len(),
+            };
+            let word = value.flatten(ValueLocation::Stack(loc));
             let word_element_count = word.len();
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             match value {
-                Value::Container(Container::Struct(_, struct_)) => {
+                Value::Container(Container(struct_)) => {
                     debug_assert_eq!(Rc::strong_count(&struct_), 1);
                     let fields = match Rc::try_unwrap(struct_) {
                         Ok(cell) => Ok(cell.into_inner()),
@@ -136,11 +141,14 @@ impl<F: FieldExt> EvalStack<F> {
         } else {
             let value = self.0.pop().unwrap();
 
-            let word = value.flatten(ValueAddress::Stack(Index(self.0.len())))?;
+            let word = value.flatten(ValueLocation::Stack(StackLocation {
+                stack_index: self.0.len(),
+            }));
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             match value {
-                Value::ContainerRef(r) => Ok(Reference::ContainerRef(r)),
+                Value::GlobalRef(r) => Ok(Reference::GlobalRef(r)),
+                Value::LocalRef(r) => Ok(Reference::LocalRef(r)),
                 Value::IndexedRef(r) => Ok(Reference::IndexedRef(r)),
                 v => Err(RuntimeError::new(StatusCode::TypeMismatch)
                     .with_message(format!("cannot pop {:?} as reference", v))),
@@ -148,25 +156,27 @@ impl<F: FieldExt> EvalStack<F> {
         }
     }
 
-    pub fn pop_as_struct_ref(
-        &mut self,
-        rw_operations: &mut Vec<RWOperation<F>>,
-    ) -> VmResult<StructRef<F>> {
-        if self.0.is_empty() {
-            Err(RuntimeError::new(StatusCode::StackUnderflow))
-        } else {
-            let value = self.0.pop().unwrap();
-
-            let word = value.flatten(ValueAddress::Stack(Index(self.0.len())))?;
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
-
-            match value {
-                Value::ContainerRef(r) => Ok(StructRef(r)),
-                v => Err(RuntimeError::new(StatusCode::TypeMismatch)
-                    .with_message(format!("cannot pop {:?} as struct_ref", v))),
-            }
-        }
-    }
+    // pub fn pop_as_struct_ref(
+    //     &mut self,
+    //     rw_operations: &mut Vec<RWOperation<F>>,
+    // ) -> VmResult<StructRef<F>> {
+    //     if self.0.is_empty() {
+    //         Err(RuntimeError::new(StatusCode::StackUnderflow))
+    //     } else {
+    //         let value = self.0.pop().unwrap();
+    //
+    //         let word = value.flatten(ValueLocation::Stack(StackLocation {
+    //             stack_index: self.0.len() as u64,
+    //         }));
+    //         Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+    //
+    //         match value {
+    //             Value::ContainerRef(r) => Ok(StructRef(r)),
+    //             v => Err(RuntimeError::new(StatusCode::TypeMismatch)
+    //                 .with_message(format!("cannot pop {:?} as struct_ref", v))),
+    //         }
+    //     }
+    // }
 
     pub fn pop_as_account_address(
         &mut self,
@@ -176,12 +186,14 @@ impl<F: FieldExt> EvalStack<F> {
             Err(RuntimeError::new(StatusCode::StackUnderflow))
         } else {
             let value = self.0.pop().unwrap();
-
-            let word = value.flatten(ValueAddress::Stack(Index(self.0.len())))?;
+            let v_loc = StackLocation {
+                stack_index: self.0.len(),
+            };
+            let word = value.flatten(ValueLocation::Stack(v_loc));
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             match value {
-                Value::Address(addr) => Ok(addr.account_address()),
+                Value::Address(addr) => Ok(addr),
                 v => Err(RuntimeError::new(StatusCode::TypeMismatch)
                     .with_message(format!("cannot pop {:?} as account address", v))),
             }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -5,7 +5,7 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::account_address::AccountAddress;
 use movelang::value::{
-    AddressPath, Container, LocatedValue, Reference, SimpleValue, StackLocation, Struct, Value,
+    AddressPath, Container, LocatedValue, PrimitiveValue, Reference, StackLocation, Struct, Value,
     ValueLocation,
 };
 use std::rc::Rc;
@@ -22,7 +22,7 @@ impl<F: FieldExt> EvalStack<F> {
     }
 
     pub fn emit_stack_ops_for_word(
-        word: Vec<(AddressPath<F>, SimpleValue<F>)>,
+        word: Vec<(AddressPath<F>, PrimitiveValue<F>)>,
         rw: RW,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -5,7 +5,8 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::account_address::AccountAddress;
 use movelang::value::{
-    AddressPath, Container, Reference, SimpleValue, StackLocation, Struct, Value, ValueLocation,
+    AddressPath, Container, LocatedValue, Reference, SimpleValue, StackLocation, Struct, Value,
+    ValueLocation,
 };
 use std::rc::Rc;
 use vm_circuit::witness::rw_operations::{RWOperation, StackOp, RW};
@@ -50,9 +51,13 @@ impl<F: FieldExt> EvalStack<F> {
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<()> {
         if self.0.len() < EVAL_STACK_SIZE {
-            let word = value.flatten(ValueLocation::Stack(StackLocation {
-                stack_index: self.0.len(),
-            }));
+            let word = LocatedValue(
+                ValueLocation::Stack(StackLocation {
+                    stack_index: self.0.len(),
+                }),
+                &value,
+            )
+            .flatten();
             Self::emit_stack_ops_for_word(word, RW::WRITE, rw_operations);
 
             self.0.push(value);
@@ -67,9 +72,13 @@ impl<F: FieldExt> EvalStack<F> {
             Err(RuntimeError::new(StatusCode::StackUnderflow))
         } else {
             let value = self.0.pop().unwrap();
-            let word = value.flatten(ValueLocation::Stack(StackLocation {
-                stack_index: self.0.len(),
-            }));
+            let word = LocatedValue(
+                ValueLocation::Stack(StackLocation {
+                    stack_index: self.0.len(),
+                }),
+                &value,
+            )
+            .flatten();
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             Ok(value)
@@ -89,9 +98,13 @@ impl<F: FieldExt> EvalStack<F> {
         let values = self.0.split_off(remaining_stack_size);
 
         for (i, value) in values.iter().enumerate() {
-            let word = value.flatten(ValueLocation::Stack(StackLocation {
-                stack_index: (remaining_stack_size + i),
-            }));
+            let word = LocatedValue(
+                ValueLocation::Stack(StackLocation {
+                    stack_index: (remaining_stack_size + i),
+                }),
+                value,
+            )
+            .flatten();
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
         }
 
@@ -110,7 +123,7 @@ impl<F: FieldExt> EvalStack<F> {
             let loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let word = value.flatten(ValueLocation::Stack(loc));
+            let word = LocatedValue(ValueLocation::Stack(loc), &value).flatten();
             let word_element_count = word.len();
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
@@ -141,9 +154,13 @@ impl<F: FieldExt> EvalStack<F> {
         } else {
             let value = self.0.pop().unwrap();
 
-            let word = value.flatten(ValueLocation::Stack(StackLocation {
-                stack_index: self.0.len(),
-            }));
+            let word = LocatedValue(
+                ValueLocation::Stack(StackLocation {
+                    stack_index: self.0.len(),
+                }),
+                &value,
+            )
+            .flatten();
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             match value {
@@ -189,7 +206,7 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let word = value.flatten(ValueLocation::Stack(v_loc));
+            let word = LocatedValue(ValueLocation::Stack(v_loc), &value).flatten();
             Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
 
             match value {

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -9,7 +9,7 @@ use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
 use movelang::state::StateStore;
-use movelang::value::{SimpleValue, Value};
+use movelang::value::{PrimitiveValue, Value};
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::execution_steps::ExecutionStep;
@@ -160,7 +160,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -168,7 +168,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -176,7 +176,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -184,7 +184,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -192,7 +192,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -200,7 +200,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: READ,
         gc: 5,
     });
@@ -366,7 +366,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -374,7 +374,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -382,7 +382,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -390,7 +390,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -398,7 +398,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -406,7 +406,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: READ,
         gc: 5,
     });
@@ -415,7 +415,7 @@ fn test_nop_step() -> VmResult<()> {
         index: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: WRITE,
         gc: 6,
     });
@@ -562,7 +562,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -570,7 +570,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -578,7 +578,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(2)),
+        value: Some(PrimitiveValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -586,7 +586,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(1)),
+        value: Some(PrimitiveValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -594,7 +594,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -602,7 +602,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Some(SimpleValue::u64(3)),
+        value: Some(PrimitiveValue::u64(3)),
         rw: READ,
         gc: 5,
     });

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -9,7 +9,7 @@ use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
 use movelang::state::StateStore;
-use movelang::value::Value;
+use movelang::value::{SimpleValue, Value};
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::execution_steps::ExecutionStep;
@@ -160,7 +160,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -168,7 +168,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -176,7 +176,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -184,7 +184,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -192,7 +192,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -200,7 +200,7 @@ fn test_execution_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: READ,
         gc: 5,
     });
@@ -366,7 +366,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -374,7 +374,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -382,7 +382,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -390,7 +390,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -398,7 +398,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -406,7 +406,7 @@ fn test_nop_step() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: READ,
         gc: 5,
     });
@@ -415,7 +415,7 @@ fn test_nop_step() -> VmResult<()> {
         index: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: WRITE,
         gc: 6,
     });
@@ -562,7 +562,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: WRITE,
         gc: 0,
     });
@@ -570,7 +570,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: WRITE,
         gc: 1,
     });
@@ -578,7 +578,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 1,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(2),
+        value: Some(SimpleValue::u64(2)),
         rw: READ,
         gc: 2,
     });
@@ -586,7 +586,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(1),
+        value: Some(SimpleValue::u64(1)),
         rw: READ,
         gc: 3,
     });
@@ -594,7 +594,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: WRITE,
         gc: 4,
     });
@@ -602,7 +602,7 @@ fn test_nop_steps() -> VmResult<()> {
         address: 0,
         address_ext_0: 0,
         address_ext_1: 0,
-        value: Value::u64(3),
+        value: Some(SimpleValue::u64(3)),
         rw: READ,
         gc: 5,
     });


### PR DESCRIPTION
The PR adopts the value design proposed in #90  with a minor addition of `SimpleValue` which is used in scenarios after flatten. 
Besides, the pr changes clone behavior of Value, which now follow the default behavior of rust `Clone` trait, and adds `copy_value` to do _deep_copy_ for container (not reference).