### PR TITLE
bench: add a benchmark (part 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ members = [
     "functional-tests",
     "cli",
 ]
+
+
+[profile.bench]
+lto=true

--- a/functional-tests/Cargo.toml
+++ b/functional-tests/Cargo.toml
@@ -14,16 +14,19 @@ vm-circuit = { path = "../vm-circuit" }
 vm = { path = "../vm" }
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
 anyhow = "1.0.38"
-criterion = "0.3.4"
+criterion = "0.5.1"
 rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
+regex = "1.5"
+walkdir = "2.3.2"
 
 [[test]]
 name = "testsuite"
 harness = false
 
-#[[bench]]
-#name = "circuit_benchmark"
-#harness = false
+[[bench]]
+name = "circuit_benchmark"
+harness = false
+

--- a/functional-tests/benches/circuit_benchmark.rs
+++ b/functional-tests/benches/circuit_benchmark.rs
@@ -1,23 +1,142 @@
 // Copyright (c) zkMove Authors
 
-use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode};
+use functional_tests::run_config::RunConfig;
+use halo2_proofs::halo2curves::pasta::{EqAffine, Fp};
+use halo2_proofs::plonk::ProvingKey;
+use halo2_proofs::poly::commitment::ParamsProver;
+use halo2_proofs::poly::ipa::commitment::ParamsIPA;
+use logger::{debug, info};
+use movelang::compiler::compile_script;
+use movelang::state::StateStore;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use vm::runtime::Runtime;
+use vm_circuit::circuit::VmCircuit;
+use vm_circuit::witness::CircuitConfig;
 
-//
+pub const TEST_MODULE_PATH: &str = "tests/modules";
+#[allow(clippy::type_complexity)]
+fn setup(
+    path: &Path,
+) -> datatest_stable::Result<(
+    Runtime<Fp>,
+    VmCircuit<Fp>,
+    ParamsIPA<EqAffine>,
+    ProvingKey<EqAffine>,
+)> {
+    let script_file = path.to_str().expect("path is None.");
+    debug!("Run test {:?}", script_file);
+
+    let mut targets = vec![script_file.to_string()];
+    let config = RunConfig::new(path)?;
+    for module in config.modules.into_iter() {
+        let path = Path::new(TEST_MODULE_PATH)
+            .join(module)
+            .to_str()
+            .unwrap()
+            .to_string();
+        targets.push(path);
+    }
+    debug!(
+        "script arguments {:?}, compile targets {:?}",
+        config.args, targets
+    );
+
+    let (compiled_script, compiled_modules) = compile_script(targets)?;
+    let script = compiled_script.expect("script is missing");
+    let runtime = Runtime::<Fp>::new();
+    let mut state = StateStore::new();
+
+    for module in compiled_modules.clone().into_iter() {
+        state.add_module(module);
+    }
+
+    debug!("Generate execution trace for script {:?}", script_file);
+    let circuit_config = CircuitConfig::default()
+        .steps_num(config.steps_num)
+        .stack_ops_num(config.stack_ops_num)
+        .locals_ops_num(config.locals_ops_num)
+        .global_ops_num(config.global_ops_num);
+
+    let witness = runtime.execute_script(
+        script,
+        compiled_modules,
+        config.ty_args.clone(),
+        config.signer.clone(),
+        config.args,
+        &mut state,
+        circuit_config,
+    )?;
+    debug!("{:?}", witness);
+
+    let vm_circuit = VmCircuit { witness };
+    let k = runtime.find_best_k(&vm_circuit, vec![])?;
+    info!("use vm circuit, k = {}", k);
+
+    runtime.mock_prove_circuit(&vm_circuit, vec![], k)?;
+
+    debug!("Generate parameters for execution trace");
+    let params: ParamsIPA<EqAffine> = ParamsIPA::new(k);
+    let pk = runtime.setup_vm_circuit(&vm_circuit, &params)?;
+    Ok((runtime, vm_circuit, params, pk))
+}
+
 // Circuit benchmarks
-//
-
-fn circuit_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
-    //
-
-    c.bench_function("fast circuit", |bencher| {
-        bencher.iter_batched(|| {}, |_| {}, BatchSize::LargeInput)
-    });
+fn circuit_benchmark(c: &mut Criterion) {
+    let root = Path::new("benches/scripts");
+    let re = regex::Regex::new(r".*\.move").unwrap();
+    let cases: Vec<_> = iterate_directory(root)
+        .filter_map(|path| {
+            if re.is_match(path.to_string_lossy().as_ref()) {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let mut group = c.benchmark_group("vm-circuit");
+    group
+        .sampling_mode(SamplingMode::Flat)
+        .warm_up_time(Duration::from_secs(60));
+    for case_path in cases {
+        let inputs = setup(case_path.as_path()).unwrap();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(&case_path.display()),
+            &inputs,
+            |b, (runtime, vm_circuit, params, pk)| {
+                b.iter_batched(
+                    || {},
+                    |_| {
+                        runtime
+                            .prove_vm_circuit(vm_circuit.clone(), &[], params, pk.clone())
+                            .unwrap();
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
 }
 
 criterion_group!(
     name = circuit_benches;
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(60*10)).without_plots();
     targets = circuit_benchmark
 );
 
 criterion_main!(circuit_benches);
+
+fn iterate_directory(path: &Path) -> impl Iterator<Item = PathBuf> {
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .map(::std::result::Result::unwrap)
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map_or(false, |s| !s.starts_with('.')) // Skip hidden files
+        })
+        .map(|entry| entry.path().to_path_buf())
+}

--- a/functional-tests/benches/scripts/call_generic.move
+++ b/functional-tests/benches/scripts/call_generic.move
@@ -1,0 +1,11 @@
+//! mods: generics.move
+//! ty_args: u8,bool
+//! args: 10u8, false
+//! new_args: false,10u8
+//! new_ty_args: bool,u8
+script {
+    use 0x1::Generics;
+    fun main<T: copy+drop, S: copy+drop>(t: T, s: S) {
+        Generics::save_t_times(t, s, 2);
+    }
+}

--- a/functional-tests/benches/scripts/loop1.move
+++ b/functional-tests/benches/scripts/loop1.move
@@ -1,0 +1,13 @@
+//! circuit: vm
+//! steps_num: 50
+//! stack_ops_num: 50
+//! locals_ops_num: 50
+//! args: 5u64
+script {
+    fun main(n: u64) {
+        let i = 0u64;
+        while (i < n) {
+            i = i + 1;
+        };
+    }
+}


### PR DESCRIPTION
To enable benchmark comparison,  first we need to add the bench code.
Then we add a ci to run benchmark and output difference between PR and base branch.
This is the first part.