### PR TITLE
chore: support new-arg/ty_args in test, and also global_ops_num

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -81,6 +81,7 @@ impl Arguments {
         // compile script and depended modules
         let mut targets = vec![script_file.to_string()];
         let config = RunConfig::new(script)?;
+
         for module in config.modules.into_iter() {
             let path = module_dir
                 .clone()
@@ -106,7 +107,8 @@ impl Arguments {
         let circuit_config = CircuitConfig::default()
             .steps_num(config.steps_num)
             .stack_ops_num(config.stack_ops_num)
-            .locals_ops_num(config.locals_ops_num);
+            .locals_ops_num(config.locals_ops_num)
+            .global_ops_num(config.global_ops_num);
         let witness = runtime.execute_script(
             script.clone(),
             compiled_modules.clone(),
@@ -138,13 +140,20 @@ impl Arguments {
         info!("prove vm circuit...");
         runtime.prove_vm_circuit(vm_circuit, &[], &params, pk.clone())?;
 
-        if let Some(new_args) = new_args {
+        if let Some(new_args) = new_args
+            .as_ref()
+            .or(config.new_args.as_ref().map(|t| t.as_inner()))
+        {
             info!("execute script with new arguments");
             let arguments = Some(ScriptArguments::new(new_args.clone()));
             let new_witness = runtime.execute_script(
                 script,
                 compiled_modules,
-                config.ty_args,
+                if config.new_ty_args.is_empty() {
+                    config.ty_args
+                } else {
+                    config.new_ty_args
+                },
                 config.signer,
                 arguments,
                 &mut state,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -139,7 +139,7 @@ impl Arguments {
 
         info!("prove vm circuit...");
         runtime.prove_vm_circuit(vm_circuit, &[], &params, pk.clone())?;
-
+        #[allow(clippy::or_fun_call)]
         if let Some(new_args) = new_args
             .as_ref()
             .or(config.new_args.as_ref().map(|t| t.as_inner()))

--- a/functional-tests/src/run_config.rs
+++ b/functional-tests/src/run_config.rs
@@ -29,12 +29,15 @@ pub enum Circuit {
 pub struct RunConfig {
     pub signer: Option<Signer>,
     pub args: Option<ScriptArguments>,
+    pub new_args: Option<ScriptArguments>,
     pub ty_args: Vec<TypeTag>,
+    pub new_ty_args: Vec<TypeTag>,
     pub modules: Vec<String>,
     pub circuit: Option<Circuit>,
     pub steps_num: Option<usize>,
     pub stack_ops_num: Option<usize>,
     pub locals_ops_num: Option<usize>,
+    pub global_ops_num: Option<usize>,
 }
 
 impl RunConfig {
@@ -43,11 +46,14 @@ impl RunConfig {
             signer: None,
             args: None,
             ty_args: vec![],
+            new_args: None,
+            new_ty_args: vec![],
             modules: vec![],
             circuit: None,
             steps_num: None,
             stack_ops_num: None,
             locals_ops_num: None,
+            global_ops_num: None,
         };
         let file_str = script_file.to_str().expect("path is None.");
 
@@ -64,8 +70,14 @@ impl RunConfig {
             if let Some(s) = s.strip_prefix("//!args:") {
                 config.args = Some(s.parse::<ScriptArguments>()?);
             }
+            if let Some(s) = s.strip_prefix("//!new_args:") {
+                config.new_args = Some(s.parse()?);
+            }
             if let Some(s) = s.strip_prefix("//!ty_args:") {
                 config.ty_args = parse_type_tags(s)?;
+            }
+            if let Some(s) = s.strip_prefix("//!new_ty_args:") {
+                config.new_ty_args = parse_type_tags(s)?;
             }
             if let Some(s) = s.strip_prefix("//!mods:") {
                 config.modules.push(s.to_string()); //todo: support multiple modules
@@ -81,6 +93,9 @@ impl RunConfig {
             }
             if let Some(s) = s.strip_prefix("//!locals_ops_num:") {
                 config.locals_ops_num = Some(s.parse::<usize>()?);
+            }
+            if let Some(s) = s.strip_prefix("//!global_ops_num:") {
+                config.global_ops_num = Some(s.parse::<usize>()?);
             }
         }
         Ok(config)

--- a/functional-tests/tests/scripts/add_u64.move
+++ b/functional-tests/tests/scripts/add_u64.move
@@ -1,4 +1,5 @@
 //! args: 1u64, 2u64
+//! new-args: 3u64, 1u64
 script {
     fun main(x: u64, y: u64) {
         assert!(x + y * 2 == 5u64, 101);

--- a/functional-tests/tests/scripts/call_generic.move
+++ b/functional-tests/tests/scripts/call_generic.move
@@ -1,6 +1,8 @@
 //! mods: generics.move
 //! ty_args: u8,bool
 //! args: 10u8, false
+//! new_args: false,10u8
+//! new_ty_args: bool,u8
 script {
     use 0x1::Generics;
     fun main<T: copy+drop, S: copy+drop>(t: T, s: S) {

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -54,16 +54,17 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
         let circuit_config = CircuitConfig::default()
             .steps_num(config.steps_num)
             .stack_ops_num(config.stack_ops_num)
-            .locals_ops_num(config.locals_ops_num);
+            .locals_ops_num(config.locals_ops_num)
+            .global_ops_num(config.global_ops_num);
 
         let witness = runtime.execute_script(
-            script,
-            compiled_modules,
-            config.ty_args,
-            config.signer,
+            script.clone(),
+            compiled_modules.clone(),
+            config.ty_args.clone(),
+            config.signer.clone(),
             config.args,
             &mut state,
-            circuit_config,
+            circuit_config.clone(),
         )?;
         debug!("{:?}", witness);
 
@@ -78,7 +79,28 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
         let pk = runtime.setup_vm_circuit(&vm_circuit, &params)?;
 
         debug!("Generate zk proof for execution trace");
-        runtime.prove_vm_circuit(vm_circuit, &[], &params, pk)?;
+        runtime.prove_vm_circuit(vm_circuit, &[], &params, pk.clone())?;
+        if let Some(new_args) = config.new_args.as_ref() {
+            info!("execute script with new arguments");
+            let new_witness = runtime.execute_script(
+                script,
+                compiled_modules,
+                if config.new_ty_args.is_empty() {
+                    config.ty_args
+                } else {
+                    config.new_ty_args
+                },
+                config.signer,
+                Some(new_args.clone()),
+                &mut state,
+                circuit_config,
+            )?;
+            let new_vm_circuit = VmCircuit {
+                witness: new_witness,
+            };
+            info!("prove the new execution with old proving key...");
+            runtime.prove_vm_circuit(new_vm_circuit, &[], &params, pk)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
so that we can test old pk/vk with new args.