### PR TITLE
dep: patch criterion

### DIFF
--- a/functional-tests/Cargo.toml
+++ b/functional-tests/Cargo.toml
@@ -14,7 +14,7 @@ vm-circuit = { path = "../vm-circuit" }
 vm = { path = "../vm" }
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
 anyhow = "1.0.38"
-criterion = "0.5.1"
+criterion = { git = "https://github.com/young-rocks/criterion.rs", rev="98922e676bacc55ed2a27f65dcd2b18650ba12e9" }
 rand_core = { version = "0.6", default-features = false }
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/functional-tests/benches/circuit_benchmark.rs
+++ b/functional-tests/benches/circuit_benchmark.rs
@@ -121,7 +121,7 @@ fn circuit_benchmark(c: &mut Criterion) {
 
 criterion_group!(
     name = circuit_benches;
-    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(60*10)).without_plots();
+    config = Criterion::default().sample_size(3).measurement_time(Duration::from_secs(60*5)).without_plots();
     targets = circuit_benchmark
 );
 


### PR DESCRIPTION
so that we can reduce sample_size to a smaller value, like 2 or 3 to decrease the time of benchmark.