### PR TITLE
halve the cells used for step.conditions

### DIFF
--- a/vm-circuit/src/chips/execution_chip.rs
+++ b/vm-circuit/src/chips/execution_chip.rs
@@ -68,6 +68,7 @@ use crate::witness::rw_operations::ConvertedRWOperation;
 use crate::witness::rw_operations::RWOperations;
 use crate::witness::Witness;
 use halo2_proofs::circuit::{AssignedCell, Chip, Region};
+use halo2_proofs::plonk::Constraints;
 use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::Layouter,
@@ -352,8 +353,8 @@ impl<F: FieldExt> ExecutionChip<F> {
         cb: ConstraintBuilder<F>,
     ) {
         // config each execution path of the step
-        let mut constraints = Vec::new();
-        StepChip::constrain_step_conditions(&step_curr.cells, &mut constraints);
+        let constraints = step_curr.cells.conditions.configure();
+        //StepChip::constrain_step_conditions(&step_curr.cells, &mut constraints);
         // for (i, constraint) in constraints.iter().enumerate() {
         //     debug!("constraint {}, {:?}", i, constraint);
         // }
@@ -380,9 +381,9 @@ impl<F: FieldExt> ExecutionChip<F> {
         if !constraints.is_empty() {
             meta.create_gate(name, |meta| {
                 let s_step = meta.query_selector(s_step);
-                constraints
-                    .into_iter()
-                    .map(move |(name, constraint)| (name, s_step.clone() * constraint))
+                // TODO: add cond here.
+                // let cond = step_curr.cells.opcode_selector([opcode]);
+                Constraints::with_selector(s_step, constraints)
             });
         }
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/_mod.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/_mod.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for Mod<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Mod.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/abort.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/abort.rs
@@ -29,7 +29,7 @@ impl<F: FieldExt> InstructionGadget<F> for Abort<F> {
         _cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Abort.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
         LookupBytecode::lookup_bytecode(
             cells,
             Opcode::Abort,

--- a/vm-circuit/src/chips/execution_chip/instructions/add.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/add.rs
@@ -34,7 +34,7 @@ impl<F: FieldExt> InstructionGadget<F> for Add<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Add
-        let cond = cells.conditions[Opcode::Add.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/and.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/and.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for And<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::And.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/bit_and.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/bit_and.rs
@@ -35,7 +35,7 @@ impl<F: FieldExt> InstructionGadget<F> for BitAnd<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //bit and
-        let cond = cells.conditions[Opcode::BitAnd.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lookup_bitwise = LookupBitwise {
             bytes: self.bytes.clone(),

--- a/vm-circuit/src/chips/execution_chip/instructions/bit_or.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/bit_or.rs
@@ -35,7 +35,7 @@ impl<F: FieldExt> InstructionGadget<F> for BitOr<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //bit and
-        let cond = cells.conditions[Opcode::BitOr.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lookup_bitwise = LookupBitwise {
             bytes: self.bytes.clone(),

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
@@ -51,7 +51,7 @@ impl<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> InstructionGadget<F>
         // 1. read reference from stack. [gc, DEPTH_OF_ADDRESS_PATH]
         // 2. write reference to element into stack.
         // [gc + DEPTH_OF_ADDRESS_PATH, DEPTH_OF_ADDRESS_PATH]
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
@@ -54,7 +54,7 @@ impl<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> InstructionGadget<F>
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
@@ -40,13 +40,7 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let opcode = if MUTABLE {
-            Opcode::MutBorrowLoc
-        } else {
-            Opcode::ImmBorrowLoc
-        };
-
-        let cond = cells.conditions[opcode.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()
@@ -114,7 +108,7 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
 
         LookupBytecode::lookup_bytecode(
             cells,
-            opcode,
+            Self::OPCODE,
             cells.locals_index.expression.clone(),
             &mut lookups.bytecode_lookups,
             cond,

--- a/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for BrFalse<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::BrFalse.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         // branch target is assigned in the auxiliary_1, condition is popped form stack as value_a
         let aux = cells.auxiliary_1.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for BrTrue<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::BrTrue.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         // branch target is assigned in the auxiliary_1, condition is popped form stack as value_a
         let aux = cells.auxiliary_1.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/branch.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/branch.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for Branch<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Branch.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
         // next pc is assigned in the auxiliary_1
         let pc_expr = cells.auxiliary_1.expression.clone() - cb.next.cells.pc.expression.clone();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/call.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/call.rs
@@ -44,7 +44,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Call<GENERIC, F>
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Self::OPCODE.index()].expr();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let arg_num = cells.auxiliary_1.expression.clone();
         // next pc is always 0

--- a/vm-circuit/src/chips/execution_chip/instructions/castu128.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/castu128.rs
@@ -34,9 +34,7 @@ impl<F: FieldExt> InstructionGadget<F> for CastU128<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::CastU128.index()]
-            .expression
-            .clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let x = self.value_a.expression.clone();
         let out = self.value_c.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/castu64.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/castu64.rs
@@ -34,7 +34,7 @@ impl<F: FieldExt> InstructionGadget<F> for CastU64<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::CastU64.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let x = self.value_a.expression.clone();
         let out = self.value_c.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/castu8.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/castu8.rs
@@ -34,7 +34,7 @@ impl<F: FieldExt> InstructionGadget<F> for CastU8<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::CastU8.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let x = self.value_a.expression.clone();
         let out = self.value_c.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
@@ -32,7 +32,7 @@ impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::CopyLoc.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/div.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/div.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for Div<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Div.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/eq.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/eq.rs
@@ -31,7 +31,7 @@ impl<F: FieldExt> InstructionGadget<F> for Eq<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Eq
-        let cond = cells.conditions[Opcode::Eq.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/freeze_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/freeze_ref.rs
@@ -30,9 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for FreezeRef<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::FreezeRef.index()]
-            .expression
-            .clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/ge.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ge.rs
@@ -36,7 +36,7 @@ impl<F: FieldExt> InstructionGadget<F> for Ge<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Ge
-        let cond = cells.conditions[Opcode::Ge.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/gt.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/gt.rs
@@ -36,7 +36,7 @@ impl<F: FieldExt> InstructionGadget<F> for Gt<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Gt
-        let cond = cells.conditions[Opcode::Gt.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/ld_const.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ld_const.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for LdConst<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
         let const_index = cells.auxiliary_1.expr();
 
         LoadOp::constrain_ld_op(cells, cb, cond.clone());

--- a/vm-circuit/src/chips/execution_chip/instructions/ld_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ld_false.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for LdFalse<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdFalse
-        let cond = cells.conditions[Opcode::LdFalse.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         LoadOp::constrain_ld_op(cells, cb, cond.clone());
         LoadOp::lookup_ld_op(cells, &self.value_a, &mut lookups.rw_lookups, cond.clone());

--- a/vm-circuit/src/chips/execution_chip/instructions/ld_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ld_true.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for LdTrue<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdTrue
-        let cond = cells.conditions[Opcode::LdTrue.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         LoadOp::constrain_ld_op(cells, cb, cond.clone());
         LoadOp::lookup_ld_op(cells, &self.value_a, &mut lookups.rw_lookups, cond.clone());

--- a/vm-circuit/src/chips/execution_chip/instructions/ldu128.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ldu128.rs
@@ -29,7 +29,7 @@ impl<F: FieldExt> InstructionGadget<F> for LdU128<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdU128
-        let cond = cells.conditions[Opcode::LdU128.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         LoadOp::constrain_ld_op(cells, cb, cond.clone());
         LoadOp::lookup_ld_op(cells, &self.value_a, &mut lookups.rw_lookups, cond.clone());

--- a/vm-circuit/src/chips/execution_chip/instructions/ldu64.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ldu64.rs
@@ -29,7 +29,7 @@ impl<F: FieldExt> InstructionGadget<F> for LdU64<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdU64
-        let cond = cells.conditions[Opcode::LdU64.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         LoadOp::constrain_ld_op(cells, cb, cond.clone());
         LoadOp::lookup_ld_op(cells, &self.value_a, &mut lookups.rw_lookups, cond.clone());

--- a/vm-circuit/src/chips/execution_chip/instructions/ldu8.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ldu8.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for LdU8<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //LdU8
-        let cond = cells.conditions[Opcode::LdU8.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         LoadOp::constrain_ld_op(cells, cb, cond.clone());
         LoadOp::lookup_ld_op(cells, &self.value_a, &mut lookups.rw_lookups, cond.clone());

--- a/vm-circuit/src/chips/execution_chip/instructions/le.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/le.rs
@@ -36,7 +36,7 @@ impl<F: FieldExt> InstructionGadget<F> for Le<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Le
-        let cond = cells.conditions[Opcode::Le.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/lt.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/lt.rs
@@ -36,7 +36,7 @@ impl<F: FieldExt> InstructionGadget<F> for Lt<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Lt
-        let cond = cells.conditions[Opcode::Lt.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -47,7 +47,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
@@ -33,7 +33,7 @@ impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::MoveLoc.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -49,7 +49,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/mul.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/mul.rs
@@ -32,7 +32,7 @@ impl<F: FieldExt> InstructionGadget<F> for Mul<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Mul.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/neq.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/neq.rs
@@ -31,7 +31,7 @@ impl<F: FieldExt> InstructionGadget<F> for Neq<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Neq
-        let cond = cells.conditions[Opcode::Neq.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/nop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/nop.rs
@@ -28,7 +28,7 @@ impl<F: FieldExt> InstructionGadget<F> for Nop<F> {
         cb: &mut ConstraintBuilder<F>,
         _lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Nop.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone();
         cb.add_constraints(vec![("pc", cond.clone() * pc_expr), ("gc", cond * gc_expr)]);

--- a/vm-circuit/src/chips/execution_chip/instructions/not.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/not.rs
@@ -29,7 +29,7 @@ impl<F: FieldExt> InstructionGadget<F> for Not<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Not.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let x = self.value_a.expression.clone();
         let out = self.value_c.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/or.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/or.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for Or<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Or.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pack.rs
@@ -46,7 +46,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Pack
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let field_num = cells.auxiliary_1.expression.clone();
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();

--- a/vm-circuit/src/chips/execution_chip/instructions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pop.rs
@@ -33,7 +33,7 @@ impl<F: FieldExt> InstructionGadget<F> for Pop<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Pop.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -45,7 +45,7 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
         // 1. read reference from stack. [gc, DEPTH_OF_ADDRESS_PATH]
         // 2. read value from lobals or global. [gc+DEPTH_OF_ADDRESS_PATH, word_element_num]
         // 3. store value into stack. [gc+DEPTH_OF_ADDRESS_PATH+word_element_num, word_element_num]
-        let cond = cells.conditions[Opcode::ReadRef.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/ret.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ret.rs
@@ -32,7 +32,7 @@ impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Ret.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
         let frame_index = cells.frame_index.expression.clone();
         let inverse = cells.auxiliary_1.expression.clone();
 

--- a/vm-circuit/src/chips/execution_chip/instructions/shl.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/shl.rs
@@ -30,7 +30,7 @@ impl<F: FieldExt> InstructionGadget<F> for Shl<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Shl.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/shr.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/shr.rs
@@ -32,7 +32,7 @@ impl<F: FieldExt> InstructionGadget<F> for Shr<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::Shr.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let dividend = self.value_a.expression.clone();
         let shift_bits = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
@@ -33,7 +33,7 @@ impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
         cb: &mut ConstraintBuilder<F>,
         lookups: &mut LookupsWithCondition<F>,
     ) {
-        let cond = cells.conditions[Opcode::StLoc.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/sub.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/sub.rs
@@ -33,7 +33,7 @@ impl<F: FieldExt> InstructionGadget<F> for Sub<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Sub
-        let cond = cells.conditions[Opcode::Sub.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lhs = self.value_a.expression.clone();
         let rhs = self.value_b.expression.clone();

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -46,7 +46,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //Unpack
-        let cond = cells.conditions[Self::OPCODE.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let field_num = cells.auxiliary_1.expression.clone();
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
@@ -44,12 +44,8 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for VecBorrow<MUTABL
         // 2. read reference from stack. [gc + 1, DEPTH_OF_ADDRESS_PATH]
         // 3. write reference to element into stack.
         // [gc + 1 + DEPTH_OF_ADDRESS_PATH, DEPTH_OF_ADDRESS_PATH]
-        let opcode = if MUTABLE {
-            Opcode::VecMutBorrow
-        } else {
-            Opcode::VecImmBorrow
-        };
-        let cond = cells.conditions[opcode.index()].expression.clone();
+
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()
@@ -143,7 +139,7 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for VecBorrow<MUTABL
 
         LookupBytecode::lookup_bytecode(
             cells,
-            opcode,
+            Self::OPCODE,
             cells.auxiliary_1.expression.clone(),
             &mut lookups.bytecode_lookups,
             cond,

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
@@ -42,7 +42,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecLen<F> {
         // 1. read reference from stack. [gc, DEPTH_OF_ADDRESS_PATH]
         // 2. read vec header from locals or global. [gc+DEPTH_OF_ADDRESS_PATH, 1]
         // 3. write length into stack. [gc+DEPTH_OF_ADDRESS_PATH+1, 1]
-        let cond = cells.conditions[Opcode::VecLen.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pack.rs
@@ -47,7 +47,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecPack<F> {
         // 1. read n values from stack. [gc, values_flattened_len]
         // 2. write vector to stack. [gc + values_flattened_len, vector_flattened_len]
 
-        let cond = cells.conditions[Opcode::VecPack.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let values_num = cells.auxiliary_1.expression.clone();
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
@@ -68,9 +68,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecPopBack<F> {
         // 4. update current and parent headers (flattened_length, length).
         // [gc + DEPTH_OF_ADDRESS_PATH + value_flattened_len * 2, headers_count * 2]
 
-        let cond = cells.conditions[Opcode::VecPopBack.index()]
-            .expression
-            .clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
@@ -66,9 +66,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecPushBack<F> {
         // 4. update current and parent headers (flattened length, length).
         // [gc + value_flattened_len * 2 + DEPTH_OF_ADDRESS_PATH, headers_count * 2]
 
-        let cond = cells.conditions[Opcode::VecPushBack.index()]
-            .expression
-            .clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
@@ -64,7 +64,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecSwap<F> {
         // [gc + 2 + DEPTH_OF_ADDRESS_PATH + 2 * value_a_flattened_len + value_b_flattened_len,
         // value_b_flattened_len]
 
-        let cond = cells.conditions[Opcode::VecSwap.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_unpack.rs
@@ -46,9 +46,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecUnpack<F> {
         // for instruction VecUnpack, there are 2 steps here:
         // 1. read vector from stack. [gc, vector_flattened_len]
         // 2. write n values to stack. [gc + vector_flattened_len, , values_flattened_len]
-        let cond = cells.conditions[Opcode::VecUnpack.index()]
-            .expression
-            .clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let values_num = cells.auxiliary_1.expression.clone();
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -44,9 +44,7 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
         // 1. read reference from stack. [gc, DEPTH_OF_ADDRESS_PATH]
         // 2. read value into stack. [gc+DEPTH_OF_ADDRESS_PATH, word_element_num]
         // 3. write value to lobals or global. [gc+DEPTH_OF_ADDRESS_PATH+word_element_num, word_element_num]
-        let cond = cells.conditions[Opcode::WriteRef.index()]
-            .expression
-            .clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()

--- a/vm-circuit/src/chips/execution_chip/instructions/xor.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/xor.rs
@@ -35,7 +35,7 @@ impl<F: FieldExt> InstructionGadget<F> for Xor<F> {
         lookups: &mut LookupsWithCondition<F>,
     ) {
         //xor
-        let cond = cells.conditions[Opcode::Xor.index()].expression.clone();
+        let cond = cells.opcode_selector([Self::OPCODE]);
 
         let lookup_bitwise = LookupBitwise {
             bytes: self.bytes.clone(),

--- a/vm-circuit/src/chips/execution_chip/param.rs
+++ b/vm-circuit/src/chips/execution_chip/param.rs
@@ -4,7 +4,7 @@ pub const BYTES_NUM: usize = 16;
 
 pub const MAX_ADDRESS_EXT_LENGTH: usize = 8;
 
-pub const STEP_CHIP_WIDTH: usize = 16;
+pub const STEP_CHIP_WIDTH: usize = 64;
 
 pub const STEP_HEIGHT: usize = 40; // default max step height
 

--- a/vm-circuit/src/chips/execution_chip/step_chip.rs
+++ b/vm-circuit/src/chips/execution_chip/step_chip.rs
@@ -1,6 +1,7 @@
 // Copyright (c) zkMove Authors
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::param::{STEP_CHIP_WIDTH, STEP_HEIGHT};
+use crate::chips::execution_chip::utils::dynamic_selector_half::DynamicSelectorHalf;
 use crate::chips::execution_chip::utils::{CellManager, CellType};
 use crate::chips::utilities::*;
 use crate::witness::execution_steps::ExecutionStep;
@@ -29,7 +30,16 @@ pub struct StepChipCells<F: FieldExt> {
     pub auxiliary_4: Cell<F>,
     pub auxiliary_5: Cell<F>,
 
-    pub conditions: Vec<Cell<F>>, // one cell for each cell
+    pub(crate) conditions: DynamicSelectorHalf<F>,
+}
+impl<F: FieldExt> StepChipCells<F> {
+    pub(crate) fn opcode_selector(
+        &self,
+        opcodes: impl IntoIterator<Item = Opcode>,
+    ) -> Expression<F> {
+        self.conditions
+            .selector(opcodes.into_iter().map(|op| op.index()))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -107,8 +117,7 @@ impl<F: FieldExt> StepChip<F> {
                 auxiliary_4: cell_manager.alloc_cell(CellType::CustomGate),
                 auxiliary_5: cell_manager.alloc_cell(CellType::CustomGate),
 
-                conditions: cell_manager
-                    .allocate_cells(CellType::CustomGate, Opcode::total_numbers()),
+                conditions: DynamicSelectorHalf::new(&mut cell_manager, Opcode::total_numbers()),
             }
         };
 
@@ -120,32 +129,32 @@ impl<F: FieldExt> StepChip<F> {
             cell_manager,
         }
     }
-
-    // step condition must be 1 or 0, and sum of all conditions must be 1
-    pub(crate) fn constrain_step_conditions(
-        cells: &StepChipCells<F>,
-        constraints: &mut Vec<(&str, Expression<F>)>,
-    ) {
-        let one = Expression::Constant(F::one());
-
-        let mut zero_or_one = cells
-            .conditions
-            .iter()
-            .map(|cell| {
-                (
-                    "zero or one",
-                    (cell.expression.clone() - one.clone()) * cell.expression.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
-        constraints.append(&mut zero_or_one);
-
-        let sum_to_one = cells
-            .conditions
-            .iter()
-            .fold(one, |acc, cell| acc - cell.expression.clone());
-        constraints.push(("sum to one", sum_to_one));
-    }
+    //
+    // // step condition must be 1 or 0, and sum of all conditions must be 1
+    // pub(crate) fn constrain_step_conditions(
+    //     cells: &StepChipCells<F>,
+    //     constraints: &mut Vec<(&str, Expression<F>)>,
+    // ) {
+    //     let one = Expression::Constant(F::one());
+    //
+    //     let mut zero_or_one = cells
+    //         .conditions
+    //         .iter()
+    //         .map(|cell| {
+    //             (
+    //                 "zero or one",
+    //                 (cell.expression.clone() - one.clone()) * cell.expression.clone(),
+    //             )
+    //         })
+    //         .collect::<Vec<_>>();
+    //     constraints.append(&mut zero_or_one);
+    //
+    //     let sum_to_one = cells
+    //         .conditions
+    //         .iter()
+    //         .fold(one, |acc, cell| acc - cell.expression.clone());
+    //     constraints.push(("sum to one", sum_to_one));
+    // }
 
     // assign each cell of the step, return assigned cell for gc
     pub fn assign(
@@ -200,16 +209,7 @@ impl<F: FieldExt> StepChip<F> {
         self.config
             .cells
             .conditions
-            .iter()
-            .enumerate()
-            .for_each(|(index, cell)| {
-                let condition = if step.opcode.index() == index {
-                    F::one()
-                } else {
-                    F::zero()
-                };
-                let _assigned = cell.assign(region, offset, Some(condition));
-            });
+            .assign(region, offset, step.opcode.index())?;
 
         // assign other cells for the step
         // step.opcode

--- a/vm-circuit/src/chips/execution_chip/utils.rs
+++ b/vm-circuit/src/chips/execution_chip/utils.rs
@@ -9,6 +9,7 @@ use std::hash::Hash;
 
 pub mod base_constaint_builder;
 pub mod constraint_builder;
+pub mod dynamic_selector_half;
 pub(crate) fn query_expression<F: FieldExt, T>(
     meta: &mut ConstraintSystem<F>,
     mut f: impl FnMut(&mut VirtualCells<F>) -> T,

--- a/vm-circuit/src/chips/execution_chip/utils/dynamic_selector_half.rs
+++ b/vm-circuit/src/chips/execution_chip/utils/dynamic_selector_half.rs
@@ -1,0 +1,102 @@
+use crate::chips::execution_chip::utils::{CellManager, CellType};
+use crate::chips::utilities::{Cell, Expr};
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{Region};
+use halo2_proofs::plonk::{Error, Expression};
+use std::iter;
+
+/// Dynamic selector that generates expressions of degree 2 to select from N
+/// possible targets using N/2 + 1 cells.
+#[derive(Clone, Debug)]
+pub(crate) struct DynamicSelectorHalf<F> {
+    /// N value: how many possible targets this selector supports.
+    count: usize,
+    /// Whether the target is odd.  `target % 2 == 1`.
+    pub(crate) target_odd: Cell<F>,
+    /// Whether the target belongs to each consecutive pair of targets.
+    /// `in [0, 1], in [2, 3], in [4, 5], ...`
+    pub(crate) target_pairs: Vec<Cell<F>>,
+}
+
+impl<F: FieldExt> DynamicSelectorHalf<F> {
+    pub(crate) fn new(cell_manager: &mut CellManager<F>, count: usize) -> Self {
+        let target_pairs = cell_manager.allocate_cells(CellType::CustomGate, (count + 1) / 2);
+        let target_odd = cell_manager.alloc_cell(CellType::CustomGate);
+        Self {
+            count,
+            target_pairs,
+            target_odd,
+        }
+    }
+
+    /// Return the list of constraints that configure this "gadget".
+    pub(crate) fn configure(&self) -> Vec<(&'static str, Expression<F>)> {
+        // Only one of target_pairs should be enabled
+        let sum_to_one = (
+            "Only one of target_pairs should be enabled",
+            self.target_pairs
+                .iter()
+                .fold(1u64.expr(), |acc, cell| acc - cell.expr()),
+        );
+        // Cells representation for target_pairs and target_odd should be bool.
+        let bool_checks = iter::once(&self.target_odd)
+            .chain(&self.target_pairs)
+            .map(|cell| {
+                (
+                    "Representation for target_pairs and target_odd should be bool",
+                    cell.expr() * (1u64.expr() - cell.expr()),
+                )
+            });
+        let mut constraints: Vec<(&'static str, Expression<F>)> =
+            iter::once(sum_to_one).chain(bool_checks).collect();
+        // In case count is odd, we must forbid selecting N+1 with (odd = 1,
+        // target_pairs[-1] = 1)
+        if self.count % 2 == 1 {
+            constraints.push((
+                "Forbid N+1 target when N is odd",
+                self.target_odd.expr() * self.target_pairs[self.count / 2].expr(),
+            ));
+        }
+        constraints
+    }
+
+    pub(crate) fn selector(&self, targets: impl IntoIterator<Item = usize>) -> Expression<F> {
+        targets
+            .into_iter()
+            .map(|target| {
+                let odd = target % 2 == 1;
+                let pair_index = target / 2;
+                (if odd {
+                    self.target_odd.expr()
+                } else {
+                    1.expr() - self.target_odd.expr()
+                }) * self.target_pairs[pair_index].expr()
+            })
+            .reduce(|acc, expr| acc + expr)
+            .expect("Select some Targets")
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        target: usize,
+    ) -> Result<(), Error> {
+        let odd = target % 2 == 1;
+        let pair_index = target / 2;
+        self.target_odd
+            .assign(region, offset, Some(if odd { F::one() } else { F::zero() }))?;
+        for (index, cell) in self.target_pairs.iter().enumerate() {
+            cell.assign(
+                region,
+                offset,
+                Some(if index == pair_index {
+                    F::one()
+                } else {
+                    F::zero()
+                }),
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/vm-circuit/src/chips/execution_chip/utils/dynamic_selector_half.rs
+++ b/vm-circuit/src/chips/execution_chip/utils/dynamic_selector_half.rs
@@ -1,7 +1,7 @@
 use crate::chips::execution_chip::utils::{CellManager, CellType};
 use crate::chips::utilities::{Cell, Expr};
 use halo2_proofs::arithmetic::FieldExt;
-use halo2_proofs::circuit::{Region};
+use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use std::iter;
 


### PR DESCRIPTION
In order to resolve last_gc_cell issue, I need to fit all cells of Opcode::Stop into one row.
so I increased step_width to 48, and halve the cells for `step.conditions` by using DynamicSelectorHalf from pse.