### PR TITLE
Rename Word to FlattenedValue and WordGadget to ValueGadget

### DIFF
--- a/movelang/src/extended_value.rs
+++ b/movelang/src/extended_value.rs
@@ -12,55 +12,56 @@ use std::marker::PhantomData;
 pub const LEN_OF_REFERENCE_VALUE: usize = 4; // header + DEPTH_OF_LOCATION_PATH + addr_ext
 pub const LEN_OF_SIMPLE_VALUE: usize = 2;
 
-/// To efficiently represent a complex value in the circuit, we defined 'word', a uniform
-/// flattened value representation, to flatten the complex value into simple values.
+/// To efficiently represent a complex value in the circuit, we defined 'ExtendedValue', an
+/// extended value representation. It starts with a value header carrying type information,
+/// followed by simple values flattened from the complex value.
 #[derive(Clone, Debug)]
-pub struct Word<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
+pub struct ExtendedValue<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
 
-impl<F: FieldExt> From<&Value<F>> for Word<F> {
+impl<F: FieldExt> From<&Value<F>> for ExtendedValue<F> {
     fn from(value: &Value<F>) -> Self {
         match value {
-            Value::Invalid => Word(vec![]), // TODO: Issue #52
+            Value::Invalid => ExtendedValue(vec![]), // TODO: Issue #52
             Value::U8(_) | Value::U64(_) | Value::U128(_) | Value::Bool(_) | Value::Address(_) => {
                 let simple = SimpleValue::try_from(value).expect("should not fail");
-                SimpleValueWord::from(simple).into()
+                ExtendedSimpleValue::from(simple).into()
             }
-            Value::Container(c) => ContainerValueWord::from(c).into(),
+            Value::Container(c) => ExtendedContainerValue::from(c).into(),
             Value::GlobalRef(_) | Value::IndexedRef(_) | Value::LocalRef(_) => {
                 let reference = Reference::try_from(value).expect("should not fail");
-                ReferenceValueWord::from(reference).into()
+                ExtendedReferenceValue::from(reference).into()
             }
         }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct SimpleValueWord<F: FieldExt>(pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE]);
+pub struct ExtendedSimpleValue<F: FieldExt>(pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE]);
 
-impl<F: FieldExt> From<SimpleValue<F>> for SimpleValueWord<F> {
-    fn from(value: SimpleValue<F>) -> SimpleValueWord<F> {
-        SimpleValueWord([
+impl<F: FieldExt> From<SimpleValue<F>> for ExtendedSimpleValue<F> {
+    fn from(value: SimpleValue<F>) -> ExtendedSimpleValue<F> {
+        ExtendedSimpleValue([
             (vec![0u128], ValueHeader::default_for_simple().into()),
             (vec![1u128], value),
         ])
     }
 }
 
-impl<F: FieldExt> From<SimpleValueWord<F>> for Word<F> {
-    fn from(word: SimpleValueWord<F>) -> Word<F> {
-        Word(word.0.to_vec())
+impl<F: FieldExt> From<ExtendedSimpleValue<F>> for ExtendedValue<F> {
+    fn from(value: ExtendedSimpleValue<F>) -> ExtendedValue<F> {
+        ExtendedValue(value.0.to_vec())
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct ReferenceValueWord<F: FieldExt>(
+pub struct ExtendedReferenceValue<F: FieldExt>(
     pub [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE],
 );
 
-impl<F: FieldExt> ReferenceValueWord<F> {
-    fn fold(word: Vec<(Vec<u128>, SimpleValue<F>)>) -> Self {
+impl<F: FieldExt> ExtendedReferenceValue<F> {
+    fn fold(simples: Vec<(Vec<u128>, SimpleValue<F>)>) -> Self {
         let mut value: u128 = 0;
-        for (i, (_, val)) in word.iter().skip(DEPTH_OF_LOCATION_PATH + 1).enumerate() {
+        for (i, (_, val)) in simples.iter().skip(DEPTH_OF_LOCATION_PATH + 1).enumerate() {
             // fold addr_ext into one cell
             let x = val
                 .value()
@@ -69,14 +70,14 @@ impl<F: FieldExt> ReferenceValueWord<F> {
             value += x << (16 * i);
         }
 
-        let mut new_ref_value = word
+        let mut new_ref_value = simples
             .into_iter()
             .take(LEN_OF_REFERENCE_VALUE)
             .collect::<Vec<_>>();
 
         let (address_path, _) = new_ref_value.pop().expect("value should not be None.");
         new_ref_value.push((address_path, SimpleValue::u128(value)));
-        let new_word: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
+        let extended_ref_value: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
             .try_into()
             .unwrap_or_else(|v: Vec<(Vec<u128>, SimpleValue<F>)>| {
                 panic!(
@@ -85,12 +86,12 @@ impl<F: FieldExt> ReferenceValueWord<F> {
                     v.len()
                 )
             });
-        ReferenceValueWord(new_word)
+        ExtendedReferenceValue(extended_ref_value)
     }
 }
 
-impl<F: FieldExt> From<Reference<F>> for ReferenceValueWord<F> {
-    fn from(value: Reference<F>) -> ReferenceValueWord<F> {
+impl<F: FieldExt> From<Reference<F>> for ExtendedReferenceValue<F> {
+    fn from(value: Reference<F>) -> ExtendedReferenceValue<F> {
         let ref_paths = match value {
             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                 // NOTICE: here, we fillup address_path for reference, as reference needs fillup-ed values.
@@ -129,29 +130,29 @@ impl<F: FieldExt> From<Reference<F>> for ReferenceValueWord<F> {
             .collect::<Vec<_>>();
 
         simples.insert(0, ValueHeader::default_for_ref_val().into());
-        let word = simples
+        let new_simples = simples
             .into_iter()
             .enumerate()
             .map(|(i, v)| (vec![i as u128], v))
             .collect::<Vec<_>>();
-        ReferenceValueWord::fold(word)
+        ExtendedReferenceValue::fold(new_simples)
     }
 }
 
-impl<F: FieldExt> From<ReferenceValueWord<F>> for Word<F> {
-    fn from(word: ReferenceValueWord<F>) -> Word<F> {
-        Word(word.0.to_vec())
+impl<F: FieldExt> From<ExtendedReferenceValue<F>> for ExtendedValue<F> {
+    fn from(value: ExtendedReferenceValue<F>) -> ExtendedValue<F> {
+        ExtendedValue(value.0.to_vec())
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct ContainerValueWord<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
+pub struct ExtendedContainerValue<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
 
-impl<F: FieldExt> From<&Container<F>> for ContainerValueWord<F> {
-    fn from(container: &Container<F>) -> ContainerValueWord<F> {
+impl<F: FieldExt> From<&Container<F>> for ExtendedContainerValue<F> {
+    fn from(container: &Container<F>) -> ExtendedContainerValue<F> {
         let mut simples = Vec::new();
         for (idx, val) in container.0.borrow().iter().enumerate() {
-            let mut sub_values = Word::from(val).0;
+            let mut sub_values = ExtendedValue::from(val).0;
             sub_values.iter_mut().for_each(|(v, _)| {
                 // prepend value idx to the sub-struct
                 // to leave a place for the header, the index is increased by 1
@@ -164,32 +165,32 @@ impl<F: FieldExt> From<&Container<F>> for ContainerValueWord<F> {
         // the flattened length includes the header itself.
         let header = ValueHeader::new(simples.len() + 1, container.len());
         simples.insert(0, (vec![0u128], header.into()));
-        ContainerValueWord(simples)
+        ExtendedContainerValue(simples)
     }
 }
 
-impl<F: FieldExt> From<ContainerValueWord<F>> for Word<F> {
-    fn from(word: ContainerValueWord<F>) -> Word<F> {
-        Word(word.0)
+impl<F: FieldExt> From<ExtendedContainerValue<F>> for ExtendedValue<F> {
+    fn from(value: ExtendedContainerValue<F>) -> ExtendedValue<F> {
+        ExtendedValue(value.0)
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct LocatedWord<F: FieldExt>(pub Vec<(AddressPath<F>, SimpleValue<F>)>);
+pub struct LocatedExtendedValue<F: FieldExt>(pub Vec<(AddressPath<F>, SimpleValue<F>)>);
 
-impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for LocatedWord<F> {
-    fn from(located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>) -> LocatedWord<F> {
+impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for LocatedExtendedValue<F> {
+    fn from(located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>) -> LocatedExtendedValue<F> {
         let v_loc = Location::ValueLocation(located_value.0)
             .to_address_path()
             .into_inner();
-        let mut values = Word::from(located_value.1).0;
+        let mut values = ExtendedValue::from(located_value.1).0;
         values.iter_mut().for_each(|(p, _)| {
             let mut new_loc = v_loc.clone();
             new_loc.append(p);
             *p = new_loc;
         });
         // in flatten, returned address_path should be filled up.
-        LocatedWord(
+        LocatedExtendedValue(
             values
                 .into_iter()
                 .map(|(p, v)| (AddressPath::from(p).fill_up(), v))
@@ -198,8 +199,8 @@ impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for Loc
     }
 }
 
-impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for LocatedWord<F> {
-    fn from(located_value: LocatedValue<'v, IndexedLocation<F>, Value<F>>) -> LocatedWord<F> {
+impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for LocatedExtendedValue<F> {
+    fn from(located_value: LocatedValue<'v, IndexedLocation<F>, Value<F>>) -> LocatedExtendedValue<F> {
         // increase the sub index by 1, because position 0 is occupied by the container header.
         let sub_indexes = located_value
             .0
@@ -211,13 +212,13 @@ impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for L
             .to_address_path()
             .with_subpath(sub_indexes)
             .into_inner();
-        let mut values = Word::from(located_value.1).0;
+        let mut values = ExtendedValue::from(located_value.1).0;
         values.iter_mut().for_each(|(p, _)| {
             let mut new_loc = v_loc.clone();
             new_loc.append(p);
             *p = new_loc;
         });
-        LocatedWord(
+        LocatedExtendedValue(
             values
                 .into_iter()
                 .map(|(p, v)| (AddressPath::from(p).fill_up(), v))

--- a/movelang/src/flattened_value.rs
+++ b/movelang/src/flattened_value.rs
@@ -12,53 +12,53 @@ use std::marker::PhantomData;
 pub const LEN_OF_REFERENCE_VALUE: usize = 4; // header + DEPTH_OF_LOCATION_PATH + addr_ext
 pub const LEN_OF_SIMPLE_VALUE: usize = 2;
 
-/// To efficiently represent a complex value in the circuit, we defined 'ExtendedValue', an
-/// extended value representation. It starts with a value header carrying type information,
-/// followed by simple values flattened from the complex value.
+/// To efficiently represent a complex value in the circuit, we defined 'FlattenedValue'.
+/// It starts with a value header carrying type information, followed by simple values
+/// flattened from the complex value.
 #[derive(Clone, Debug)]
-pub struct ExtendedValue<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
+pub struct FlattenedValue<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
 
-impl<F: FieldExt> From<&Value<F>> for ExtendedValue<F> {
+impl<F: FieldExt> From<&Value<F>> for FlattenedValue<F> {
     fn from(value: &Value<F>) -> Self {
         match value {
-            Value::Invalid => ExtendedValue(vec![]), // TODO: Issue #52
+            Value::Invalid => FlattenedValue(vec![]), // TODO: Issue #52
             Value::U8(_) | Value::U64(_) | Value::U128(_) | Value::Bool(_) | Value::Address(_) => {
                 let simple = SimpleValue::try_from(value).expect("should not fail");
-                ExtendedSimpleValue::from(simple).into()
+                FlattenedSimpleValue::from(simple).into()
             }
-            Value::Container(c) => ExtendedContainerValue::from(c).into(),
+            Value::Container(c) => FlattenedContainerValue::from(c).into(),
             Value::GlobalRef(_) | Value::IndexedRef(_) | Value::LocalRef(_) => {
                 let reference = Reference::try_from(value).expect("should not fail");
-                ExtendedReferenceValue::from(reference).into()
+                FlattenedReferenceValue::from(reference).into()
             }
         }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct ExtendedSimpleValue<F: FieldExt>(pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE]);
+pub struct FlattenedSimpleValue<F: FieldExt>(pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE]);
 
-impl<F: FieldExt> From<SimpleValue<F>> for ExtendedSimpleValue<F> {
-    fn from(value: SimpleValue<F>) -> ExtendedSimpleValue<F> {
-        ExtendedSimpleValue([
+impl<F: FieldExt> From<SimpleValue<F>> for FlattenedSimpleValue<F> {
+    fn from(value: SimpleValue<F>) -> FlattenedSimpleValue<F> {
+        FlattenedSimpleValue([
             (vec![0u128], ValueHeader::default_for_simple().into()),
             (vec![1u128], value),
         ])
     }
 }
 
-impl<F: FieldExt> From<ExtendedSimpleValue<F>> for ExtendedValue<F> {
-    fn from(value: ExtendedSimpleValue<F>) -> ExtendedValue<F> {
-        ExtendedValue(value.0.to_vec())
+impl<F: FieldExt> From<FlattenedSimpleValue<F>> for FlattenedValue<F> {
+    fn from(value: FlattenedSimpleValue<F>) -> FlattenedValue<F> {
+        FlattenedValue(value.0.to_vec())
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct ExtendedReferenceValue<F: FieldExt>(
+pub struct FlattenedReferenceValue<F: FieldExt>(
     pub [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE],
 );
 
-impl<F: FieldExt> ExtendedReferenceValue<F> {
+impl<F: FieldExt> FlattenedReferenceValue<F> {
     fn fold(simples: Vec<(Vec<u128>, SimpleValue<F>)>) -> Self {
         let mut value: u128 = 0;
         for (i, (_, val)) in simples.iter().skip(DEPTH_OF_LOCATION_PATH + 1).enumerate() {
@@ -77,7 +77,7 @@ impl<F: FieldExt> ExtendedReferenceValue<F> {
 
         let (address_path, _) = new_ref_value.pop().expect("value should not be None.");
         new_ref_value.push((address_path, SimpleValue::u128(value)));
-        let extended_ref_value: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
+        let flattened_ref_value: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
             .try_into()
             .unwrap_or_else(|v: Vec<(Vec<u128>, SimpleValue<F>)>| {
                 panic!(
@@ -86,12 +86,12 @@ impl<F: FieldExt> ExtendedReferenceValue<F> {
                     v.len()
                 )
             });
-        ExtendedReferenceValue(extended_ref_value)
+        FlattenedReferenceValue(flattened_ref_value)
     }
 }
 
-impl<F: FieldExt> From<Reference<F>> for ExtendedReferenceValue<F> {
-    fn from(value: Reference<F>) -> ExtendedReferenceValue<F> {
+impl<F: FieldExt> From<Reference<F>> for FlattenedReferenceValue<F> {
+    fn from(value: Reference<F>) -> FlattenedReferenceValue<F> {
         let ref_paths = match value {
             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                 // NOTICE: here, we fillup address_path for reference, as reference needs fillup-ed values.
@@ -135,24 +135,24 @@ impl<F: FieldExt> From<Reference<F>> for ExtendedReferenceValue<F> {
             .enumerate()
             .map(|(i, v)| (vec![i as u128], v))
             .collect::<Vec<_>>();
-        ExtendedReferenceValue::fold(new_simples)
+        FlattenedReferenceValue::fold(new_simples)
     }
 }
 
-impl<F: FieldExt> From<ExtendedReferenceValue<F>> for ExtendedValue<F> {
-    fn from(value: ExtendedReferenceValue<F>) -> ExtendedValue<F> {
-        ExtendedValue(value.0.to_vec())
+impl<F: FieldExt> From<FlattenedReferenceValue<F>> for FlattenedValue<F> {
+    fn from(value: FlattenedReferenceValue<F>) -> FlattenedValue<F> {
+        FlattenedValue(value.0.to_vec())
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct ExtendedContainerValue<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
+pub struct FlattenedContainerValue<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
 
-impl<F: FieldExt> From<&Container<F>> for ExtendedContainerValue<F> {
-    fn from(container: &Container<F>) -> ExtendedContainerValue<F> {
+impl<F: FieldExt> From<&Container<F>> for FlattenedContainerValue<F> {
+    fn from(container: &Container<F>) -> FlattenedContainerValue<F> {
         let mut simples = Vec::new();
         for (idx, val) in container.0.borrow().iter().enumerate() {
-            let mut sub_values = ExtendedValue::from(val).0;
+            let mut sub_values = FlattenedValue::from(val).0;
             sub_values.iter_mut().for_each(|(v, _)| {
                 // prepend value idx to the sub-struct
                 // to leave a place for the header, the index is increased by 1
@@ -165,32 +165,32 @@ impl<F: FieldExt> From<&Container<F>> for ExtendedContainerValue<F> {
         // the flattened length includes the header itself.
         let header = ValueHeader::new(simples.len() + 1, container.len());
         simples.insert(0, (vec![0u128], header.into()));
-        ExtendedContainerValue(simples)
+        FlattenedContainerValue(simples)
     }
 }
 
-impl<F: FieldExt> From<ExtendedContainerValue<F>> for ExtendedValue<F> {
-    fn from(value: ExtendedContainerValue<F>) -> ExtendedValue<F> {
-        ExtendedValue(value.0)
+impl<F: FieldExt> From<FlattenedContainerValue<F>> for FlattenedValue<F> {
+    fn from(value: FlattenedContainerValue<F>) -> FlattenedValue<F> {
+        FlattenedValue(value.0)
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct LocatedExtendedValue<F: FieldExt>(pub Vec<(AddressPath<F>, SimpleValue<F>)>);
+pub struct LocatedFlattenedValue<F: FieldExt>(pub Vec<(AddressPath<F>, SimpleValue<F>)>);
 
-impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for LocatedExtendedValue<F> {
-    fn from(located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>) -> LocatedExtendedValue<F> {
+impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for LocatedFlattenedValue<F> {
+    fn from(located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>) -> LocatedFlattenedValue<F> {
         let v_loc = Location::ValueLocation(located_value.0)
             .to_address_path()
             .into_inner();
-        let mut values = ExtendedValue::from(located_value.1).0;
+        let mut values = FlattenedValue::from(located_value.1).0;
         values.iter_mut().for_each(|(p, _)| {
             let mut new_loc = v_loc.clone();
             new_loc.append(p);
             *p = new_loc;
         });
         // in flatten, returned address_path should be filled up.
-        LocatedExtendedValue(
+        LocatedFlattenedValue(
             values
                 .into_iter()
                 .map(|(p, v)| (AddressPath::from(p).fill_up(), v))
@@ -199,8 +199,8 @@ impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for Loc
     }
 }
 
-impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for LocatedExtendedValue<F> {
-    fn from(located_value: LocatedValue<'v, IndexedLocation<F>, Value<F>>) -> LocatedExtendedValue<F> {
+impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for LocatedFlattenedValue<F> {
+    fn from(located_value: LocatedValue<'v, IndexedLocation<F>, Value<F>>) -> LocatedFlattenedValue<F> {
         // increase the sub index by 1, because position 0 is occupied by the container header.
         let sub_indexes = located_value
             .0
@@ -212,13 +212,13 @@ impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for L
             .to_address_path()
             .with_subpath(sub_indexes)
             .into_inner();
-        let mut values = ExtendedValue::from(located_value.1).0;
+        let mut values = FlattenedValue::from(located_value.1).0;
         values.iter_mut().for_each(|(p, _)| {
             let mut new_loc = v_loc.clone();
             new_loc.append(p);
             *p = new_loc;
         });
-        LocatedExtendedValue(
+        LocatedFlattenedValue(
             values
                 .into_iter()
                 .map(|(p, v)| (AddressPath::from(p).fill_up(), v))

--- a/movelang/src/lib.rs
+++ b/movelang/src/lib.rs
@@ -9,4 +9,4 @@ pub mod state;
 pub mod type_transition;
 pub mod utility;
 pub mod value;
-pub mod extended_value;
+pub mod flattened_value;

--- a/movelang/src/lib.rs
+++ b/movelang/src/lib.rs
@@ -9,4 +9,4 @@ pub mod state;
 pub mod type_transition;
 pub mod utility;
 pub mod value;
-pub mod flattened_value;
+pub mod value_ext;

--- a/movelang/src/lib.rs
+++ b/movelang/src/lib.rs
@@ -9,4 +9,4 @@ pub mod state;
 pub mod type_transition;
 pub mod utility;
 pub mod value;
-pub mod word;
+pub mod extended_value;

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -4,7 +4,7 @@
 use crate::account_address::AccountAddress;
 use crate::utility::{convert_to_field, move_div, move_rem};
 use crate::utility::{MoveValue, MoveValueType};
-use crate::extended_value::{ExtendedContainerValue, ExtendedValue};
+use crate::flattened_value::{FlattenedContainerValue, FlattenedValue};
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Value as CircuitValue;
@@ -505,7 +505,7 @@ impl<F: FieldExt> VectorRef<F> {
                 let ref_val = l.read_ref()?;
                 match ref_val {
                     Value::Container(_) => {
-                        let flattened_value = ExtendedValue::from(&ref_val).0;
+                        let flattened_value = FlattenedValue::from(&ref_val).0;
                         let (_, header_value) =
                             flattened_value.first().expect("header should not be none");
                         res.push((
@@ -523,7 +523,7 @@ impl<F: FieldExt> VectorRef<F> {
             VectorRef::IndexedRef(i) => {
                 let value_loc = i.container_ref.location();
                 let mut cur_value = i.container_ref.container();
-                let flattened_value = ExtendedContainerValue::from(&cur_value).0;
+                let flattened_value = FlattenedContainerValue::from(&cur_value).0;
                 let (_, header_value) = flattened_value.first().expect("header should not be none");
                 res.push((Location::ValueLocation(value_loc), *header_value));
 
@@ -546,7 +546,7 @@ impl<F: FieldExt> VectorRef<F> {
                         sub_indexes: cur_sub_indexes.clone(),
                         value_loc,
                     };
-                    let flattened_value = ExtendedContainerValue::from(&cur_value).0;
+                    let flattened_value = FlattenedContainerValue::from(&cur_value).0;
                     let (_, header_value) =
                         flattened_value.first().expect("header should not be none");
                     res.push((Location::IndexedLocation(loc), *header_value));

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -4,7 +4,7 @@
 use crate::account_address::AccountAddress;
 use crate::utility::{convert_to_field, move_div, move_rem};
 use crate::utility::{MoveValue, MoveValueType};
-use crate::word::{ContainerValueWord, Word};
+use crate::extended_value::{ExtendedContainerValue, ExtendedValue};
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Value as CircuitValue;
@@ -505,7 +505,7 @@ impl<F: FieldExt> VectorRef<F> {
                 let ref_val = l.read_ref()?;
                 match ref_val {
                     Value::Container(_) => {
-                        let flattened_value = Word::from(&ref_val).0;
+                        let flattened_value = ExtendedValue::from(&ref_val).0;
                         let (_, header_value) =
                             flattened_value.first().expect("header should not be none");
                         res.push((
@@ -523,7 +523,7 @@ impl<F: FieldExt> VectorRef<F> {
             VectorRef::IndexedRef(i) => {
                 let value_loc = i.container_ref.location();
                 let mut cur_value = i.container_ref.container();
-                let flattened_value = ContainerValueWord::from(&cur_value).0;
+                let flattened_value = ExtendedContainerValue::from(&cur_value).0;
                 let (_, header_value) = flattened_value.first().expect("header should not be none");
                 res.push((Location::ValueLocation(value_loc), *header_value));
 
@@ -546,7 +546,7 @@ impl<F: FieldExt> VectorRef<F> {
                         sub_indexes: cur_sub_indexes.clone(),
                         value_loc,
                     };
-                    let flattened_value = ContainerValueWord::from(&cur_value).0;
+                    let flattened_value = ExtendedContainerValue::from(&cur_value).0;
                     let (_, header_value) =
                         flattened_value.first().expect("header should not be none");
                     res.push((Location::IndexedLocation(loc), *header_value));

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -4,7 +4,7 @@
 use crate::account_address::AccountAddress;
 use crate::utility::{convert_to_field, move_div, move_rem};
 use crate::utility::{MoveValue, MoveValueType};
-use crate::flattened_value::{FlattenedContainerValue, FlattenedValue};
+use crate::value_ext::{FlattenedContainerValue, FlattenedValue};
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Value as CircuitValue;

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -933,7 +933,7 @@ impl<F: FieldExt> Value<F> {
     }
 
     /// Cast the value into simple value if it's simple
-    /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
+    /// NOTICE: restrict access to `pub(self)` so that outside use flatten or flattened_value_len instead of this.
     pub fn cast_simple(&self) -> Option<SimpleValue<F>> {
         Some(match self {
             Value::U8(v) => SimpleValue::U8(*v),

--- a/movelang/src/value.rs
+++ b/movelang/src/value.rs
@@ -97,7 +97,7 @@ impl<F: FieldExt> AddressPath<F> {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum PrimitiveValue<F: FieldExt> {
+pub enum SimpleValue<F: FieldExt> {
     U8(U8<F>),
     U64(U64<F>),
     U128(U128<F>),
@@ -105,14 +105,14 @@ pub enum PrimitiveValue<F: FieldExt> {
     Address(AccountAddress<F>),
 }
 
-impl<F: FieldExt> From<PrimitiveValue<F>> for MoveValue {
-    fn from(value: PrimitiveValue<F>) -> MoveValue {
+impl<F: FieldExt> From<SimpleValue<F>> for MoveValue {
+    fn from(value: SimpleValue<F>) -> MoveValue {
         match value {
-            PrimitiveValue::U8(field) => MoveValue::U8(field.0.get_lower_128() as u8),
-            PrimitiveValue::U64(field) => MoveValue::U64(field.0.get_lower_128() as u64),
-            PrimitiveValue::U128(field) => MoveValue::U128(field.0.get_lower_128()),
-            PrimitiveValue::Bool(field) => MoveValue::Bool(field.0 == F::one()),
-            PrimitiveValue::Address(field) => {
+            SimpleValue::U8(field) => MoveValue::U8(field.0.get_lower_128() as u8),
+            SimpleValue::U64(field) => MoveValue::U64(field.0.get_lower_128() as u64),
+            SimpleValue::U128(field) => MoveValue::U128(field.0.get_lower_128()),
+            SimpleValue::Bool(field) => MoveValue::Bool(field.0 == F::one()),
+            SimpleValue::Address(field) => {
                 // FIXME: f -> bytes for address
                 let mut bytes = 0u128.to_be_bytes().to_vec();
                 bytes.append(&mut field.value().get_lower_128().to_be_bytes().to_vec());
@@ -498,7 +498,7 @@ impl<F: FieldExt> VectorRef<F> {
 
     pub fn current_and_parent_container_headers(
         &self,
-    ) -> VmResult<Vec<(Location<F>, PrimitiveValue<F>)>> {
+    ) -> VmResult<Vec<(Location<F>, SimpleValue<F>)>> {
         let mut res = Vec::new();
         match self {
             VectorRef::LocalRef(l) => {
@@ -784,47 +784,47 @@ impl<F: FieldExt> From<IndexedRef<F>> for VmResult<(IndexedLocation<F>, Value<F>
     }
 }
 
-impl<F: FieldExt> From<PrimitiveValue<F>> for Value<F> {
-    fn from(simple: PrimitiveValue<F>) -> Self {
+impl<F: FieldExt> From<SimpleValue<F>> for Value<F> {
+    fn from(simple: SimpleValue<F>) -> Self {
         match simple {
-            PrimitiveValue::U8(v) => Value::U8(v),
-            PrimitiveValue::U64(v) => Value::U64(v),
-            PrimitiveValue::U128(v) => Value::U128(v),
-            PrimitiveValue::Bool(v) => Value::Bool(v),
-            PrimitiveValue::Address(v) => Value::Address(v),
+            SimpleValue::U8(v) => Value::U8(v),
+            SimpleValue::U64(v) => Value::U64(v),
+            SimpleValue::U128(v) => Value::U128(v),
+            SimpleValue::Bool(v) => Value::Bool(v),
+            SimpleValue::Address(v) => Value::Address(v),
         }
     }
 }
 
-impl<F: FieldExt> TryFrom<&Value<F>> for PrimitiveValue<F> {
+impl<F: FieldExt> TryFrom<&Value<F>> for SimpleValue<F> {
     type Error = RuntimeError;
 
-    fn try_from(value: &Value<F>) -> VmResult<PrimitiveValue<F>> {
+    fn try_from(value: &Value<F>) -> VmResult<SimpleValue<F>> {
         match value {
-            Value::U8(v) => Ok(PrimitiveValue::U8(*v)),
-            Value::U64(v) => Ok(PrimitiveValue::U64(*v)),
-            Value::U128(v) => Ok(PrimitiveValue::U128(*v)),
-            Value::Bool(v) => Ok(PrimitiveValue::Bool(*v)),
-            Value::Address(v) => Ok(PrimitiveValue::Address(*v)),
+            Value::U8(v) => Ok(SimpleValue::U8(*v)),
+            Value::U64(v) => Ok(SimpleValue::U64(*v)),
+            Value::U128(v) => Ok(SimpleValue::U128(*v)),
+            Value::Bool(v) => Ok(SimpleValue::Bool(*v)),
+            Value::Address(v) => Ok(SimpleValue::Address(*v)),
             _ => Err(RuntimeError::new(StatusCode::TypeMismatch)),
         }
     }
 }
 
-impl<F: FieldExt> From<MoveValue> for PrimitiveValue<F> {
+impl<F: FieldExt> From<MoveValue> for SimpleValue<F> {
     fn from(value: MoveValue) -> Self {
         match value {
-            MoveValue::U8(v) => PrimitiveValue::u8(v),
-            MoveValue::U64(v) => PrimitiveValue::u64(v),
-            MoveValue::U128(v) => PrimitiveValue::u128(v),
-            MoveValue::Bool(v) => PrimitiveValue::bool(v),
-            MoveValue::Address(v) => PrimitiveValue::address(v.into()),
+            MoveValue::U8(v) => SimpleValue::u8(v),
+            MoveValue::U64(v) => SimpleValue::u64(v),
+            MoveValue::U128(v) => SimpleValue::u128(v),
+            MoveValue::Bool(v) => SimpleValue::bool(v),
+            MoveValue::Address(v) => SimpleValue::address(v.into()),
             _ => unimplemented!("not supported"),
         }
     }
 }
 
-impl<F: FieldExt> PrimitiveValue<F> {
+impl<F: FieldExt> SimpleValue<F> {
     pub fn bool(x: bool) -> Self {
         let value = if x { F::one() } else { F::zero() };
         Self::Bool(Bool(value))
@@ -934,13 +934,13 @@ impl<F: FieldExt> Value<F> {
 
     /// Cast the value into simple value if it's simple
     /// NOTICE: restrict access to `pub(self)` so that outside use flatten or word_element_count instead of this.
-    pub fn cast_simple(&self) -> Option<PrimitiveValue<F>> {
+    pub fn cast_simple(&self) -> Option<SimpleValue<F>> {
         Some(match self {
-            Value::U8(v) => PrimitiveValue::U8(*v),
-            Value::U64(v) => PrimitiveValue::U64(*v),
-            Value::U128(v) => PrimitiveValue::U128(*v),
-            Value::Bool(v) => PrimitiveValue::Bool(*v),
-            Value::Address(v) => PrimitiveValue::Address(*v),
+            Value::U8(v) => SimpleValue::U8(*v),
+            Value::U64(v) => SimpleValue::U64(*v),
+            Value::U128(v) => SimpleValue::U128(*v),
+            Value::Bool(v) => SimpleValue::Bool(*v),
+            Value::Address(v) => SimpleValue::Address(*v),
             _ => return None,
         })
     }

--- a/movelang/src/value_ext.rs
+++ b/movelang/src/value_ext.rs
@@ -2,7 +2,7 @@
 
 use crate::value::{
     AddressPath, Container, GlobalRef, IndexedLocation, IndexedRef, LocalRef, LocatedValue,
-    Location, SimpleValue, Reference, Value, ValueLocation, DEPTH_OF_LOCATION_PATH, U128,
+    Location, Reference, SimpleValue, Value, ValueLocation, DEPTH_OF_LOCATION_PATH, U128,
 };
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::plonk::Expression;
@@ -36,7 +36,9 @@ impl<F: FieldExt> From<&Value<F>> for FlattenedValue<F> {
 }
 
 #[derive(Clone, Debug)]
-pub struct FlattenedSimpleValue<F: FieldExt>(pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE]);
+pub struct FlattenedSimpleValue<F: FieldExt>(
+    pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE],
+);
 
 impl<F: FieldExt> From<SimpleValue<F>> for FlattenedSimpleValue<F> {
     fn from(value: SimpleValue<F>) -> FlattenedSimpleValue<F> {
@@ -77,15 +79,16 @@ impl<F: FieldExt> FlattenedReferenceValue<F> {
 
         let (address_path, _) = new_ref_value.pop().expect("value should not be None.");
         new_ref_value.push((address_path, SimpleValue::u128(value)));
-        let flattened_ref_value: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
-            .try_into()
-            .unwrap_or_else(|v: Vec<(Vec<u128>, SimpleValue<F>)>| {
-                panic!(
-                    "Expected a Vec of length {} but it was {}",
-                    LEN_OF_REFERENCE_VALUE,
-                    v.len()
-                )
-            });
+        let flattened_ref_value: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] =
+            new_ref_value
+                .try_into()
+                .unwrap_or_else(|v: Vec<(Vec<u128>, SimpleValue<F>)>| {
+                    panic!(
+                        "Expected a Vec of length {} but it was {}",
+                        LEN_OF_REFERENCE_VALUE,
+                        v.len()
+                    )
+                });
         FlattenedReferenceValue(flattened_ref_value)
     }
 }
@@ -178,8 +181,12 @@ impl<F: FieldExt> From<FlattenedContainerValue<F>> for FlattenedValue<F> {
 #[derive(Clone, Debug)]
 pub struct LocatedFlattenedValue<F: FieldExt>(pub Vec<(AddressPath<F>, SimpleValue<F>)>);
 
-impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for LocatedFlattenedValue<F> {
-    fn from(located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>) -> LocatedFlattenedValue<F> {
+impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>>
+    for LocatedFlattenedValue<F>
+{
+    fn from(
+        located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>,
+    ) -> LocatedFlattenedValue<F> {
         let v_loc = Location::ValueLocation(located_value.0)
             .to_address_path()
             .into_inner();
@@ -199,8 +206,12 @@ impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for Loc
     }
 }
 
-impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>> for LocatedFlattenedValue<F> {
-    fn from(located_value: LocatedValue<'v, IndexedLocation<F>, Value<F>>) -> LocatedFlattenedValue<F> {
+impl<'v, F: FieldExt> From<LocatedValue<'v, IndexedLocation<F>, Value<F>>>
+    for LocatedFlattenedValue<F>
+{
+    fn from(
+        located_value: LocatedValue<'v, IndexedLocation<F>, Value<F>>,
+    ) -> LocatedFlattenedValue<F> {
         // increase the sub index by 1, because position 0 is occupied by the container header.
         let sub_indexes = located_value
             .0

--- a/movelang/src/word.rs
+++ b/movelang/src/word.rs
@@ -2,7 +2,7 @@
 
 use crate::value::{
     AddressPath, Container, GlobalRef, IndexedLocation, IndexedRef, LocalRef, LocatedValue,
-    Location, PrimitiveValue, Reference, Value, ValueLocation, DEPTH_OF_LOCATION_PATH, U128,
+    Location, SimpleValue, Reference, Value, ValueLocation, DEPTH_OF_LOCATION_PATH, U128,
 };
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::plonk::Expression;
@@ -15,14 +15,14 @@ pub const LEN_OF_SIMPLE_VALUE: usize = 2;
 /// To efficiently represent a complex value in the circuit, we defined 'word', a uniform
 /// flattened value representation, to flatten the complex value into simple values.
 #[derive(Clone, Debug)]
-pub struct Word<F: FieldExt>(pub Vec<(Vec<u128>, PrimitiveValue<F>)>);
+pub struct Word<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
 
 impl<F: FieldExt> From<&Value<F>> for Word<F> {
     fn from(value: &Value<F>) -> Self {
         match value {
             Value::Invalid => Word(vec![]), // TODO: Issue #52
             Value::U8(_) | Value::U64(_) | Value::U128(_) | Value::Bool(_) | Value::Address(_) => {
-                let simple = PrimitiveValue::try_from(value).expect("should not fail");
+                let simple = SimpleValue::try_from(value).expect("should not fail");
                 SimpleValueWord::from(simple).into()
             }
             Value::Container(c) => ContainerValueWord::from(c).into(),
@@ -35,10 +35,10 @@ impl<F: FieldExt> From<&Value<F>> for Word<F> {
 }
 
 #[derive(Clone, Debug)]
-pub struct SimpleValueWord<F: FieldExt>(pub [(Vec<u128>, PrimitiveValue<F>); LEN_OF_SIMPLE_VALUE]);
+pub struct SimpleValueWord<F: FieldExt>(pub [(Vec<u128>, SimpleValue<F>); LEN_OF_SIMPLE_VALUE]);
 
-impl<F: FieldExt> From<PrimitiveValue<F>> for SimpleValueWord<F> {
-    fn from(value: PrimitiveValue<F>) -> SimpleValueWord<F> {
+impl<F: FieldExt> From<SimpleValue<F>> for SimpleValueWord<F> {
+    fn from(value: SimpleValue<F>) -> SimpleValueWord<F> {
         SimpleValueWord([
             (vec![0u128], ValueHeader::default_for_simple().into()),
             (vec![1u128], value),
@@ -54,11 +54,11 @@ impl<F: FieldExt> From<SimpleValueWord<F>> for Word<F> {
 
 #[derive(Clone, Debug)]
 pub struct ReferenceValueWord<F: FieldExt>(
-    pub [(Vec<u128>, PrimitiveValue<F>); LEN_OF_REFERENCE_VALUE],
+    pub [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE],
 );
 
 impl<F: FieldExt> ReferenceValueWord<F> {
-    fn fold(word: Vec<(Vec<u128>, PrimitiveValue<F>)>) -> Self {
+    fn fold(word: Vec<(Vec<u128>, SimpleValue<F>)>) -> Self {
         let mut value: u128 = 0;
         for (i, (_, val)) in word.iter().skip(DEPTH_OF_LOCATION_PATH + 1).enumerate() {
             // fold addr_ext into one cell
@@ -75,10 +75,10 @@ impl<F: FieldExt> ReferenceValueWord<F> {
             .collect::<Vec<_>>();
 
         let (address_path, _) = new_ref_value.pop().expect("value should not be None.");
-        new_ref_value.push((address_path, PrimitiveValue::u128(value)));
-        let new_word: [(Vec<u128>, PrimitiveValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
+        new_ref_value.push((address_path, SimpleValue::u128(value)));
+        let new_word: [(Vec<u128>, SimpleValue<F>); LEN_OF_REFERENCE_VALUE] = new_ref_value
             .try_into()
-            .unwrap_or_else(|v: Vec<(Vec<u128>, PrimitiveValue<F>)>| {
+            .unwrap_or_else(|v: Vec<(Vec<u128>, SimpleValue<F>)>| {
                 panic!(
                     "Expected a Vec of length {} but it was {}",
                     LEN_OF_REFERENCE_VALUE,
@@ -125,7 +125,7 @@ impl<F: FieldExt> From<Reference<F>> for ReferenceValueWord<F> {
 
         let mut simples = ref_paths
             .into_iter()
-            .map(|v| PrimitiveValue::U128(U128(F::from_u128(v))))
+            .map(|v| SimpleValue::U128(U128(F::from_u128(v))))
             .collect::<Vec<_>>();
 
         simples.insert(0, ValueHeader::default_for_ref_val().into());
@@ -145,7 +145,7 @@ impl<F: FieldExt> From<ReferenceValueWord<F>> for Word<F> {
 }
 
 #[derive(Clone, Debug)]
-pub struct ContainerValueWord<F: FieldExt>(pub Vec<(Vec<u128>, PrimitiveValue<F>)>);
+pub struct ContainerValueWord<F: FieldExt>(pub Vec<(Vec<u128>, SimpleValue<F>)>);
 
 impl<F: FieldExt> From<&Container<F>> for ContainerValueWord<F> {
     fn from(container: &Container<F>) -> ContainerValueWord<F> {
@@ -175,7 +175,7 @@ impl<F: FieldExt> From<ContainerValueWord<F>> for Word<F> {
 }
 
 #[derive(Clone, Debug)]
-pub struct LocatedWord<F: FieldExt>(pub Vec<(AddressPath<F>, PrimitiveValue<F>)>);
+pub struct LocatedWord<F: FieldExt>(pub Vec<(AddressPath<F>, SimpleValue<F>)>);
 
 impl<'v, F: FieldExt> From<LocatedValue<'v, ValueLocation<F>, Value<F>>> for LocatedWord<F> {
     fn from(located_value: LocatedValue<'v, ValueLocation<F>, Value<F>>) -> LocatedWord<F> {
@@ -279,9 +279,9 @@ impl<F: FieldExt> ValueHeader<F> {
     }
 }
 
-impl<F: FieldExt> From<ValueHeader<F>> for PrimitiveValue<F> {
-    fn from(value: ValueHeader<F>) -> PrimitiveValue<F> {
-        PrimitiveValue::U128(U128(value.value()))
+impl<F: FieldExt> From<ValueHeader<F>> for SimpleValue<F> {
+    fn from(value: ValueHeader<F>) -> SimpleValue<F> {
+        SimpleValue::U128(U128(value.value()))
     }
 }
 

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -13,7 +13,7 @@ use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
 use movelang::value::{SimpleValue, Value};
-use movelang::extended_value::ValueHeader;
+use movelang::flattened_value::ValueHeader;
 
 #[test]
 fn test_fake_rw_operation() -> VmResult<()> {

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -13,7 +13,7 @@ use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
 use movelang::value::{SimpleValue, Value};
-use movelang::flattened_value::ValueHeader;
+use movelang::value_ext::ValueHeader;
 
 #[test]
 fn test_fake_rw_operation() -> VmResult<()> {

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -12,7 +12,7 @@ use halo2_proofs::halo2curves::pasta::Fp;
 use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
-use movelang::value::{PrimitiveValue, Value};
+use movelang::value::{SimpleValue, Value};
 use movelang::word::ValueHeader;
 
 #[test]
@@ -180,7 +180,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     let rw_op_1 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: WRITE,
         gc: 1,
@@ -196,7 +196,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     let rw_op_3 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: WRITE,
         gc: 3,
@@ -212,7 +212,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     let rw_op_5 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: READ,
         gc: 5,
@@ -228,7 +228,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     let rw_op_7 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: READ,
         gc: 7,
@@ -244,7 +244,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     let rw_op_9 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: WRITE,
         gc: 9,
@@ -260,7 +260,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
     let rw_op_11 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: READ,
         gc: 11,
@@ -269,7 +269,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         frame_index: 0,
         index: 0,
         address_ext: 0,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: WRITE,
         gc: 12,

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -13,7 +13,7 @@ use logger::prelude::*;
 use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
 use movelang::value::{SimpleValue, Value};
-use movelang::word::ValueHeader;
+use movelang::extended_value::ValueHeader;
 
 #[test]
 fn test_fake_rw_operation() -> VmResult<()> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
@@ -13,7 +13,7 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowField<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
@@ -13,7 +13,7 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowField<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_field.rs
@@ -13,7 +13,7 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowField<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
@@ -20,8 +20,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
-use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct BorrowGlobal<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
@@ -20,8 +20,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
-use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct BorrowGlobal<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
@@ -3,7 +3,7 @@
 use crate::chips::execution_chip::instructions::common::generic_gadget::GenericTypeGadget;
 use crate::chips::execution_chip::instructions::common::reference_value_gadget::RefValGadget;
 use crate::chips::execution_chip::instructions::common::simple_value_gadget::SimpleValueGadget;
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -26,7 +26,7 @@ use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 #[derive(Clone, Debug)]
 pub struct BorrowGlobal<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {
     account_address: SimpleValueGadget<F>,
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
     ref_val: RefValGadget<F>,
     type_cells: Option<GenericTypeGadget<F>>,
 }
@@ -230,7 +230,7 @@ impl<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> InstructionGadget<F>
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         // alloc cell
         let account_address = SimpleValueGadget::construct(cb);
-        let value = WordGadget::construct(cb);
+        let value = ValueGadget::construct(cb);
         let ref_val = RefValGadget::construct(cb);
         let type_cells = if GENERIC {
             let instantiation_index = cb.curr.cells.auxiliary_1.expr();

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
@@ -177,7 +177,7 @@ impl<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> InstructionGadget<F>
     ) -> Result<(), Error> {
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
-        let word_elem_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
@@ -188,13 +188,13 @@ impl<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> InstructionGadget<F>
             offset,
             rw_operations,
             step.gc + LEN_OF_SIMPLE_VALUE,
-            word_elem_num,
+            flattened_value_len,
         )?;
         self.ref_val.assign(
             region,
             offset,
             rw_operations,
-            step.gc + LEN_OF_SIMPLE_VALUE + word_elem_num,
+            step.gc + LEN_OF_SIMPLE_VALUE + flattened_value_len,
         )?;
 
         if GENERIC {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_global.rs
@@ -20,8 +20,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
-use movelang::word::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct BorrowGlobal<const MUTABLE: bool, const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::word::ValueHeader;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::ValueHeader;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowLoc<const MUTABLE: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::extended_value::ValueHeader;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::ValueHeader;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowLoc<const MUTABLE: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
@@ -39,9 +39,9 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
             + 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + word_element_num.clone()
+            + flattened_value_len.clone()
             + (LEN_OF_REFERENCE_VALUE as u64).expr();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
@@ -56,7 +56,7 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
             ("function index", func_index),
         ]);
 
-        self.value.configure(cb, word_element_num.clone());
+        self.value.configure(cb, flattened_value_len.clone());
         self.ref_val.configure(cb);
 
         for (i, _) in self.value.cells.word.iter().enumerate() {
@@ -80,7 +80,7 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
             cb.add_lookup(
                 "borrow_local(stack push ref_val)",
                 RWLookup::stack_push(
-                    cells.gc.expression.clone() + word_element_num.clone() + (i as u64).expr(),
+                    cells.gc.expression.clone() + flattened_value_len.clone() + (i as u64).expr(),
                     cells.stack_size.expression.clone(),
                     (i as u64).expr(),
                     item.expression.clone(),
@@ -122,15 +122,15 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
         self.value
-            .assign(region, offset, rw_operations, step.gc, word_element_num)?;
+            .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
 
         self.ref_val
-            .assign(region, offset, rw_operations, step.gc + word_element_num)?;
+            .assign(region, offset, rw_operations, step.gc + flattened_value_len)?;
         Ok(())
     }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::flattened_value::ValueHeader;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::ValueHeader;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowLoc<const MUTABLE: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/borrow_loc.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::common::reference_value_gadget::RefValGadget;
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -19,7 +19,7 @@ use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct BorrowLoc<const MUTABLE: bool, F: FieldExt> {
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
     ref_val: RefValGadget<F>,
 }
 
@@ -136,7 +136,7 @@ impl<const MUTABLE: bool, F: FieldExt> InstructionGadget<F> for BorrowLoc<MUTABL
 
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         // alloc cell
-        let value = WordGadget::construct(cb);
+        let value = ValueGadget::construct(cb);
         let ref_val = RefValGadget::construct(cb);
 
         Self { value, ref_val }

--- a/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
@@ -13,7 +13,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::word::ValueHeader;
+use movelang::extended_value::ValueHeader;
 
 #[derive(Clone, Debug)]
 pub struct BrFalse<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
@@ -13,7 +13,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::flattened_value::ValueHeader;
+use movelang::value_ext::ValueHeader;
 
 #[derive(Clone, Debug)]
 pub struct BrFalse<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_false.rs
@@ -13,7 +13,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::extended_value::ValueHeader;
+use movelang::flattened_value::ValueHeader;
 
 #[derive(Clone, Debug)]
 pub struct BrFalse<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
@@ -13,7 +13,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::extended_value::ValueHeader;
+use movelang::flattened_value::ValueHeader;
 
 #[derive(Clone, Debug)]
 pub struct BrTrue<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
@@ -13,7 +13,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::flattened_value::ValueHeader;
+use movelang::value_ext::ValueHeader;
 
 #[derive(Clone, Debug)]
 pub struct BrTrue<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/br_true.rs
@@ -13,7 +13,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::word::ValueHeader;
+use movelang::extended_value::ValueHeader;
 
 #[derive(Clone, Debug)]
 pub struct BrTrue<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/call.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/call.rs
@@ -121,8 +121,10 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Call<GENERIC, F>
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
         // assign arg_num
-        let _aux_value = Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
-        let _func_handle_idx = Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
+        let _aux_value =
+            Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
+        let _func_handle_idx =
+            Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
         let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;

--- a/vm-circuit/src/chips/execution_chip/instructions/call.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/call.rs
@@ -49,9 +49,9 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Call<GENERIC, F>
             - cb.next.cells.frame_index.expression.clone()
             + 1.expr();
         // each argument has 2 rw operations
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + word_element_num.clone() * 2.expr();
+            + flattened_value_len.clone() * 2.expr();
         cb.add_constraints(vec![
             ("Call pc", pc_expr),
             ("Call stack_size", stack_size_expr),
@@ -76,7 +76,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Call<GENERIC, F>
                     "call(locals write)",
                     RWLookup {
                         gc: cells.gc.expression.clone()
-                            + word_element_num.clone()
+                            + flattened_value_len.clone()
                             + (i as u64).expr(),
                         rw_target: (RWTarget::Locals as u64).expr(),
                         rw: (RW::WRITE as u64).expr(),
@@ -121,23 +121,11 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Call<GENERIC, F>
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
         // assign arg_num
-        let aux_value = step.auxiliary_1.as_ref().ok_or_else(|| {
-            error!("auxiliary_1 is None");
-            Error::Synthesis
-        })?;
-        cells
-            .auxiliary_1
-            .assign(region, offset, aux_value.value())?;
-
-        let func_handle_idx = step.auxiliary_2.as_ref().ok_or_else(|| {
-            error!("auxiliary_2 is None");
-            Error::Synthesis
-        })?;
-        cells
-            .auxiliary_2
-            .assign(region, offset, func_handle_idx.value())?;
-
-        let word_element_num = Word::get_word_element_num(region, offset, step, cells)?;
+        let _aux_value = Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
+        let _func_handle_idx = Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
+        let flattened_value_len =
+            Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
+                .get_lower_128() as usize;
 
         let word = Word {
             word: self.word_a.clone(),
@@ -151,7 +139,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Call<GENERIC, F>
             &word,
             &self.word_address,
             step.gc,
-            word_element_num,
+            flattened_value_len,
             RW::WRITE,
         )?;
         if GENERIC {

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -594,32 +594,6 @@ pub struct RefVal<F: FieldExt> {
 }
 
 impl<F: FieldExt> Word<F> {
-    pub fn get_word_element_num(
-        region: &mut Region<'_, F>,
-        offset: usize,
-        step: &ExecutionStep<F>,
-        cells: &StepChipCells<F>,
-    ) -> VmResult<usize> {
-        let word_element_num = step.auxiliary_3.as_ref().ok_or_else(|| {
-            error!("auxiliary_3 is None");
-            Error::Synthesis
-        })?;
-
-        // assign to cells.auxiliary_3
-        cells
-            .auxiliary_3
-            .assign(region, offset, word_element_num.value())?;
-
-        // return word_element_num
-        Ok(word_element_num
-            .value()
-            .ok_or_else(|| {
-                error!("failed to get word_element_num");
-                Error::Synthesis
-            })?
-            .get_lower_128() as usize)
-    }
-
     pub fn assign_step_value(
         region: &mut Region<'_, F>,
         offset: usize,
@@ -675,9 +649,9 @@ impl<F: FieldExt> Word<F> {
         rw_operations: &RWOperations<F>,
         cells: &Word<F>,
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
     ) -> Result<(), Error> {
-        for (i, _) in cells.word.iter().enumerate().take(word_element_num) {
+        for (i, _) in cells.word.iter().enumerate().take(flattened_value_len) {
             let op = rw_operations.0.get(op_index + i).ok_or(Error::Synthesis)?;
             cells.word[i].assign(region, offset, op.value().value())?;
             cells.word_mask[i].assign(region, offset, Some(F::zero()))?;
@@ -688,7 +662,7 @@ impl<F: FieldExt> Word<F> {
             )?;
         }
 
-        for (i, _) in cells.word.iter().enumerate().skip(word_element_num) {
+        for (i, _) in cells.word.iter().enumerate().skip(flattened_value_len) {
             cells.word_mask[i].assign(region, offset, Some(F::one()))?;
             cells.word_addr_ext[i].assign(region, offset, Some(F::zero()))?;
         }
@@ -704,10 +678,10 @@ impl<F: FieldExt> Word<F> {
         rw_operations: &RWOperations<F>,
         cells: &Word<F>,
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
         capacity: usize,
     ) -> Result<(), Error> {
-        for i in 0..word_element_num {
+        for i in 0..flattened_value_len {
             let op = rw_operations.0.get(op_index + i).ok_or(Error::Synthesis)?;
             cells.word[i].assign(region, offset, op.value().value())?;
             cells.word_mask[i].assign(region, offset, Some(F::zero()))?;
@@ -718,9 +692,9 @@ impl<F: FieldExt> Word<F> {
             )?;
         }
 
-        debug_assert!(word_element_num <= capacity);
+        debug_assert!(flattened_value_len <= capacity);
 
-        for i in word_element_num..capacity {
+        for i in flattened_value_len..capacity {
             cells.word_mask[i].assign(region, offset, Some(F::one()))?;
             cells.word_addr_ext[i].assign(region, offset, Some(F::zero()))?;
         }
@@ -737,7 +711,7 @@ impl<F: FieldExt> Word<F> {
         cells: &Word<F>,
         word_address: &[Cell<F>],
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
     ) -> Result<(), Error> {
         // leave word[0] empty
         cells.word_mask[0].assign(region, offset, Some(F::one()))?;
@@ -747,7 +721,7 @@ impl<F: FieldExt> Word<F> {
         for (i, item) in word_address
             .iter()
             .enumerate()
-            .take(word_element_num + 1)
+            .take(flattened_value_len + 1)
             .skip(1)
         {
             let op = rw_operations
@@ -764,7 +738,7 @@ impl<F: FieldExt> Word<F> {
             item.assign(region, offset, Some(F::from(op.address() as u64)))?;
         }
 
-        for (i, item) in word_address.iter().enumerate().skip(word_element_num + 1) {
+        for (i, item) in word_address.iter().enumerate().skip(flattened_value_len + 1) {
             cells.word_mask[i].assign(region, offset, Some(F::one()))?;
             cells.word_addr_ext[i].assign(region, offset, Some(F::zero()))?;
             item.assign(region, offset, Some(F::zero()))?;
@@ -781,14 +755,14 @@ impl<F: FieldExt> Word<F> {
         cells: &Word<F>,
         word_address: &[Cell<F>],
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
         filter: RW,
     ) -> Result<(), Error> {
         let mut index = op_index;
         let mut op = rw_operations.0.get(index).ok_or(Error::Synthesis)?;
         let mut i = 0;
 
-        while i < word_element_num {
+        while i < flattened_value_len {
             if op.rw() == filter {
                 cells.word[i].assign(region, offset, op.value().value())?;
                 cells.word_mask[i].assign(region, offset, Some(F::zero()))?;
@@ -806,7 +780,7 @@ impl<F: FieldExt> Word<F> {
             op = rw_operations.0.get(index).ok_or(Error::Synthesis)?;
         }
 
-        for (i, item) in word_address.iter().enumerate().skip(word_element_num) {
+        for (i, item) in word_address.iter().enumerate().skip(flattened_value_len) {
             cells.word_mask[i].assign(region, offset, Some(F::one()))?;
             cells.word_addr_ext[i].assign(region, offset, Some(F::zero()))?;
             item.assign(region, offset, Some(F::zero()))?;
@@ -822,15 +796,15 @@ impl<F: FieldExt> Word<F> {
         rw_operations: &RWOperations<F>,
         cells: &RefVal<F>,
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
     ) -> Result<(), Error> {
-        for i in 0..word_element_num.min(LEN_OF_REFERENCE_VALUE) {
+        for i in 0..flattened_value_len.min(LEN_OF_REFERENCE_VALUE) {
             let op = rw_operations.0.get(op_index + i).ok_or(Error::Synthesis)?;
             cells.ref_val[i].assign(region, offset, op.value().value())?;
             cells.ref_val_mask[i].assign(region, offset, Some(F::zero()))?;
         }
 
-        for i in word_element_num..LEN_OF_REFERENCE_VALUE {
+        for i in flattened_value_len..LEN_OF_REFERENCE_VALUE {
             cells.ref_val_mask[i].assign(region, offset, Some(F::one()))?;
         }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -19,7 +19,7 @@ use logger::prelude::*;
 use movelang::value::{
     Value, DEPTH_OF_LOCATION_PATH, NUM_OF_BYTES_U128, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
 };
-use movelang::word::{ValueHeader, LEN_OF_REFERENCE_VALUE};
+use movelang::extended_value::{ValueHeader, LEN_OF_REFERENCE_VALUE};
 use std::convert::TryInto;
 use std::marker::PhantomData;
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -26,7 +26,7 @@ use std::marker::PhantomData;
 pub(crate) mod generic_gadget;
 pub(crate) mod reference_value_gadget;
 pub(crate) mod simple_value_gadget;
-pub(crate) mod word_gadget;
+pub(crate) mod value_gadget;
 
 #[derive(Clone, Debug)]
 pub struct BinaryOp<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -19,7 +19,7 @@ use logger::prelude::*;
 use movelang::value::{
     Value, DEPTH_OF_LOCATION_PATH, NUM_OF_BYTES_U128, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
 };
-use movelang::flattened_value::{ValueHeader, LEN_OF_REFERENCE_VALUE};
+use movelang::value_ext::{ValueHeader, LEN_OF_REFERENCE_VALUE};
 use std::convert::TryInto;
 use std::marker::PhantomData;
 
@@ -738,7 +738,11 @@ impl<F: FieldExt> Word<F> {
             item.assign(region, offset, Some(F::from(op.address() as u64)))?;
         }
 
-        for (i, item) in word_address.iter().enumerate().skip(flattened_value_len + 1) {
+        for (i, item) in word_address
+            .iter()
+            .enumerate()
+            .skip(flattened_value_len + 1)
+        {
             cells.word_mask[i].assign(region, offset, Some(F::one()))?;
             cells.word_addr_ext[i].assign(region, offset, Some(F::zero()))?;
             item.assign(region, offset, Some(F::zero()))?;

--- a/vm-circuit/src/chips/execution_chip/instructions/common.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common.rs
@@ -19,7 +19,7 @@ use logger::prelude::*;
 use movelang::value::{
     Value, DEPTH_OF_LOCATION_PATH, NUM_OF_BYTES_U128, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
 };
-use movelang::extended_value::{ValueHeader, LEN_OF_REFERENCE_VALUE};
+use movelang::flattened_value::{ValueHeader, LEN_OF_REFERENCE_VALUE};
 use std::convert::TryInto;
 use std::marker::PhantomData;
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common/reference_value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/reference_value_gadget.rs
@@ -8,7 +8,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use logger::error;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 use std::convert::TryInto;
 use std::ops::Index;
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common/reference_value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/reference_value_gadget.rs
@@ -8,7 +8,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use logger::error;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 use std::convert::TryInto;
 use std::ops::Index;
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common/reference_value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/reference_value_gadget.rs
@@ -8,7 +8,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use logger::error;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 use std::convert::TryInto;
 use std::ops::Index;
 

--- a/vm-circuit/src/chips/execution_chip/instructions/common/simple_value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/simple_value_gadget.rs
@@ -8,7 +8,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use logger::prelude::*;
-use movelang::word::LEN_OF_SIMPLE_VALUE;
+use movelang::extended_value::LEN_OF_SIMPLE_VALUE;
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]

--- a/vm-circuit/src/chips/execution_chip/instructions/common/simple_value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/simple_value_gadget.rs
@@ -8,7 +8,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use logger::prelude::*;
-use movelang::extended_value::LEN_OF_SIMPLE_VALUE;
+use movelang::flattened_value::LEN_OF_SIMPLE_VALUE;
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]

--- a/vm-circuit/src/chips/execution_chip/instructions/common/simple_value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/simple_value_gadget.rs
@@ -8,7 +8,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::{Error, Expression};
 use logger::prelude::*;
-use movelang::flattened_value::LEN_OF_SIMPLE_VALUE;
+use movelang::value_ext::LEN_OF_SIMPLE_VALUE;
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]

--- a/vm-circuit/src/chips/execution_chip/instructions/common/value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/value_gadget.rs
@@ -11,13 +11,13 @@ use halo2_proofs::plonk::{Error, Expression};
 use logger::error;
 
 #[derive(Clone, Debug)]
-pub(crate) struct WordCells<F> {
+pub(crate) struct GadgetCells<F> {
     pub(crate) word: Vec<Cell<F>>,
     pub(crate) word_mask: Vec<Cell<F>>,
     pub(crate) word_addr_ext: Vec<Cell<F>>,
 }
 
-impl<F: FieldExt> WordCells<F> {
+impl<F: FieldExt> GadgetCells<F> {
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         let word_cap = word_capacity();
 
@@ -69,15 +69,15 @@ impl<F: FieldExt> WordCells<F> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct WordGadget<F> {
-    pub(crate) cells: WordCells<F>,
+pub(crate) struct ValueGadget<F> {
+    pub(crate) cells: GadgetCells<F>,
     pub(crate) header_cells: HeaderCells<F>,
 }
 
-impl<F: FieldExt> WordGadget<F> {
+impl<F: FieldExt> ValueGadget<F> {
     pub(crate) fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         Self {
-            cells: WordCells::construct(cb),
+            cells: GadgetCells::construct(cb),
             header_cells: HeaderCells::construct(cb),
         }
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/common/value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/value_gadget.rs
@@ -39,27 +39,27 @@ impl<F: FieldExt> GadgetCells<F> {
         offset: usize,
         rw_operations: &RWOperations<F>,
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
     ) -> Result<(), Error> {
-        if word_element_num > word_capacity() {
+        if flattened_value_len > word_capacity() {
             // TODO: a better place to do word cap check is in "fn from(value: &Value<F>) -> Word<F>"
             // but we have no capacity set at the moment. Considering move word.rs to the folder "witness".
             error!(
                 "word element num is {:?}, exceeds word capacity {:?}",
-                word_element_num,
+                flattened_value_len,
                 word_capacity()
             );
             return Err(Error::Synthesis);
         }
 
-        for (i, _) in self.word.iter().enumerate().take(word_element_num) {
+        for (i, _) in self.word.iter().enumerate().take(flattened_value_len) {
             let op = rw_operations.0.get(op_index + i).ok_or(Error::Synthesis)?;
             self.word[i].assign(region, offset, op.value().value())?;
             self.word_mask[i].assign(region, offset, Some(F::zero()))?;
             self.word_addr_ext[i].assign(region, offset, Some(F::from(op.address_ext() as u64)))?;
         }
 
-        for (i, _) in self.word.iter().enumerate().skip(word_element_num) {
+        for (i, _) in self.word.iter().enumerate().skip(flattened_value_len) {
             self.word_mask[i].assign(region, offset, Some(F::one()))?;
             self.word_addr_ext[i].assign(region, offset, Some(F::zero()))?;
         }
@@ -87,7 +87,7 @@ impl<F: FieldExt> ValueGadget<F> {
         offset: usize,
         rw_operations: &RWOperations<F>,
         op_index: usize,
-        word_element_num: usize,
+        flattened_value_len: usize,
     ) -> Result<(), Error> {
         let op = rw_operations.0.get(op_index).ok_or(Error::Synthesis)?;
         let header_value = op.value().value().ok_or_else(|| {
@@ -96,12 +96,12 @@ impl<F: FieldExt> ValueGadget<F> {
         })?;
 
         self.cells
-            .assign(region, offset, rw_operations, op_index, word_element_num)?;
+            .assign(region, offset, rw_operations, op_index, flattened_value_len)?;
         self.header_cells.assign(region, offset, header_value)?;
         Ok(())
     }
 
-    pub(crate) fn configure(&self, cb: &mut ConstraintBuilder<F>, word_elem_num: Expression<F>) {
+    pub(crate) fn configure(&self, cb: &mut ConstraintBuilder<F>, flattened_value_len: Expression<F>) {
         // check word header
         self.constrain_header(cb, self.cells.word[0].expression.clone());
 
@@ -113,7 +113,7 @@ impl<F: FieldExt> ValueGadget<F> {
         );
 
         // check word element number
-        let constraint = word_elem_num - self.header_cells.flattened_len.expression.clone();
+        let constraint = flattened_value_len - self.header_cells.flattened_len.expression.clone();
         cb.add_constraint("check word element number", constraint);
 
         // TODO: check addr_ext

--- a/vm-circuit/src/chips/execution_chip/instructions/common/value_gadget.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/common/value_gadget.rs
@@ -101,7 +101,11 @@ impl<F: FieldExt> ValueGadget<F> {
         Ok(())
     }
 
-    pub(crate) fn configure(&self, cb: &mut ConstraintBuilder<F>, flattened_value_len: Expression<F>) {
+    pub(crate) fn configure(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        flattened_value_len: Expression<F>,
+    ) {
         // check word header
         self.constrain_header(cb, self.cells.word[0].expression.clone());
 

--- a/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -16,7 +16,7 @@ use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub struct CopyLoc<F: FieldExt> {
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
@@ -94,7 +94,7 @@ impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
     }
 
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
-        let value = WordGadget::construct(cb);
+        let value = ValueGadget::construct(cb);
 
         Self { value }
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/copy_loc.rs
@@ -30,9 +30,9 @@ impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
             + 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + 2.expr() * word_element_num.clone();
+            + 2.expr() * flattened_value_len.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -46,7 +46,7 @@ impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
             ("function index", func_index),
         ]);
 
-        self.value.configure(cb, word_element_num.clone());
+        self.value.configure(cb, flattened_value_len.clone());
 
         for (i, _) in self.value.cells.word.iter().enumerate() {
             let (read, write) = RWLookup::locals_copy(
@@ -56,7 +56,7 @@ impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
                 cells.stack_size.expression.clone(),
                 self.value.cells.word_addr_ext[i].expression.clone(),
                 self.value.cells.word[i].expression.clone(),
-                word_element_num.clone(), // word_element_num
+                flattened_value_len.clone(), // flattened_value_len
             );
             cb.condition(
                 1.expr() - self.value.cells.word_mask[i].expression.clone(),
@@ -83,12 +83,12 @@ impl<F: FieldExt> InstructionGadget<F> for CopyLoc<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
         self.value
-            .assign(region, offset, rw_operations, step.gc, word_element_num)?;
+            .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
 
         Ok(())
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -17,7 +17,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct MoveFrom<const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -17,7 +17,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::value_ext::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct MoveFrom<const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -46,9 +46,9 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
             cells.stack_size.expression.clone() - cb.next.cells.stack_size.expression.clone();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_elem_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + word_elem_num.clone() * 3.expr() // two for global read resource, one for stack push value
+            + flattened_value_len.clone() * 3.expr() // two for global read resource, one for stack push value
             + 2.expr(); // stack pop account_address
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
@@ -64,7 +64,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
         ]);
 
         self.account_address.configure(cb);
-        self.global_value.configure(cb, word_elem_num.clone());
+        self.global_value.configure(cb, flattened_value_len.clone());
 
         let account_address_expr = self.account_address.cells.value().expression.clone();
         let sd_index_expr = cells.auxiliary_1.expression.clone();
@@ -102,7 +102,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
                     cells.stack_size.expression.clone(),
                     self.global_value.cells.word_addr_ext[i].expression.clone(),
                     self.global_value.cells.word[i].expression.clone(),
-                    word_elem_num.clone(),
+                    flattened_value_len.clone(),
                 );
             cb.condition(
                 1.expr() - self.global_value.cells.word_mask[i].expression.clone(),
@@ -130,7 +130,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
     ) -> Result<(), Error> {
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
@@ -141,7 +141,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
             offset,
             rw_operations,
             step.gc + LEN_OF_SIMPLE_VALUE,
-            word_element_num,
+            flattened_value_len,
         )?;
 
         if GENERIC {

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::generic_gadget::GenericTypeGadget;
 use crate::chips::execution_chip::instructions::common::simple_value_gadget::SimpleValueGadget;
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -22,7 +22,7 @@ use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 #[derive(Clone, Debug)]
 pub struct MoveFrom<const GENERIC: bool, F: FieldExt> {
     account_address: SimpleValueGadget<F>,
-    global_value: WordGadget<F>,
+    global_value: ValueGadget<F>,
 
     type_cells: Option<GenericTypeGadget<F>>,
 }
@@ -177,7 +177,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveFrom<GENERIC
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         // alloc cell
         let account_address = SimpleValueGadget::construct(cb);
-        let global_value = WordGadget::construct(cb);
+        let global_value = ValueGadget::construct(cb);
 
         let type_cells = if GENERIC {
             let instantiation_index = cb.curr.cells.auxiliary_1.expr();

--- a/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_from.rs
@@ -17,7 +17,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::word::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct MoveFrom<const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -16,7 +16,7 @@ use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub struct MoveLoc<F: FieldExt> {
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
@@ -97,7 +97,7 @@ impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
 
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         Self {
-            value: WordGadget::construct(cb),
+            value: ValueGadget::construct(cb),
         }
     }
 }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_loc.rs
@@ -31,9 +31,9 @@ impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
             + 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + 3.expr() * word_element_num.clone();
+            + 3.expr() * flattened_value_len.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -47,7 +47,7 @@ impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
             ("function index", func_index),
         ]);
 
-        self.value.configure(cb, word_element_num.clone());
+        self.value.configure(cb, flattened_value_len.clone());
 
         for (i, _) in self.value.cells.word.iter().enumerate() {
             let (read, write_locals, write_stack) = RWLookup::locals_move(
@@ -57,7 +57,7 @@ impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
                 cells.stack_size.expression.clone(),
                 self.value.cells.word_addr_ext[i].expression.clone(),
                 self.value.cells.word[i].expression.clone(),
-                word_element_num.clone(), // word_element_num
+                flattened_value_len.clone(), // flattened_value_len
             );
             cb.condition(
                 1.expr() - self.value.cells.word_mask[i].expression.clone(),
@@ -85,12 +85,12 @@ impl<F: FieldExt> InstructionGadget<F> for MoveLoc<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
         self.value
-            .assign(region, offset, rw_operations, step.gc, word_element_num)?;
+            .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
 
         Ok(())
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -17,7 +17,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct MoveTo<const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -47,10 +47,10 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
             - 2.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_elem_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
 
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + 2.expr() * word_elem_num.clone()
+            + 2.expr() * flattened_value_len.clone()
             + (LEN_OF_REFERENCE_VALUE as u64).expr();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
@@ -65,7 +65,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
             ("function index", func_index),
         ]);
 
-        self.value.configure(cb, word_elem_num.clone());
+        self.value.configure(cb, flattened_value_len.clone());
         self.signer_ref.configure(cb);
         let global_address = self.account_address.expression.clone();
 
@@ -83,7 +83,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
                 },
                 self.value.cells.word_addr_ext[i].expression.clone(),
                 self.value.cells.word[i].expression.clone(),
-                word_elem_num.clone(),
+                flattened_value_len.clone(),
                 (LEN_OF_REFERENCE_VALUE as u64).expr(),
             );
             cb.condition(
@@ -100,7 +100,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
             cb.add_lookup(
                 "move_to(signer stack pop)",
                 RWLookup::stack_pop(
-                    cells.gc.expression.clone() + word_elem_num.clone() + (i as u64).expr(),
+                    cells.gc.expression.clone() + flattened_value_len.clone() + (i as u64).expr(),
                     cells.stack_size.expression.clone() - 1.expr(),
                     (i as u64).expr(),
                     item.expression.clone(),
@@ -126,19 +126,19 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
     ) -> Result<(), Error> {
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
-        let word_elem_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
         self.value
-            .assign(region, offset, rw_operations, step.gc, word_elem_num)?;
+            .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
         self.signer_ref
-            .assign(region, offset, rw_operations, step.gc + word_elem_num)?;
+            .assign(region, offset, rw_operations, step.gc + flattened_value_len)?;
 
         // global account address
         let op = rw_operations
             .0
-            .get(step.gc + word_elem_num + LEN_OF_REFERENCE_VALUE)
+            .get(step.gc + flattened_value_len + LEN_OF_REFERENCE_VALUE)
             .ok_or(Error::Synthesis)?;
         debug_assert!(op.rw() == RW::WRITE);
         self.account_address

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -17,7 +17,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct MoveTo<const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -2,7 +2,7 @@
 
 use crate::chips::execution_chip::instructions::common::generic_gadget::GenericTypeGadget;
 use crate::chips::execution_chip::instructions::common::reference_value_gadget::RefValGadget;
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -21,7 +21,7 @@ use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct MoveTo<const GENERIC: bool, F: FieldExt> {
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
     signer_ref: RefValGadget<F>,
     account_address: Cell<F>,
     type_cells: Option<GenericTypeGadget<F>>,
@@ -175,7 +175,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for MoveTo<GENERIC, 
     }
 
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
-        let value = WordGadget::construct(cb);
+        let value = ValueGadget::construct(cb);
         let signer_ref = RefValGadget::construct(cb);
         let account_address = cb.alloc_cell();
 

--- a/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/move_to.rs
@@ -17,7 +17,7 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::error;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct MoveTo<const GENERIC: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pack.rs
@@ -44,11 +44,11 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             + 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let struct_word_element_num = cells.auxiliary_3.expression.clone();
-        let values_element_num = struct_word_element_num.clone() - 1.expr();
+        let struct_element_num = cells.auxiliary_3.expression.clone();
+        let values_element_num = struct_element_num.clone() - 1.expr();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
             + values_element_num.clone()
-            + struct_word_element_num.clone();
+            + struct_element_num.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -62,7 +62,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             ("function index", func_index),
         ]);
 
-        self.struct_value.configure(cb, struct_word_element_num);
+        self.struct_value.configure(cb, struct_element_num);
 
         // read values from stack, write back the packed struct
         // struct_value[0] is the header. To make the constraint simple, we have already
@@ -144,10 +144,10 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
-        let struct_word_element_num =
+        let struct_element_num =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
-        let values_element_num = struct_word_element_num - 1;
+        let values_element_num = struct_element_num - 1;
 
         let values = Word {
             word: self.values.clone(),
@@ -169,7 +169,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             offset,
             rw_operations,
             step.gc + values_element_num,
-            struct_word_element_num,
+            struct_element_num,
         )?;
 
         Ok(())

--- a/vm-circuit/src/chips/execution_chip/instructions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pack.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::{rw_table::RWLookup, rw_table::RWTarget};
@@ -21,7 +21,7 @@ pub struct Pack<const GENERIC: bool, F: FieldExt> {
     values_mask: Vec<Cell<F>>,
     values_addr_ext: Vec<Cell<F>>,
     values_address: Vec<Cell<F>>,
-    struct_value: WordGadget<F>,
+    struct_value: ValueGadget<F>,
 }
 
 impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F> {
@@ -44,11 +44,11 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             + 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let struct_value_element_num = cells.auxiliary_3.expression.clone();
-        let values_element_num = struct_value_element_num.clone() - 1.expr();
+        let struct_word_element_num = cells.auxiliary_3.expression.clone();
+        let values_element_num = struct_word_element_num.clone() - 1.expr();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
             + values_element_num.clone()
-            + struct_value_element_num.clone();
+            + struct_word_element_num.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -62,7 +62,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             ("function index", func_index),
         ]);
 
-        self.struct_value.configure(cb, struct_value_element_num);
+        self.struct_value.configure(cb, struct_word_element_num);
 
         // read values from stack, write back the packed struct
         // struct_value[0] is the header. To make the constraint simple, we have already
@@ -144,10 +144,10 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
-        let struct_value_element_num =
+        let struct_word_element_num =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
-        let values_element_num = struct_value_element_num - 1;
+        let values_element_num = struct_word_element_num - 1;
 
         let values = Word {
             word: self.values.clone(),
@@ -169,7 +169,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
             offset,
             rw_operations,
             step.gc + values_element_num,
-            struct_value_element_num,
+            struct_word_element_num,
         )?;
 
         Ok(())
@@ -183,7 +183,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Pack<GENERIC, F>
         let values_mask = cb.alloc_n_cells(word_cap);
         let values_addr_ext = cb.alloc_n_cells(word_cap);
         let values_address = cb.alloc_n_cells(word_cap);
-        let struct_value = WordGadget::construct(cb);
+        let struct_value = ValueGadget::construct(cb);
 
         Self {
             values,

--- a/vm-circuit/src/chips/execution_chip/instructions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pop.rs
@@ -31,9 +31,9 @@ impl<F: FieldExt> InstructionGadget<F> for Pop<F> {
             - 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + word_element_num.clone();
+            + flattened_value_len.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -47,7 +47,7 @@ impl<F: FieldExt> InstructionGadget<F> for Pop<F> {
             ("function index", func_index),
         ]);
 
-        self.value.configure(cb, word_element_num);
+        self.value.configure(cb, flattened_value_len);
 
         for (i, _) in self.value.cells.word.iter().enumerate() {
             cb.condition(
@@ -77,12 +77,12 @@ impl<F: FieldExt> InstructionGadget<F> for Pop<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_elem_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
         self.value
-            .assign(region, offset, rw_operations, step.gc, word_elem_num)?;
+            .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
         Ok(())
     }
 

--- a/vm-circuit/src/chips/execution_chip/instructions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/pop.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -16,7 +16,7 @@ use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub struct Pop<F: FieldExt> {
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for Pop<F> {
@@ -87,7 +87,7 @@ impl<F: FieldExt> InstructionGadget<F> for Pop<F> {
     }
 
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
-        let value = WordGadget::construct(cb);
+        let value = ValueGadget::construct(cb);
 
         Self { value }
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::flattened_value::ValueHeader;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::ValueHeader;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct ReadRef<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -32,19 +32,19 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
     fn configure(&self, cells: &StepChipCells<F>, cb: &mut ConstraintBuilder<F>) {
         // for instruction readref, there are 3 pipeline stages here:
         // 1. read reference from stack. [gc, LEN_OF_REFERENCE_VALUE]
-        // 2. read value from lobals or global. [gc+LEN_OF_REFERENCE_VALUE, word_element_num]
-        // 3. store value into stack. [gc+LEN_OF_REFERENCE_VALUE+word_element_num, word_element_num]
+        // 2. read value from lobals or global. [gc+LEN_OF_REFERENCE_VALUE, flattened_value_len]
+        // 3. store value into stack. [gc+LEN_OF_REFERENCE_VALUE+flattened_value_len, flattened_value_len]
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr =
             cells.stack_size.expression.clone() - cb.next.cells.stack_size.expression.clone();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
 
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
             + (LEN_OF_REFERENCE_VALUE as u64).expr()
-            + 2.expr() * word_element_num.clone();
+            + 2.expr() * flattened_value_len.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -59,8 +59,8 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
         ]);
 
         self.ref_val.configure(cb);
-        self.value_a.configure(cb, word_element_num.clone());
-        self.value_b.configure(cb, word_element_num.clone());
+        self.value_a.configure(cb, flattened_value_len.clone());
+        self.value_b.configure(cb, flattened_value_len.clone());
 
         for (i, item) in self.ref_val.cells.as_inner().iter().enumerate() {
             cb.add_lookup(
@@ -114,7 +114,7 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
             let write = RWLookup::stack_push(
                 cells.gc.expression.clone()
                     + (LEN_OF_REFERENCE_VALUE as u64).expr()
-                    + word_element_num.clone()
+                    + flattened_value_len.clone()
                     + (i as u64).expr(),
                 cells.stack_size.expression.clone() - 1.expr(),
                 self.value_b.cells.word_addr_ext[i].expression.clone(),
@@ -162,7 +162,7 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
@@ -174,15 +174,15 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
             offset,
             rw_operations,
             step.gc + LEN_OF_REFERENCE_VALUE,
-            word_element_num,
+            flattened_value_len,
         )?;
 
         self.value_b.assign(
             region,
             offset,
             rw_operations,
-            step.gc + LEN_OF_REFERENCE_VALUE + word_element_num,
-            word_element_num,
+            step.gc + LEN_OF_REFERENCE_VALUE + flattened_value_len,
+            flattened_value_len,
         )?;
 
         let is_global =

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::common::reference_value_gadget::RefValGadget;
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -20,8 +20,8 @@ use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 #[derive(Clone, Debug)]
 pub struct ReadRef<F: FieldExt> {
     ref_val: RefValGadget<F>,
-    value_a: WordGadget<F>,
-    value_b: WordGadget<F>,
+    value_a: ValueGadget<F>,
+    value_b: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
@@ -205,8 +205,8 @@ impl<F: FieldExt> InstructionGadget<F> for ReadRef<F> {
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         // alloc cell
         let ref_val = RefValGadget::construct(cb);
-        let value_a = WordGadget::construct(cb);
-        let value_b = WordGadget::construct(cb);
+        let value_a = ValueGadget::construct(cb);
+        let value_b = ValueGadget::construct(cb);
 
         Self {
             ref_val,

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::word::ValueHeader;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::ValueHeader;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct ReadRef<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/read_ref.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::extended_value::ValueHeader;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::ValueHeader;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct ReadRef<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -16,7 +16,7 @@ use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub struct StLoc<F: FieldExt> {
-    value: WordGadget<F>,
+    value: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
@@ -94,7 +94,7 @@ impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
     }
 
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
-        let value = WordGadget::construct(cb);
+        let value = ValueGadget::construct(cb);
 
         Self { value }
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/st_loc.rs
@@ -31,9 +31,9 @@ impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
             - 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + 2.expr() * word_element_num.clone();
+            + 2.expr() * flattened_value_len.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -47,7 +47,7 @@ impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
             ("function index", func_index),
         ]);
 
-        self.value.configure(cb, word_element_num.clone());
+        self.value.configure(cb, flattened_value_len.clone());
         for (i, _) in self.value.cells.word.iter().enumerate() {
             let (read, write) = RWLookup::locals_store(
                 cells.gc.expression.clone() + (i as u64).expr(),
@@ -56,7 +56,7 @@ impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
                 cells.stack_size.expression.clone(),
                 self.value.cells.word_addr_ext[i].expression.clone(),
                 self.value.cells.word[i].expression.clone(),
-                word_element_num.clone(), // word_element_num
+                flattened_value_len.clone(), // flattened_value_len
             );
             cb.condition(
                 1.expr() - self.value.cells.word_mask[i].expression.clone(),
@@ -83,12 +83,12 @@ impl<F: FieldExt> InstructionGadget<F> for StLoc<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
         self.value
-            .assign(region, offset, rw_operations, step.gc, word_element_num)?;
+            .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
 
         Ok(())
     }

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::{rw_table::RWLookup, rw_table::RWTarget};
@@ -17,7 +17,7 @@ use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub struct Unpack<const GENERIC: bool, F: FieldExt> {
-    struct_value: WordGadget<F>,
+    struct_value: ValueGadget<F>,
     values: Vec<Cell<F>>,
     values_mask: Vec<Cell<F>>,
     values_addr_ext: Vec<Cell<F>>,
@@ -44,10 +44,10 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             - 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let struct_value_element_num = cells.auxiliary_3.expression.clone();
-        let values_element_num = struct_value_element_num.clone() - 1.expr();
+        let struct_word_element_num = cells.auxiliary_3.expression.clone();
+        let values_element_num = struct_word_element_num.clone() - 1.expr();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + struct_value_element_num.clone()
+            + struct_word_element_num.clone()
             + values_element_num;
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
@@ -63,7 +63,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
         ]);
 
         self.struct_value
-            .configure(cb, struct_value_element_num.clone());
+            .configure(cb, struct_word_element_num.clone());
 
         cb.condition(
             1.expr() - self.struct_value.cells.word_mask[0].expression.clone(),
@@ -104,7 +104,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
                     "unpack(stack push)",
                     RWLookup {
                         gc: cells.gc.expression.clone()
-                            + struct_value_element_num.clone()
+                            + struct_word_element_num.clone()
                             + ((i - 1) as u64).expr(),
                         rw_target: (RWTarget::Stack as u64).expr(),
                         rw: (RW::WRITE as u64).expr(),
@@ -151,17 +151,17 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
-        let struct_value_element_num =
+        let struct_word_element_num =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
-        let values_element_num = struct_value_element_num - 1;
+        let values_element_num = struct_word_element_num - 1;
 
         self.struct_value.assign(
             region,
             offset,
             rw_operations,
             step.gc,
-            struct_value_element_num,
+            struct_word_element_num,
         )?;
 
         let values = Word {
@@ -175,7 +175,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             rw_operations,
             &values,
             &self.values_address,
-            step.gc + struct_value_element_num,
+            step.gc + struct_word_element_num,
             values_element_num,
         )?;
 
@@ -186,7 +186,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
         let word_cap = word_capacity();
 
         // alloc cell
-        let struct_value = WordGadget::construct(cb);
+        let struct_value = ValueGadget::construct(cb);
         let values = cb.alloc_n_cells(word_cap);
         let values_mask = cb.alloc_n_cells(word_cap);
         let values_addr_ext = cb.alloc_n_cells(word_cap);

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -44,10 +44,10 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             - 1.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let struct_word_element_num = cells.auxiliary_3.expression.clone();
-        let values_element_num = struct_word_element_num.clone() - 1.expr();
+        let struct_element_num = cells.auxiliary_3.expression.clone();
+        let values_element_num = struct_element_num.clone() - 1.expr();
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
-            + struct_word_element_num.clone()
+            + struct_element_num.clone()
             + values_element_num;
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
@@ -63,7 +63,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
         ]);
 
         self.struct_value
-            .configure(cb, struct_word_element_num.clone());
+            .configure(cb, struct_element_num.clone());
 
         cb.condition(
             1.expr() - self.struct_value.cells.word_mask[0].expression.clone(),
@@ -104,7 +104,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
                     "unpack(stack push)",
                     RWLookup {
                         gc: cells.gc.expression.clone()
-                            + struct_word_element_num.clone()
+                            + struct_element_num.clone()
                             + ((i - 1) as u64).expr(),
                         rw_target: (RWTarget::Stack as u64).expr(),
                         rw: (RW::WRITE as u64).expr(),
@@ -151,17 +151,17 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
         let _sd_idx =
             Word::assign_step_value(region, offset, &step.auxiliary_2, &cells.auxiliary_2)?;
-        let struct_word_element_num =
+        let struct_element_num =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
-        let values_element_num = struct_word_element_num - 1;
+        let values_element_num = struct_element_num - 1;
 
         self.struct_value.assign(
             region,
             offset,
             rw_operations,
             step.gc,
-            struct_word_element_num,
+            struct_element_num,
         )?;
 
         let values = Word {
@@ -175,7 +175,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             rw_operations,
             &values,
             &self.values_address,
-            step.gc + struct_word_element_num,
+            step.gc + struct_element_num,
             values_element_num,
         )?;
 

--- a/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/unpack.rs
@@ -62,8 +62,7 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
             ("function index", func_index),
         ]);
 
-        self.struct_value
-            .configure(cb, struct_element_num.clone());
+        self.struct_value.configure(cb, struct_element_num.clone());
 
         cb.condition(
             1.expr() - self.struct_value.cells.word_mask[0].expression.clone(),
@@ -156,13 +155,8 @@ impl<const GENERIC: bool, F: FieldExt> InstructionGadget<F> for Unpack<GENERIC, 
                 .get_lower_128() as usize;
         let values_element_num = struct_element_num - 1;
 
-        self.struct_value.assign(
-            region,
-            offset,
-            rw_operations,
-            step.gc,
-            struct_element_num,
-        )?;
+        self.struct_value
+            .assign(region, offset, rw_operations, step.gc, struct_element_num)?;
 
         let values = Word {
             word: self.values.clone(),

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
-use movelang::word::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct VecBorrow<const MUTABLE: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
-use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct VecBorrow<const MUTABLE: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_borrow.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
-use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct VecBorrow<const MUTABLE: bool, F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
@@ -15,8 +15,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
-use movelang::word::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct VecLen<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
@@ -15,8 +15,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
-use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct VecLen<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_len.rs
@@ -15,8 +15,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use logger::prelude::*;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
-use movelang::extended_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::{ValueHeader, LEN_OF_SIMPLE_VALUE};
 
 #[derive(Clone, Debug)]
 pub struct VecLen<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pack.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::{rw_table::RWLookup, rw_table::RWTarget};
@@ -24,7 +24,7 @@ pub struct VecPack<F: FieldExt> {
     values_address: Vec<Cell<F>>,
 
     // cells for the vector pushed back
-    vector: WordGadget<F>,
+    vector: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for VecPack<F> {
@@ -186,7 +186,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecPack<F> {
         let values_addr_ext = cb.alloc_n_cells(word_cap);
         let values_address = cb.alloc_n_cells(word_cap);
 
-        let vector = WordGadget::construct(cb);
+        let vector = ValueGadget::construct(cb);
 
         Self {
             values,

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
@@ -14,8 +14,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use movelang::value::DEPTH_OF_LOCATION_PATH;
-use movelang::word::ValueHeader;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::ValueHeader;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecPopBack<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
@@ -32,7 +32,7 @@ pub struct VecPopBack<F: FieldExt> {
     vec_frame_index_or_global_address: Cell<F>,
     vec_locals_index_or_global_sd_idx: Cell<F>,
 
-    // TODO: adopt WordGadget
+    // TODO: adopt ValueGadget
     value: Vec<Cell<F>>,
     value_mask: Vec<Cell<F>>,
     value_addr_ext: Vec<Cell<F>>,

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
@@ -14,8 +14,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use movelang::value::DEPTH_OF_LOCATION_PATH;
-use movelang::flattened_value::ValueHeader;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::ValueHeader;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecPopBack<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_pop_back.rs
@@ -14,8 +14,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use movelang::value::DEPTH_OF_LOCATION_PATH;
-use movelang::extended_value::ValueHeader;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::ValueHeader;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecPopBack<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
@@ -14,8 +14,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use movelang::value::DEPTH_OF_LOCATION_PATH;
-use movelang::flattened_value::ValueHeader;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::ValueHeader;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecPushBack<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
@@ -14,8 +14,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use movelang::value::DEPTH_OF_LOCATION_PATH;
-use movelang::word::ValueHeader;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::ValueHeader;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecPushBack<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
@@ -23,7 +23,7 @@ pub struct VecPushBack<F: FieldExt> {
     value_index: Cell<F>,
     offset_pow2: Cell<F>,
 
-    // TODO: adopt WordGadget
+    // TODO: adopt ValueGadget
     value: Vec<Cell<F>>,
     value_mask: Vec<Cell<F>>,
     value_addr_ext: Vec<Cell<F>>,

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_push_back.rs
@@ -14,8 +14,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
 use movelang::value::DEPTH_OF_LOCATION_PATH;
-use movelang::extended_value::ValueHeader;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::ValueHeader;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecPushBack<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
@@ -31,12 +31,12 @@ pub struct VecSwap<F: FieldExt> {
     vec_frame_index_or_global_address: Cell<F>,
     vec_locals_index_or_global_sd_idx: Cell<F>,
 
-    // TODO: adopt WordGadget
+    // TODO: adopt ValueGadget
     value_a: Vec<Cell<F>>,
     value_a_mask: Vec<Cell<F>>,
     value_a_addr_ext: Vec<Cell<F>>,
 
-    // TODO: adopt WordGadget
+    // TODO: adopt ValueGadget
     value_b: Vec<Cell<F>>,
     value_b_mask: Vec<Cell<F>>,
     value_b_addr_ext: Vec<Cell<F>>,

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::flattened_value::ValueHeader;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::ValueHeader;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecSwap<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::word::ValueHeader;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::ValueHeader;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecSwap<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_swap.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::extended_value::ValueHeader;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::ValueHeader;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct VecSwap<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/vec_unpack.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/vec_unpack.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::{rw_table::RWLookup, rw_table::RWTarget};
@@ -18,7 +18,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub struct VecUnpack<F: FieldExt> {
     // word for the popped vector
-    vector: WordGadget<F>,
+    vector: ValueGadget<F>,
 
     // word for the unpacked values
     values: Vec<Cell<F>>,
@@ -176,7 +176,7 @@ impl<F: FieldExt> InstructionGadget<F> for VecUnpack<F> {
         let word_cap = word_capacity();
 
         // alloc cell
-        let vector = WordGadget::construct(cb);
+        let vector = ValueGadget::construct(cb);
         let values = cb.alloc_n_cells(word_cap);
         let values_mask = cb.alloc_n_cells(word_cap);
         let values_addr_ext = cb.alloc_n_cells(word_cap);

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::extended_value::ValueHeader;
-use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
+use movelang::flattened_value::ValueHeader;
+use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct WriteRef<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -1,7 +1,7 @@
 // Copyright (c) zkMove Authors
 
 use crate::chips::execution_chip::instructions::common::reference_value_gadget::RefValGadget;
-use crate::chips::execution_chip::instructions::common::word_gadget::WordGadget;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
 use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
@@ -20,8 +20,8 @@ use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 #[derive(Clone, Debug)]
 pub struct WriteRef<F: FieldExt> {
     ref_val: RefValGadget<F>,
-    value_a: WordGadget<F>,
-    value_b: WordGadget<F>,
+    value_a: ValueGadget<F>,
+    value_b: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
@@ -204,8 +204,8 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
     fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         // alloc cell
         let ref_val = RefValGadget::construct(cb);
-        let value_a = WordGadget::construct(cb);
-        let value_b = WordGadget::construct(cb);
+        let value_a = ValueGadget::construct(cb);
+        let value_b = ValueGadget::construct(cb);
 
         Self {
             ref_val,

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::flattened_value::ValueHeader;
-use movelang::flattened_value::LEN_OF_REFERENCE_VALUE;
+use movelang::value_ext::ValueHeader;
+use movelang::value_ext::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct WriteRef<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -14,8 +14,8 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use movelang::word::ValueHeader;
-use movelang::word::LEN_OF_REFERENCE_VALUE;
+use movelang::extended_value::ValueHeader;
+use movelang::extended_value::LEN_OF_REFERENCE_VALUE;
 
 #[derive(Clone, Debug)]
 pub struct WriteRef<F: FieldExt> {

--- a/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/write_ref.rs
@@ -31,8 +31,8 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
     fn configure(&self, cells: &StepChipCells<F>, cb: &mut ConstraintBuilder<F>) {
         // for instruction readref, there are 3 pipeline stages here:
         // 1. read reference from stack. [gc, LEN_OF_REFERENCE_VALUE]
-        // 2. read value into stack. [gc+LEN_OF_REFERENCE_VALUE, word_element_num]
-        // 3. write value to lobals or global. [gc+LEN_OF_REFERENCE_VALUE+word_element_num, word_element_num]
+        // 2. read value into stack. [gc+LEN_OF_REFERENCE_VALUE, flattened_value_len]
+        // 3. write value to lobals or global. [gc+LEN_OF_REFERENCE_VALUE+flattened_value_len, flattened_value_len]
 
         let pc_expr = cells.pc.expression.clone() - cb.next.cells.pc.expression.clone() + 1.expr();
         let stack_size_expr = cells.stack_size.expression.clone()
@@ -40,11 +40,11 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
             - 2.expr();
         let frame_index_expr =
             cells.frame_index.expression.clone() - cb.next.cells.frame_index.expression.clone();
-        let word_element_num = cells.auxiliary_3.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
 
         let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
             + (LEN_OF_REFERENCE_VALUE as u64).expr()
-            + 2.expr() * word_element_num.clone();
+            + 2.expr() * flattened_value_len.clone();
         let module_index =
             cells.module_index.expression.clone() - cb.next.cells.module_index.expression.clone();
         let func_index = cells.function_index.expression.clone()
@@ -59,8 +59,8 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
         ]);
 
         self.ref_val.configure(cb);
-        self.value_a.configure(cb, word_element_num.clone());
-        self.value_b.configure(cb, word_element_num.clone());
+        self.value_a.configure(cb, flattened_value_len.clone());
+        self.value_b.configure(cb, flattened_value_len.clone());
 
         for (i, item) in self.ref_val.cells.as_inner().iter().enumerate() {
             cb.add_lookup(
@@ -100,7 +100,7 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
                         let write = RWLookup::locals_write(
                             cells.gc.expression.clone()
                                 + (LEN_OF_REFERENCE_VALUE as u64).expr()
-                                + word_element_num.clone()
+                                + flattened_value_len.clone()
                                 + (i as u64).expr(),
                             cells.auxiliary_2.expression.clone(),
                             cells.locals_index.expression.clone(),
@@ -113,7 +113,7 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
                         let write = RWLookup::global_write(
                             cells.gc.expression.clone()
                                 + (LEN_OF_REFERENCE_VALUE as u64).expr()
-                                + word_element_num.clone()
+                                + flattened_value_len.clone()
                                 + (i as u64).expr(),
                             cells.auxiliary_2.expression.clone(), //address
                             self.value_b.cells.word[i].expression.clone(),
@@ -160,7 +160,7 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
         rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
-        let word_element_num =
+        let flattened_value_len =
             Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
                 .get_lower_128() as usize;
 
@@ -172,15 +172,15 @@ impl<F: FieldExt> InstructionGadget<F> for WriteRef<F> {
             offset,
             rw_operations,
             step.gc + LEN_OF_REFERENCE_VALUE,
-            word_element_num,
+            flattened_value_len,
         )?;
 
         self.value_b.assign(
             region,
             offset,
             rw_operations,
-            step.gc + LEN_OF_REFERENCE_VALUE + word_element_num,
-            word_element_num,
+            step.gc + LEN_OF_REFERENCE_VALUE + flattened_value_len,
+            flattened_value_len,
         )?;
 
         let is_global =

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/constant_lookup_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/constant_lookup_table.rs
@@ -3,7 +3,7 @@ use crate::witness::const_table::ConstantInfo;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Layouter;
 use halo2_proofs::plonk::{ConstraintSystem, Error, Expression, TableColumn};
-use movelang::value::PrimitiveValue;
+use movelang::value::SimpleValue;
 
 #[derive(Clone, Debug)]
 pub struct ConstantLookupTable {
@@ -34,7 +34,7 @@ impl ConstantLookupTable {
         let values = traces
             .into_iter()
             .map(|t| {
-                let v: PrimitiveValue<F> = t.value.into();
+                let v: SimpleValue<F> = t.value.into();
                 vec![
                     F::from_u128(t.module_index as u128),
                     F::from_u128(t.constant_index as u128),

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/rw_table.rs
@@ -144,7 +144,7 @@ impl<F: FieldExt> RWLookup<F> {
         stack_size: Expression<F>,
         address_ext: Expression<F>,
         value: Expression<F>,
-        word_element_num: Expression<F>,
+        flattened_value_len: Expression<F>,
     ) -> (RWLookup<F>, RWLookup<F>) {
         (
             RWLookup {
@@ -158,7 +158,7 @@ impl<F: FieldExt> RWLookup<F> {
                 sd_index: 0.expr(),
             },
             RWLookup {
-                gc: gc + word_element_num,
+                gc: gc + flattened_value_len,
                 rw_target: (RWTarget::Stack as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),
@@ -178,7 +178,7 @@ impl<F: FieldExt> RWLookup<F> {
         stack_size: Expression<F>,
         address_ext: Expression<F>,
         value: Expression<F>,
-        word_element_num: Expression<F>,
+        flattened_value_len: Expression<F>,
     ) -> (RWLookup<F>, RWLookup<F>, RWLookup<F>) {
         (
             RWLookup {
@@ -192,7 +192,7 @@ impl<F: FieldExt> RWLookup<F> {
                 sd_index: 0.expr(),
             },
             RWLookup {
-                gc: gc.clone() + word_element_num.clone(),
+                gc: gc.clone() + flattened_value_len.clone(),
                 rw_target: (RWTarget::Locals as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index,
@@ -202,7 +202,7 @@ impl<F: FieldExt> RWLookup<F> {
                 sd_index: 0.expr(),
             },
             RWLookup {
-                gc: gc + word_element_num * 2.expr(),
+                gc: gc + flattened_value_len * 2.expr(),
                 rw_target: (RWTarget::Stack as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),
@@ -222,7 +222,7 @@ impl<F: FieldExt> RWLookup<F> {
         stack_size: Expression<F>,
         address_ext: Expression<F>,
         value: Expression<F>,
-        word_element_num: Expression<F>,
+        flattened_value_len: Expression<F>,
     ) -> (RWLookup<F>, RWLookup<F>) {
         (
             RWLookup {
@@ -236,7 +236,7 @@ impl<F: FieldExt> RWLookup<F> {
                 sd_index: 0.expr(),
             },
             RWLookup {
-                gc: gc + word_element_num,
+                gc: gc + flattened_value_len,
                 rw_target: (RWTarget::Locals as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index,
@@ -312,7 +312,7 @@ impl<F: FieldExt> RWLookup<F> {
         stack_size: Expression<F>,
         address_ext: Expression<F>,
         value: Expression<F>,
-        word_element_num: Expression<F>,
+        flattened_value_len: Expression<F>,
     ) -> (RWLookup<F>, RWLookup<F>, RWLookup<F>) {
         (
             RWLookup {
@@ -326,7 +326,7 @@ impl<F: FieldExt> RWLookup<F> {
                 value: value.clone(),
             },
             RWLookup {
-                gc: gc.clone() + word_element_num.clone(),
+                gc: gc.clone() + flattened_value_len.clone(),
                 rw_target: (RWTarget::Global as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),
@@ -336,7 +336,7 @@ impl<F: FieldExt> RWLookup<F> {
                 value: 0.expr(),
             },
             RWLookup {
-                gc: gc + word_element_num * 2.expr(),
+                gc: gc + flattened_value_len * 2.expr(),
                 rw_target: (RWTarget::Stack as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),
@@ -356,7 +356,7 @@ impl<F: FieldExt> RWLookup<F> {
         sd_index: Expression<F>,
         address_ext: Expression<F>,
         value: Expression<F>,
-        word_elem_num: Expression<F>,
+        flattened_value_len: Expression<F>,
         depth_of_addr_path: Expression<F>,
     ) -> (RWLookup<F>, RWLookup<F>) {
         (
@@ -371,7 +371,7 @@ impl<F: FieldExt> RWLookup<F> {
                 sd_index: 0.expr(),
             },
             RWLookup {
-                gc: gc + depth_of_addr_path + word_elem_num, // + depth_of_addr_path, because, in the middle, a signer reference is popped.
+                gc: gc + depth_of_addr_path + flattened_value_len, // + depth_of_addr_path, because, in the middle, a signer reference is popped.
                 rw_target: (RWTarget::Global as u64).expr(),
                 rw: (RW::WRITE as u64).expr(),
                 frame_index: 0.expr(),

--- a/vm-circuit/src/witness/rw_operations.rs
+++ b/vm-circuit/src/witness/rw_operations.rs
@@ -5,7 +5,7 @@ use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::AssignedCell;
 use movelang::account_address::AccountAddress;
-use movelang::value::{PrimitiveValue, Value};
+use movelang::value::{SimpleValue, Value};
 use std::cmp::Ordering;
 use std::convert::From;
 
@@ -103,7 +103,7 @@ pub struct LocalsOp<F: FieldExt> {
     pub address_ext: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Option<PrimitiveValue<F>>,
+    pub value: Option<SimpleValue<F>>,
 }
 
 impl<F: FieldExt> LocalsOp<F> {
@@ -114,7 +114,7 @@ impl<F: FieldExt> LocalsOp<F> {
             address_ext: 0,
             gc: 0,
             rw: RW::READ,
-            value: Some(PrimitiveValue::u64(0)),
+            value: Some(SimpleValue::u64(0)),
         }
     }
 }
@@ -162,7 +162,7 @@ pub struct StackOp<F: FieldExt> {
     pub address_ext: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Option<PrimitiveValue<F>>,
+    pub value: Option<SimpleValue<F>>,
 }
 
 impl<F: FieldExt> StackOp<F> {
@@ -170,7 +170,7 @@ impl<F: FieldExt> StackOp<F> {
         Self {
             address: 0,
             address_ext: 0,
-            value: Some(PrimitiveValue::u64(0)),
+            value: Some(SimpleValue::u64(0)),
             rw: RW::READ,
             gc: 0,
         }
@@ -220,7 +220,7 @@ pub struct GlobalOp<F: FieldExt> {
     pub address_ext: usize,
     pub gc: usize,
     pub rw: RW,
-    pub value: Option<PrimitiveValue<F>>,
+    pub value: Option<SimpleValue<F>>,
 }
 
 impl<F: FieldExt> GlobalOp<F> {
@@ -229,7 +229,7 @@ impl<F: FieldExt> GlobalOp<F> {
             address: AccountAddress::zero(),
             sd_index: 0,
             address_ext: 0,
-            value: Some(PrimitiveValue::u64(0)),
+            value: Some(SimpleValue::u64(0)),
             rw: RW::READ,
             gc: 0,
         }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -17,7 +17,7 @@ use movelang::value::{
     ContainerRef, GlobalRef, IndexedLocation, IndexedRef, LocalRef, LocatedValue, Location,
     SimpleValue, Reference, Value, ValueLocation,
 };
-use movelang::extended_value::{LocatedExtendedValue, ExtendedValue};
+use movelang::flattened_value::{LocatedFlattenedValue, FlattenedValue};
 use petgraph::prelude::EdgeRef;
 use petgraph::Direction;
 use std::convert::From;
@@ -184,7 +184,7 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::Pop => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         Ok(())
                     }
@@ -227,14 +227,14 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::CopyLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.copy(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::StLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         self.locals
                             .store(*v as usize, value, frame_index, rw_operations)
@@ -242,7 +242,7 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::MoveLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.move_(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -252,7 +252,7 @@ impl<F: FieldExt> Frame<F> {
                             self.locals
                                 .borrow_locals(*v as usize, frame_index, rw_operations)?;
                         let word_element_count =
-                            ExtendedValue::from(local_ref.refer.borrow().deref()).0.len();
+                            FlattenedValue::from(local_ref.refer.borrow().deref()).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(local_ref.into(), rw_operations)
                     }
@@ -270,28 +270,28 @@ impl<F: FieldExt> Frame<F> {
                         match reference {
                             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                                 let (account_addr, sd_index) = (loc.address, loc.sd_index);
-                                let extended_value: LocatedExtendedValue<F> =
+                                let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Global(loc), &value).into();
-                                let word_element_count = extended_value.0.len();
+                                let word_element_count = flattened_value.0.len();
                                 execution_step.auxiliary_2 = Some(Value::Address(account_addr));
                                 execution_step.auxiliary_3 =
                                     Some(Value::u64(word_element_count as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_index.to_u128()));
                                 execution_step.auxiliary_5 = Some(Value::bool(true)); // global
-                                globals::emit_global_ops(extended_value, RW::READ, rw_operations);
+                                globals::emit_global_ops(flattened_value, RW::READ, rw_operations);
                             }
                             Reference::LocalRef(LocalRef { loc, .. }) => {
                                 let frame_index = loc.frame_index;
                                 let index = loc.index;
-                                let extended_value: LocatedExtendedValue<F> =
+                                let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Local(loc), &value).into();
-                                let word_element_count = extended_value.0.len();
+                                let word_element_count = flattened_value.0.len();
                                 execution_step.locals_index = index;
                                 execution_step.auxiliary_2 = Some(Value::u64(frame_index.0 as u64));
                                 execution_step.auxiliary_3 =
                                     Some(Value::u64(word_element_count as u64)); // word_elem_count
                                 execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
-                                locals::emit_locals_ops(extended_value, RW::READ, rw_operations);
+                                locals::emit_locals_ops(flattened_value, RW::READ, rw_operations);
                             }
                             Reference::IndexedRef(IndexedRef {
                                 sub_indexes,
@@ -308,8 +308,8 @@ impl<F: FieldExt> Frame<F> {
                                             },
                                             &value,
                                         );
-                                        let extended_value: LocatedExtendedValue<F> = indexed_value.into();
-                                        let word_element_count = extended_value.0.len();
+                                        let flattened_value: LocatedFlattenedValue<F> = indexed_value.into();
+                                        let word_element_count = flattened_value.0.len();
                                         execution_step.auxiliary_2 =
                                             Some(Value::Address(account_addr));
                                         execution_step.auxiliary_3 =
@@ -318,7 +318,7 @@ impl<F: FieldExt> Frame<F> {
                                             Some(Value::u128(sd_index.to_u128()));
                                         execution_step.auxiliary_5 = Some(Value::bool(true)); // global
                                         globals::emit_global_ops(
-                                            extended_value,
+                                            flattened_value,
                                             RW::READ,
                                             rw_operations,
                                         );
@@ -333,8 +333,8 @@ impl<F: FieldExt> Frame<F> {
                                             },
                                             &value,
                                         );
-                                        let extended_value: LocatedExtendedValue<F> = indexed_value.into();
-                                        let word_element_count = extended_value.0.len();
+                                        let flattened_value: LocatedFlattenedValue<F> = indexed_value.into();
+                                        let word_element_count = flattened_value.0.len();
                                         execution_step.locals_index = index;
                                         execution_step.auxiliary_2 =
                                             Some(Value::u64(frame_index.0 as u64));
@@ -342,7 +342,7 @@ impl<F: FieldExt> Frame<F> {
                                             Some(Value::u64(word_element_count as u64)); // word_elem_count
                                         execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
                                         locals::emit_locals_ops(
-                                            extended_value,
+                                            flattened_value,
                                             RW::READ,
                                             rw_operations,
                                         );
@@ -361,28 +361,28 @@ impl<F: FieldExt> Frame<F> {
 
                         match reference {
                             Reference::LocalRef(LocalRef { loc, .. }) => {
-                                let extended_value: LocatedExtendedValue<F> =
+                                let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Local(loc), &value).into();
-                                let word_element_count = extended_value.0.len();
+                                let word_element_count = flattened_value.0.len();
                                 execution_step.locals_index = loc.index;
                                 execution_step.auxiliary_2 =
                                     Some(Value::u64(loc.frame_index.0 as u64));
                                 execution_step.auxiliary_3 =
                                     Some(Value::u64(word_element_count as u64));
                                 execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
-                                locals::emit_locals_ops(extended_value, RW::WRITE, rw_operations);
+                                locals::emit_locals_ops(flattened_value, RW::WRITE, rw_operations);
                             }
                             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                                 let (account_addr, sd_idx) = (loc.address, loc.sd_index);
-                                let extended_value: LocatedExtendedValue<F> =
+                                let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Global(loc), &value).into();
 
                                 execution_step.auxiliary_2 = Some(Value::address(account_addr));
-                                execution_step.auxiliary_3 = Some(Value::u64(extended_value.0.len() as u64)); // word_elem_count
+                                execution_step.auxiliary_3 = Some(Value::u64(flattened_value.0.len() as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_idx.to_u128()));
                                 execution_step.auxiliary_5 = Some(Value::bool(true)); // is global
                                 globals::emit_global_ops(
-                                    extended_value.clone(),
+                                    flattened_value.clone(),
                                     RW::WRITE,
                                     rw_operations,
                                 );
@@ -393,7 +393,7 @@ impl<F: FieldExt> Frame<F> {
                             }) => {
                                 match container_ref {
                                     ContainerRef::Local(vloc, _) => {
-                                        let extended_value: LocatedExtendedValue<F> = LocatedValue(
+                                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Local(vloc),
@@ -401,7 +401,7 @@ impl<F: FieldExt> Frame<F> {
                                             &value,
                                         )
                                         .into();
-                                        let word_element_count = extended_value.0.len();
+                                        let word_element_count = flattened_value.0.len();
                                         execution_step.locals_index = vloc.index;
                                         execution_step.auxiliary_2 =
                                             Some(Value::u64(vloc.frame_index.0 as u64));
@@ -409,14 +409,14 @@ impl<F: FieldExt> Frame<F> {
                                             Some(Value::u64(word_element_count as u64));
                                         execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
                                         locals::emit_locals_ops(
-                                            extended_value,
+                                            flattened_value,
                                             RW::WRITE,
                                             rw_operations,
                                         );
                                     }
                                     ContainerRef::Global(vloc, _) => {
                                         let (account_addr, sd_idx) = (vloc.address, vloc.sd_index);
-                                        let extended_value: LocatedExtendedValue<F> = LocatedValue(
+                                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Global(vloc),
@@ -428,12 +428,12 @@ impl<F: FieldExt> Frame<F> {
                                         execution_step.auxiliary_2 =
                                             Some(Value::address(account_addr));
                                         execution_step.auxiliary_3 =
-                                            Some(Value::u64(extended_value.0.len() as u64)); // word_elem_count
+                                            Some(Value::u64(flattened_value.0.len() as u64)); // word_elem_count
                                         execution_step.auxiliary_4 =
                                             Some(Value::u128(sd_idx.to_u128()));
                                         execution_step.auxiliary_5 = Some(Value::bool(true)); // is global
                                         globals::emit_global_ops(
-                                            extended_value.clone(),
+                                            flattened_value.clone(),
                                             RW::WRITE,
                                             rw_operations,
                                         );
@@ -610,7 +610,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
                         let value = Value::container(args);
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -620,7 +620,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
                         let value = Value::container(args);
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -918,7 +918,7 @@ impl<F: FieldExt> Frame<F> {
                             })?;
                         let elements = interp.stack.popn(*num as u16, rw_operations)?;
                         let value = Value::container(elements);
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -934,13 +934,13 @@ impl<F: FieldExt> Frame<F> {
 
                         // emit read op for vec header
                         let vec = vec_ref.read_ref()?;
-                        let extended_value: LocatedExtendedValue<F> = match vec_ref.location()? {
+                        let flattened_value: LocatedFlattenedValue<F> = match vec_ref.location()? {
                             Location::ValueLocation(l) => LocatedValue(l, &vec).into(),
                             Location::IndexedLocation(l) => LocatedValue(l, &vec).into(),
                         };
                         if vec_ref.is_global() {
                             let (header_address_path, header_value) =
-                                extended_value.0.first().expect("header address should not be none");
+                                flattened_value.0.first().expect("header address should not be none");
                             globals::emit_global_op(
                                 header_address_path.clone(),
                                 *header_value,
@@ -950,7 +950,7 @@ impl<F: FieldExt> Frame<F> {
                             execution_step.auxiliary_1 = Some(Value::bool(true));
                         } else {
                             let (header_address_path, header_value) =
-                                extended_value.0.first().expect("header address should not be none");
+                                flattened_value.0.first().expect("header address should not be none");
                             locals::emit_locals_op(
                                 header_address_path.clone(),
                                 *header_value,
@@ -982,7 +982,7 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::VecPushBack(si) => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
                         let vec_ref = interp.stack.pop_as_vector_ref(rw_operations)?;
                         let ref_val_flattened_len = vec_ref.value_address_path().len();
                         let headers = vec_ref.current_and_parent_container_headers()?;
@@ -1001,13 +1001,13 @@ impl<F: FieldExt> Frame<F> {
                         let value_ref = vec_ref.try_borrow_elem(value_idx)?;
                         let (value_loc, value) =
                             VmResult::<(IndexedLocation<F>, Value<F>)>::from(value_ref)?;
-                        let extended_value: LocatedExtendedValue<F> = LocatedValue(value_loc, &value).into();
+                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(value_loc, &value).into();
                         let is_global = vec_ref.is_global();
                         if is_global {
-                            globals::emit_global_ops(extended_value, RW::WRITE, rw_operations);
+                            globals::emit_global_ops(flattened_value, RW::WRITE, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(true));
                         } else {
-                            locals::emit_locals_ops(extended_value, RW::WRITE, rw_operations);
+                            locals::emit_locals_ops(flattened_value, RW::WRITE, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
 
@@ -1076,16 +1076,16 @@ impl<F: FieldExt> Frame<F> {
                         let value_ref = vec_ref.try_borrow_elem(value_idx)?;
                         let (value_loc, value) =
                             VmResult::<(IndexedLocation<F>, Value<F>)>::from(value_ref)?;
-                        let extended_value: LocatedExtendedValue<F> = LocatedValue(value_loc, &value).into();
+                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(value_loc, &value).into();
                         let is_global = vec_ref.is_global();
                         if is_global {
-                            globals::emit_global_ops(extended_value, RW::READ, rw_operations);
+                            globals::emit_global_ops(flattened_value, RW::READ, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(true));
                         } else {
-                            locals::emit_locals_ops(extended_value, RW::READ, rw_operations);
+                            locals::emit_locals_ops(flattened_value, RW::READ, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
-                        let word_element_count = ExtendedValue::from(&value).0.len();
+                        let word_element_count = FlattenedValue::from(&value).0.len();
 
                         execution_step.auxiliary_1 = Some(Value::u64(si.0 as u64));
                         // auxiliary_2 is multiplexed by header_len and value_index.
@@ -1225,8 +1225,8 @@ impl<F: FieldExt> Frame<F> {
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
 
-                        let word_a_element_count = ExtendedValue::from(&elem_a).0.len();
-                        let word_b_element_count = ExtendedValue::from(&elem_b).0.len();
+                        let word_a_element_count = FlattenedValue::from(&elem_a).0.len();
+                        let word_b_element_count = FlattenedValue::from(&elem_b).0.len();
 
                         execution_step.auxiliary_1 = Some(Value::u64(si.0 as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(word_a_element_count as u64));

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -15,7 +15,7 @@ use movelang::state::StateStore;
 use movelang::utility::MoveValueType;
 use movelang::value::{
     ContainerRef, GlobalRef, IndexedLocation, IndexedRef, LocalRef, LocatedValue, Location,
-    PrimitiveValue, Reference, Value, ValueLocation,
+    SimpleValue, Reference, Value, ValueLocation,
 };
 use movelang::word::{LocatedWord, Word};
 use petgraph::prelude::EdgeRef;
@@ -154,7 +154,7 @@ impl<F: FieldExt> Frame<F> {
                 match instruction {
                     Bytecode::LdConst(const_index) => {
                         let constant = resolver.constant_at(*const_index);
-                        let val: PrimitiveValue<_> = constant
+                        let val: SimpleValue<_> = constant
                             .deserialize_constant()
                             .ok_or_else(|| {
                                 RuntimeError::new(StatusCode::UnknownInvariantViolationError)

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -15,9 +15,9 @@ use movelang::state::StateStore;
 use movelang::utility::MoveValueType;
 use movelang::value::{
     ContainerRef, GlobalRef, IndexedLocation, IndexedRef, LocalRef, LocatedValue, Location,
-    SimpleValue, Reference, Value, ValueLocation,
+    Reference, SimpleValue, Value, ValueLocation,
 };
-use movelang::flattened_value::{LocatedFlattenedValue, FlattenedValue};
+use movelang::value_ext::{FlattenedValue, LocatedFlattenedValue};
 use petgraph::prelude::EdgeRef;
 use petgraph::Direction;
 use std::convert::From;
@@ -252,7 +252,9 @@ impl<F: FieldExt> Frame<F> {
                             self.locals
                                 .borrow_locals(*v as usize, frame_index, rw_operations)?;
                         let flattened_value_len =
-                            FlattenedValue::from(local_ref.refer.borrow().deref()).0.len();
+                            FlattenedValue::from(local_ref.refer.borrow().deref())
+                                .0
+                                .len();
                         execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(local_ref.into(), rw_operations)
                     }
@@ -308,7 +310,8 @@ impl<F: FieldExt> Frame<F> {
                                             },
                                             &value,
                                         );
-                                        let flattened_value: LocatedFlattenedValue<F> = indexed_value.into();
+                                        let flattened_value: LocatedFlattenedValue<F> =
+                                            indexed_value.into();
                                         let flattened_value_len = flattened_value.0.len();
                                         execution_step.auxiliary_2 =
                                             Some(Value::Address(account_addr));
@@ -333,7 +336,8 @@ impl<F: FieldExt> Frame<F> {
                                             },
                                             &value,
                                         );
-                                        let flattened_value: LocatedFlattenedValue<F> = indexed_value.into();
+                                        let flattened_value: LocatedFlattenedValue<F> =
+                                            indexed_value.into();
                                         let flattened_value_len = flattened_value.0.len();
                                         execution_step.locals_index = index;
                                         execution_step.auxiliary_2 =
@@ -378,7 +382,8 @@ impl<F: FieldExt> Frame<F> {
                                     LocatedValue(ValueLocation::Global(loc), &value).into();
 
                                 execution_step.auxiliary_2 = Some(Value::address(account_addr));
-                                execution_step.auxiliary_3 = Some(Value::u64(flattened_value.0.len() as u64)); // word_elem_count
+                                execution_step.auxiliary_3 =
+                                    Some(Value::u64(flattened_value.0.len() as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_idx.to_u128()));
                                 execution_step.auxiliary_5 = Some(Value::bool(true)); // is global
                                 globals::emit_global_ops(
@@ -393,14 +398,15 @@ impl<F: FieldExt> Frame<F> {
                             }) => {
                                 match container_ref {
                                     ContainerRef::Local(vloc, _) => {
-                                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
-                                            IndexedLocation {
-                                                sub_indexes,
-                                                value_loc: ValueLocation::Local(vloc),
-                                            },
-                                            &value,
-                                        )
-                                        .into();
+                                        let flattened_value: LocatedFlattenedValue<F> =
+                                            LocatedValue(
+                                                IndexedLocation {
+                                                    sub_indexes,
+                                                    value_loc: ValueLocation::Local(vloc),
+                                                },
+                                                &value,
+                                            )
+                                            .into();
                                         let flattened_value_len = flattened_value.0.len();
                                         execution_step.locals_index = vloc.index;
                                         execution_step.auxiliary_2 =
@@ -416,14 +422,15 @@ impl<F: FieldExt> Frame<F> {
                                     }
                                     ContainerRef::Global(vloc, _) => {
                                         let (account_addr, sd_idx) = (vloc.address, vloc.sd_index);
-                                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
-                                            IndexedLocation {
-                                                sub_indexes,
-                                                value_loc: ValueLocation::Global(vloc),
-                                            },
-                                            &value,
-                                        )
-                                        .into();
+                                        let flattened_value: LocatedFlattenedValue<F> =
+                                            LocatedValue(
+                                                IndexedLocation {
+                                                    sub_indexes,
+                                                    value_loc: ValueLocation::Global(vloc),
+                                                },
+                                                &value,
+                                            )
+                                            .into();
 
                                         execution_step.auxiliary_2 =
                                             Some(Value::address(account_addr));
@@ -939,8 +946,10 @@ impl<F: FieldExt> Frame<F> {
                             Location::IndexedLocation(l) => LocatedValue(l, &vec).into(),
                         };
                         if vec_ref.is_global() {
-                            let (header_address_path, header_value) =
-                                flattened_value.0.first().expect("header address should not be none");
+                            let (header_address_path, header_value) = flattened_value
+                                .0
+                                .first()
+                                .expect("header address should not be none");
                             globals::emit_global_op(
                                 header_address_path.clone(),
                                 *header_value,
@@ -949,8 +958,10 @@ impl<F: FieldExt> Frame<F> {
                             );
                             execution_step.auxiliary_1 = Some(Value::bool(true));
                         } else {
-                            let (header_address_path, header_value) =
-                                flattened_value.0.first().expect("header address should not be none");
+                            let (header_address_path, header_value) = flattened_value
+                                .0
+                                .first()
+                                .expect("header address should not be none");
                             locals::emit_locals_op(
                                 header_address_path.clone(),
                                 *header_value,
@@ -1001,7 +1012,8 @@ impl<F: FieldExt> Frame<F> {
                         let value_ref = vec_ref.try_borrow_elem(value_idx)?;
                         let (value_loc, value) =
                             VmResult::<(IndexedLocation<F>, Value<F>)>::from(value_ref)?;
-                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(value_loc, &value).into();
+                        let flattened_value: LocatedFlattenedValue<F> =
+                            LocatedValue(value_loc, &value).into();
                         let is_global = vec_ref.is_global();
                         if is_global {
                             globals::emit_global_ops(flattened_value, RW::WRITE, rw_operations);
@@ -1076,7 +1088,8 @@ impl<F: FieldExt> Frame<F> {
                         let value_ref = vec_ref.try_borrow_elem(value_idx)?;
                         let (value_loc, value) =
                             VmResult::<(IndexedLocation<F>, Value<F>)>::from(value_ref)?;
-                        let flattened_value: LocatedFlattenedValue<F> = LocatedValue(value_loc, &value).into();
+                        let flattened_value: LocatedFlattenedValue<F> =
+                            LocatedValue(value_loc, &value).into();
                         let is_global = vec_ref.is_global();
                         if is_global {
                             globals::emit_global_ops(flattened_value, RW::READ, rw_operations);

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -17,7 +17,7 @@ use movelang::value::{
     ContainerRef, GlobalRef, IndexedLocation, IndexedRef, LocalRef, LocatedValue, Location,
     SimpleValue, Reference, Value, ValueLocation,
 };
-use movelang::word::{LocatedWord, Word};
+use movelang::extended_value::{LocatedExtendedValue, ExtendedValue};
 use petgraph::prelude::EdgeRef;
 use petgraph::Direction;
 use std::convert::From;
@@ -184,7 +184,7 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::Pop => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         Ok(())
                     }
@@ -227,14 +227,14 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::CopyLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.copy(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::StLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         self.locals
                             .store(*v as usize, value, frame_index, rw_operations)
@@ -242,7 +242,7 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::MoveLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.move_(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -252,7 +252,7 @@ impl<F: FieldExt> Frame<F> {
                             self.locals
                                 .borrow_locals(*v as usize, frame_index, rw_operations)?;
                         let word_element_count =
-                            Word::from(local_ref.refer.borrow().deref()).0.len();
+                            ExtendedValue::from(local_ref.refer.borrow().deref()).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(local_ref.into(), rw_operations)
                     }
@@ -270,28 +270,28 @@ impl<F: FieldExt> Frame<F> {
                         match reference {
                             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                                 let (account_addr, sd_index) = (loc.address, loc.sd_index);
-                                let word: LocatedWord<F> =
+                                let extended_value: LocatedExtendedValue<F> =
                                     LocatedValue(ValueLocation::Global(loc), &value).into();
-                                let word_element_count = word.0.len();
+                                let word_element_count = extended_value.0.len();
                                 execution_step.auxiliary_2 = Some(Value::Address(account_addr));
                                 execution_step.auxiliary_3 =
                                     Some(Value::u64(word_element_count as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_index.to_u128()));
                                 execution_step.auxiliary_5 = Some(Value::bool(true)); // global
-                                globals::emit_global_ops_for_word(word, RW::READ, rw_operations);
+                                globals::emit_global_ops(extended_value, RW::READ, rw_operations);
                             }
                             Reference::LocalRef(LocalRef { loc, .. }) => {
                                 let frame_index = loc.frame_index;
                                 let index = loc.index;
-                                let word: LocatedWord<F> =
+                                let extended_value: LocatedExtendedValue<F> =
                                     LocatedValue(ValueLocation::Local(loc), &value).into();
-                                let word_element_count = word.0.len();
+                                let word_element_count = extended_value.0.len();
                                 execution_step.locals_index = index;
                                 execution_step.auxiliary_2 = Some(Value::u64(frame_index.0 as u64));
                                 execution_step.auxiliary_3 =
                                     Some(Value::u64(word_element_count as u64)); // word_elem_count
                                 execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
-                                locals::emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                                locals::emit_locals_ops(extended_value, RW::READ, rw_operations);
                             }
                             Reference::IndexedRef(IndexedRef {
                                 sub_indexes,
@@ -308,8 +308,8 @@ impl<F: FieldExt> Frame<F> {
                                             },
                                             &value,
                                         );
-                                        let word: LocatedWord<F> = indexed_value.into();
-                                        let word_element_count = word.0.len();
+                                        let extended_value: LocatedExtendedValue<F> = indexed_value.into();
+                                        let word_element_count = extended_value.0.len();
                                         execution_step.auxiliary_2 =
                                             Some(Value::Address(account_addr));
                                         execution_step.auxiliary_3 =
@@ -317,8 +317,8 @@ impl<F: FieldExt> Frame<F> {
                                         execution_step.auxiliary_4 =
                                             Some(Value::u128(sd_index.to_u128()));
                                         execution_step.auxiliary_5 = Some(Value::bool(true)); // global
-                                        globals::emit_global_ops_for_word(
-                                            word,
+                                        globals::emit_global_ops(
+                                            extended_value,
                                             RW::READ,
                                             rw_operations,
                                         );
@@ -333,16 +333,16 @@ impl<F: FieldExt> Frame<F> {
                                             },
                                             &value,
                                         );
-                                        let word: LocatedWord<F> = indexed_value.into();
-                                        let word_element_count = word.0.len();
+                                        let extended_value: LocatedExtendedValue<F> = indexed_value.into();
+                                        let word_element_count = extended_value.0.len();
                                         execution_step.locals_index = index;
                                         execution_step.auxiliary_2 =
                                             Some(Value::u64(frame_index.0 as u64));
                                         execution_step.auxiliary_3 =
                                             Some(Value::u64(word_element_count as u64)); // word_elem_count
                                         execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
-                                        locals::emit_locals_ops_for_word(
-                                            word,
+                                        locals::emit_locals_ops(
+                                            extended_value,
                                             RW::READ,
                                             rw_operations,
                                         );
@@ -361,28 +361,28 @@ impl<F: FieldExt> Frame<F> {
 
                         match reference {
                             Reference::LocalRef(LocalRef { loc, .. }) => {
-                                let word: LocatedWord<F> =
+                                let extended_value: LocatedExtendedValue<F> =
                                     LocatedValue(ValueLocation::Local(loc), &value).into();
-                                let word_element_count = Word::from(&value).0.len();
+                                let word_element_count = extended_value.0.len();
                                 execution_step.locals_index = loc.index;
                                 execution_step.auxiliary_2 =
                                     Some(Value::u64(loc.frame_index.0 as u64));
                                 execution_step.auxiliary_3 =
                                     Some(Value::u64(word_element_count as u64));
                                 execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
-                                locals::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
+                                locals::emit_locals_ops(extended_value, RW::WRITE, rw_operations);
                             }
                             Reference::GlobalRef(GlobalRef { loc, .. }) => {
                                 let (account_addr, sd_idx) = (loc.address, loc.sd_index);
-                                let word: LocatedWord<F> =
+                                let extended_value: LocatedExtendedValue<F> =
                                     LocatedValue(ValueLocation::Global(loc), &value).into();
 
                                 execution_step.auxiliary_2 = Some(Value::address(account_addr));
-                                execution_step.auxiliary_3 = Some(Value::u64(word.0.len() as u64)); // word_elem_count
+                                execution_step.auxiliary_3 = Some(Value::u64(extended_value.0.len() as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_idx.to_u128()));
                                 execution_step.auxiliary_5 = Some(Value::bool(true)); // is global
-                                globals::emit_global_ops_for_word(
-                                    word.clone(),
+                                globals::emit_global_ops(
+                                    extended_value.clone(),
                                     RW::WRITE,
                                     rw_operations,
                                 );
@@ -393,7 +393,7 @@ impl<F: FieldExt> Frame<F> {
                             }) => {
                                 match container_ref {
                                     ContainerRef::Local(vloc, _) => {
-                                        let word: LocatedWord<F> = LocatedValue(
+                                        let extended_value: LocatedExtendedValue<F> = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Local(vloc),
@@ -401,22 +401,22 @@ impl<F: FieldExt> Frame<F> {
                                             &value,
                                         )
                                         .into();
-                                        let word_element_count = Word::from(&value).0.len();
+                                        let word_element_count = extended_value.0.len();
                                         execution_step.locals_index = vloc.index;
                                         execution_step.auxiliary_2 =
                                             Some(Value::u64(vloc.frame_index.0 as u64));
                                         execution_step.auxiliary_3 =
                                             Some(Value::u64(word_element_count as u64));
                                         execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
-                                        locals::emit_locals_ops_for_word(
-                                            word,
+                                        locals::emit_locals_ops(
+                                            extended_value,
                                             RW::WRITE,
                                             rw_operations,
                                         );
                                     }
                                     ContainerRef::Global(vloc, _) => {
                                         let (account_addr, sd_idx) = (vloc.address, vloc.sd_index);
-                                        let word: LocatedWord<F> = LocatedValue(
+                                        let extended_value: LocatedExtendedValue<F> = LocatedValue(
                                             IndexedLocation {
                                                 sub_indexes,
                                                 value_loc: ValueLocation::Global(vloc),
@@ -428,12 +428,12 @@ impl<F: FieldExt> Frame<F> {
                                         execution_step.auxiliary_2 =
                                             Some(Value::address(account_addr));
                                         execution_step.auxiliary_3 =
-                                            Some(Value::u64(word.0.len() as u64)); // word_elem_count
+                                            Some(Value::u64(extended_value.0.len() as u64)); // word_elem_count
                                         execution_step.auxiliary_4 =
                                             Some(Value::u128(sd_idx.to_u128()));
                                         execution_step.auxiliary_5 = Some(Value::bool(true)); // is global
-                                        globals::emit_global_ops_for_word(
-                                            word.clone(),
+                                        globals::emit_global_ops(
+                                            extended_value.clone(),
                                             RW::WRITE,
                                             rw_operations,
                                         );
@@ -610,7 +610,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
                         let value = Value::container(args);
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -620,7 +620,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
                         let value = Value::container(args);
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -918,7 +918,7 @@ impl<F: FieldExt> Frame<F> {
                             })?;
                         let elements = interp.stack.popn(*num as u16, rw_operations)?;
                         let value = Value::container(elements);
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -934,13 +934,13 @@ impl<F: FieldExt> Frame<F> {
 
                         // emit read op for vec header
                         let vec = vec_ref.read_ref()?;
-                        let word: LocatedWord<F> = match vec_ref.location()? {
+                        let extended_value: LocatedExtendedValue<F> = match vec_ref.location()? {
                             Location::ValueLocation(l) => LocatedValue(l, &vec).into(),
                             Location::IndexedLocation(l) => LocatedValue(l, &vec).into(),
                         };
                         if vec_ref.is_global() {
                             let (header_address_path, header_value) =
-                                word.0.first().expect("header address should not be none");
+                                extended_value.0.first().expect("header address should not be none");
                             globals::emit_global_op(
                                 header_address_path.clone(),
                                 *header_value,
@@ -950,7 +950,7 @@ impl<F: FieldExt> Frame<F> {
                             execution_step.auxiliary_1 = Some(Value::bool(true));
                         } else {
                             let (header_address_path, header_value) =
-                                word.0.first().expect("header address should not be none");
+                                extended_value.0.first().expect("header address should not be none");
                             locals::emit_locals_op(
                                 header_address_path.clone(),
                                 *header_value,
@@ -982,7 +982,7 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::VecPushBack(si) => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
                         let vec_ref = interp.stack.pop_as_vector_ref(rw_operations)?;
                         let ref_val_flattened_len = vec_ref.value_address_path().len();
                         let headers = vec_ref.current_and_parent_container_headers()?;
@@ -1001,13 +1001,13 @@ impl<F: FieldExt> Frame<F> {
                         let value_ref = vec_ref.try_borrow_elem(value_idx)?;
                         let (value_loc, value) =
                             VmResult::<(IndexedLocation<F>, Value<F>)>::from(value_ref)?;
-                        let word: LocatedWord<F> = LocatedValue(value_loc, &value).into();
+                        let extended_value: LocatedExtendedValue<F> = LocatedValue(value_loc, &value).into();
                         let is_global = vec_ref.is_global();
                         if is_global {
-                            globals::emit_global_ops_for_word(word, RW::WRITE, rw_operations);
+                            globals::emit_global_ops(extended_value, RW::WRITE, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(true));
                         } else {
-                            locals::emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
+                            locals::emit_locals_ops(extended_value, RW::WRITE, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
 
@@ -1076,16 +1076,16 @@ impl<F: FieldExt> Frame<F> {
                         let value_ref = vec_ref.try_borrow_elem(value_idx)?;
                         let (value_loc, value) =
                             VmResult::<(IndexedLocation<F>, Value<F>)>::from(value_ref)?;
-                        let word: LocatedWord<F> = LocatedValue(value_loc, &value).into();
+                        let extended_value: LocatedExtendedValue<F> = LocatedValue(value_loc, &value).into();
                         let is_global = vec_ref.is_global();
                         if is_global {
-                            globals::emit_global_ops_for_word(word, RW::READ, rw_operations);
+                            globals::emit_global_ops(extended_value, RW::READ, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(true));
                         } else {
-                            locals::emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                            locals::emit_locals_ops(extended_value, RW::READ, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
-                        let word_element_count = Word::from(&value).0.len();
+                        let word_element_count = ExtendedValue::from(&value).0.len();
 
                         execution_step.auxiliary_1 = Some(Value::u64(si.0 as u64));
                         // auxiliary_2 is multiplexed by header_len and value_index.
@@ -1180,44 +1180,44 @@ impl<F: FieldExt> Frame<F> {
 
                         let is_global = vec_ref.is_global();
                         if is_global {
-                            globals::emit_global_ops_for_word(
+                            globals::emit_global_ops(
                                 LocatedValue(elem_a_loc.clone(), &elem_a).into(),
                                 RW::READ,
                                 rw_operations,
                             );
-                            globals::emit_global_ops_for_word(
+                            globals::emit_global_ops(
                                 LocatedValue(elem_b_loc.clone(), &elem_b).into(),
                                 RW::READ,
                                 rw_operations,
                             );
-                            globals::emit_global_ops_for_word(
+                            globals::emit_global_ops(
                                 LocatedValue(elem_b_loc, &elem_a).into(),
                                 RW::WRITE,
                                 rw_operations,
                             );
-                            globals::emit_global_ops_for_word(
+                            globals::emit_global_ops(
                                 LocatedValue(elem_a_loc, &elem_b).into(),
                                 RW::WRITE,
                                 rw_operations,
                             );
                             execution_step.auxiliary_5 = Some(Value::bool(true));
                         } else {
-                            locals::emit_locals_ops_for_word(
+                            locals::emit_locals_ops(
                                 LocatedValue(elem_a_loc.clone(), &elem_a).into(),
                                 RW::READ,
                                 rw_operations,
                             );
-                            locals::emit_locals_ops_for_word(
+                            locals::emit_locals_ops(
                                 LocatedValue(elem_b_loc.clone(), &elem_b).into(),
                                 RW::READ,
                                 rw_operations,
                             );
-                            locals::emit_locals_ops_for_word(
+                            locals::emit_locals_ops(
                                 LocatedValue(elem_b_loc, &elem_a).into(),
                                 RW::WRITE,
                                 rw_operations,
                             );
-                            locals::emit_locals_ops_for_word(
+                            locals::emit_locals_ops(
                                 LocatedValue(elem_a_loc, &elem_b).into(),
                                 RW::WRITE,
                                 rw_operations,
@@ -1225,8 +1225,8 @@ impl<F: FieldExt> Frame<F> {
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
 
-                        let word_a_element_count = Word::from(&elem_a).0.len();
-                        let word_b_element_count = Word::from(&elem_b).0.len();
+                        let word_a_element_count = ExtendedValue::from(&elem_a).0.len();
+                        let word_b_element_count = ExtendedValue::from(&elem_b).0.len();
 
                         execution_step.auxiliary_1 = Some(Value::u64(si.0 as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(word_a_element_count as u64));

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -184,8 +184,8 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::Pop => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         Ok(())
                     }
                     Bytecode::Add => {
@@ -227,23 +227,23 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::CopyLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.copy(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::StLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         self.locals
                             .store(*v as usize, value, frame_index, rw_operations)
                     }
                     Bytecode::MoveLoc(v) => {
                         execution_step.locals_index = *v as usize;
                         let value = self.locals.move_(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::ImmBorrowLoc(v) | Bytecode::MutBorrowLoc(v) => {
@@ -251,9 +251,9 @@ impl<F: FieldExt> Frame<F> {
                         let local_ref =
                             self.locals
                                 .borrow_locals(*v as usize, frame_index, rw_operations)?;
-                        let word_element_count =
+                        let flattened_value_len =
                             FlattenedValue::from(local_ref.refer.borrow().deref()).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(local_ref.into(), rw_operations)
                     }
 
@@ -272,10 +272,10 @@ impl<F: FieldExt> Frame<F> {
                                 let (account_addr, sd_index) = (loc.address, loc.sd_index);
                                 let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Global(loc), &value).into();
-                                let word_element_count = flattened_value.0.len();
+                                let flattened_value_len = flattened_value.0.len();
                                 execution_step.auxiliary_2 = Some(Value::Address(account_addr));
                                 execution_step.auxiliary_3 =
-                                    Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                    Some(Value::u64(flattened_value_len as u64)); // word_elem_count
                                 execution_step.auxiliary_4 = Some(Value::u128(sd_index.to_u128()));
                                 execution_step.auxiliary_5 = Some(Value::bool(true)); // global
                                 globals::emit_global_ops(flattened_value, RW::READ, rw_operations);
@@ -285,11 +285,11 @@ impl<F: FieldExt> Frame<F> {
                                 let index = loc.index;
                                 let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Local(loc), &value).into();
-                                let word_element_count = flattened_value.0.len();
+                                let flattened_value_len = flattened_value.0.len();
                                 execution_step.locals_index = index;
                                 execution_step.auxiliary_2 = Some(Value::u64(frame_index.0 as u64));
                                 execution_step.auxiliary_3 =
-                                    Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                    Some(Value::u64(flattened_value_len as u64)); // word_elem_count
                                 execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
                                 locals::emit_locals_ops(flattened_value, RW::READ, rw_operations);
                             }
@@ -309,11 +309,11 @@ impl<F: FieldExt> Frame<F> {
                                             &value,
                                         );
                                         let flattened_value: LocatedFlattenedValue<F> = indexed_value.into();
-                                        let word_element_count = flattened_value.0.len();
+                                        let flattened_value_len = flattened_value.0.len();
                                         execution_step.auxiliary_2 =
                                             Some(Value::Address(account_addr));
                                         execution_step.auxiliary_3 =
-                                            Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                            Some(Value::u64(flattened_value_len as u64)); // word_elem_count
                                         execution_step.auxiliary_4 =
                                             Some(Value::u128(sd_index.to_u128()));
                                         execution_step.auxiliary_5 = Some(Value::bool(true)); // global
@@ -334,12 +334,12 @@ impl<F: FieldExt> Frame<F> {
                                             &value,
                                         );
                                         let flattened_value: LocatedFlattenedValue<F> = indexed_value.into();
-                                        let word_element_count = flattened_value.0.len();
+                                        let flattened_value_len = flattened_value.0.len();
                                         execution_step.locals_index = index;
                                         execution_step.auxiliary_2 =
                                             Some(Value::u64(frame_index.0 as u64));
                                         execution_step.auxiliary_3 =
-                                            Some(Value::u64(word_element_count as u64)); // word_elem_count
+                                            Some(Value::u64(flattened_value_len as u64)); // word_elem_count
                                         execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
                                         locals::emit_locals_ops(
                                             flattened_value,
@@ -363,12 +363,12 @@ impl<F: FieldExt> Frame<F> {
                             Reference::LocalRef(LocalRef { loc, .. }) => {
                                 let flattened_value: LocatedFlattenedValue<F> =
                                     LocatedValue(ValueLocation::Local(loc), &value).into();
-                                let word_element_count = flattened_value.0.len();
+                                let flattened_value_len = flattened_value.0.len();
                                 execution_step.locals_index = loc.index;
                                 execution_step.auxiliary_2 =
                                     Some(Value::u64(loc.frame_index.0 as u64));
                                 execution_step.auxiliary_3 =
-                                    Some(Value::u64(word_element_count as u64));
+                                    Some(Value::u64(flattened_value_len as u64));
                                 execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
                                 locals::emit_locals_ops(flattened_value, RW::WRITE, rw_operations);
                             }
@@ -401,12 +401,12 @@ impl<F: FieldExt> Frame<F> {
                                             &value,
                                         )
                                         .into();
-                                        let word_element_count = flattened_value.0.len();
+                                        let flattened_value_len = flattened_value.0.len();
                                         execution_step.locals_index = vloc.index;
                                         execution_step.auxiliary_2 =
                                             Some(Value::u64(vloc.frame_index.0 as u64));
                                         execution_step.auxiliary_3 =
-                                            Some(Value::u64(word_element_count as u64));
+                                            Some(Value::u64(flattened_value_len as u64));
                                         execution_step.auxiliary_5 = Some(Value::bool(false)); // is not global
                                         locals::emit_locals_ops(
                                             flattened_value,
@@ -451,23 +451,23 @@ impl<F: FieldExt> Frame<F> {
                     }
                     Bytecode::ImmBorrowField(fh_idx) | Bytecode::MutBorrowField(fh_idx) => {
                         let reference = interp.stack.pop_as_reference(rw_operations)?;
-                        let word_element_count = reference.value_address_path().len();
+                        let flattened_value_len = reference.value_address_path().len();
                         let field_offset = resolver.field_offset(*fh_idx);
                         let field_ref = reference.try_borrow_field(field_offset)?;
                         execution_step.auxiliary_1 = Some(Value::u64(fh_idx.0 as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(field_offset as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(field_ref.into(), rw_operations)
                     }
                     Bytecode::ImmBorrowFieldGeneric(fh_idx)
                     | Bytecode::MutBorrowFieldGeneric(fh_idx) => {
                         let reference = interp.stack.pop_as_reference(rw_operations)?;
-                        let word_element_count = reference.value_address_path().len();
+                        let flattened_value_len = reference.value_address_path().len();
                         let field_offset = resolver.field_instantiation_offset(*fh_idx);
                         let field_ref = reference.try_borrow_field(field_offset)?;
                         execution_step.auxiliary_1 = Some(Value::u64(fh_idx.0 as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(field_offset as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(field_ref.into(), rw_operations)
                     }
                     Bytecode::LdTrue => {
@@ -610,8 +610,8 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
                         let value = Value::container(args);
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::PackGeneric(sd_idx) => {
@@ -620,17 +620,17 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
                         let args = interp.stack.popn(field_count, rw_operations)?;
                         let value = Value::container(args);
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::Unpack(sd_idx) => {
                         let field_count = resolver.field_count(*sd_idx);
                         execution_step.auxiliary_1 = Some(Value::u64(field_count as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(sd_idx.0 as u64));
-                        let (struct_, word_element_count) =
+                        let (struct_, flattened_value_len) =
                             interp.stack.pop_as_container(rw_operations)?;
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         for value in struct_.unpack() {
                             interp.stack.push(value, rw_operations)?;
                         }
@@ -640,9 +640,9 @@ impl<F: FieldExt> Frame<F> {
                         let field_count = resolver.field_instantiation_count(*sdi_idx);
                         execution_step.auxiliary_1 = Some(Value::u64(field_count as u64));
                         execution_step.auxiliary_2 = Some(Value::u64(sdi_idx.0 as u64));
-                        let (struct_, word_element_count) =
+                        let (struct_, flattened_value_len) =
                             interp.stack.pop_as_container(rw_operations)?;
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         for value in struct_.unpack() {
                             interp.stack.push(value, rw_operations)?;
                         }
@@ -678,7 +678,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 =
                             Some(Value::u128(pos_to_id(callee_node.pos())));
                         let caller_pc = interp.frames.top().map(|f| f.pc()).unwrap_or(0);
-                        // execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        // execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         execution_step.auxiliary_4 = Some(Value::u64(caller_pc as u64));
 
                         let addr = interp.stack.pop_as_account_address(rw_operations)?;
@@ -698,7 +698,7 @@ impl<F: FieldExt> Frame<F> {
                         // If this limit is constrained by bytecode verifier, then circuit doesn't need to worry about this.
                         // But if not, we should write a Invalid to the global struct.
                         // For now, we take a progressive action.
-                        let word_elem_num = globals::emit_ops_for_global_value(
+                        let flattened_value_len = globals::emit_ops_for_global_value(
                             addr,
                             (*sd_idx).into(),
                             value.clone(),
@@ -707,7 +707,7 @@ impl<F: FieldExt> Frame<F> {
                             rw_operations,
                         )?;
                         execution_step.auxiliary_1 = Some(Value::u64(sd_idx.0 as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::MoveFromGeneric(sd_idx) => {
@@ -721,7 +721,7 @@ impl<F: FieldExt> Frame<F> {
                         // If this limit is constrained by bytecode verifier, then circuit doesn't need to worry about this.
                         // But if not, we should write a Invalid to the global struct.
                         // For now, we take a progressive action.
-                        let word_elem_num = globals::emit_ops_for_global_value(
+                        let flattened_value_len = globals::emit_ops_for_global_value(
                             addr,
                             (*sd_idx).into(),
                             value.clone(),
@@ -752,7 +752,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 =
                             Some(Value::u128(pos_to_id(callee_node.pos())));
                         let caller_pc = interp.frames.top().map(|f| f.pc()).unwrap_or(0);
-                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         execution_step.auxiliary_4 = Some(Value::u64(caller_pc as u64));
                         interp.stack.push(value, rw_operations)
                     }
@@ -766,7 +766,7 @@ impl<F: FieldExt> Frame<F> {
                         let addr = addr_value
                             .into_account_address()
                             .expect("address should not be None");
-                        let word_elem_num = globals::emit_ops_for_global_value(
+                        let flattened_value_len = globals::emit_ops_for_global_value(
                             addr,
                             (*sd_idx).into(),
                             resource.clone(),
@@ -775,7 +775,7 @@ impl<F: FieldExt> Frame<F> {
                             rw_operations,
                         )?;
                         execution_step.auxiliary_1 = Some(Value::u64(sd_idx.0 as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
 
                         let ty = resolver.get_struct_type(*sd_idx);
                         interp.move_to(data_store, loader, addr, &ty, resource)
@@ -790,7 +790,7 @@ impl<F: FieldExt> Frame<F> {
                         let addr = addr_value
                             .into_account_address()
                             .expect("address should not be None");
-                        let word_elem_num = globals::emit_ops_for_global_value(
+                        let flattened_value_len = globals::emit_ops_for_global_value(
                             addr,
                             (*sd_idx).into(),
                             resource.clone(),
@@ -821,7 +821,7 @@ impl<F: FieldExt> Frame<F> {
                         execution_step.auxiliary_2 =
                             Some(Value::u128(pos_to_id(callee_node.pos())));
                         let caller_pc = interp.frames.top().map(|f| f.pc()).unwrap_or(0);
-                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         execution_step.auxiliary_4 = Some(Value::u64(caller_pc as u64));
 
                         let ty = resolver.instantiate_generic_type(*sd_idx, self.ty_args()).map_err(|e| {
@@ -841,7 +841,7 @@ impl<F: FieldExt> Frame<F> {
                             (*sd_idx).into(),
                         )?);
                         let global_value = global_ref.read_ref()?;
-                        let word_elem_num = globals::emit_ops_for_global_value(
+                        let flattened_value_len = globals::emit_ops_for_global_value(
                             addr,
                             (*sd_idx).into(),
                             global_value,
@@ -850,7 +850,7 @@ impl<F: FieldExt> Frame<F> {
                             rw_operations,
                         )?;
                         execution_step.auxiliary_1 = Some(Value::u64(sd_idx.0 as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
 
                         interp.stack.push(global_ref.into(), rw_operations)
                     }
@@ -869,7 +869,7 @@ impl<F: FieldExt> Frame<F> {
                             (*sd_idx).into(),
                         )?);
                         let global_value = global_ref.read_ref()?;
-                        let word_elem_num = globals::emit_ops_for_global_value(
+                        let flattened_value_len = globals::emit_ops_for_global_value(
                             addr,
                             (*sd_idx).into(),
                             global_value,
@@ -878,7 +878,7 @@ impl<F: FieldExt> Frame<F> {
                             rw_operations,
                         )?;
                         execution_step.auxiliary_1 = Some(Value::u64(sd_idx.0 as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_elem_num as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
 
                         let next_node_index = self.get_next_call_node(call_graph, true);
                         let callee_node = call_graph.graph.node_weight(next_node_index).unwrap();
@@ -918,8 +918,8 @@ impl<F: FieldExt> Frame<F> {
                             })?;
                         let elements = interp.stack.popn(*num as u16, rw_operations)?;
                         let value = Value::container(elements);
-                        let word_element_count = FlattenedValue::from(&value).0.len();
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         interp.stack.push(value, rw_operations)
                     }
                     Bytecode::VecLen(si) => {
@@ -967,7 +967,7 @@ impl<F: FieldExt> Frame<F> {
                     Bytecode::VecImmBorrow(si) | Bytecode::VecMutBorrow(si) => {
                         let idx = interp.stack.pop_as_u64(rw_operations)? as usize;
                         let vec_ref = interp.stack.pop_as_vector_ref(rw_operations)?;
-                        let word_element_count = vec_ref.value_address_path().len();
+                        let flattened_value_len = vec_ref.value_address_path().len();
                         //fixme: need type check?
                         let _ty = resolver
                             .instantiate_single_type(*si, self.ty_args())
@@ -976,13 +976,13 @@ impl<F: FieldExt> Frame<F> {
                                 RuntimeError::new(StatusCode::InstantiateTypeFailed)
                             })?;
                         execution_step.auxiliary_1 = Some(Value::u64(si.0 as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         let res = vec_ref.try_borrow_elem(idx)?;
                         interp.stack.push(res.into(), rw_operations)
                     }
                     Bytecode::VecPushBack(si) => {
                         let value = interp.stack.pop(rw_operations)?;
-                        let word_element_count = FlattenedValue::from(&value).0.len();
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
                         let vec_ref = interp.stack.pop_as_vector_ref(rw_operations)?;
                         let ref_val_flattened_len = vec_ref.value_address_path().len();
                         let headers = vec_ref.current_and_parent_container_headers()?;
@@ -1015,7 +1015,7 @@ impl<F: FieldExt> Frame<F> {
                         // auxiliary_2 is multiplexed by header_len and value_index.
                         let val = (value_idx << 8) + headers.len();
                         execution_step.auxiliary_2 = Some(Value::u64(val as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         execution_step.auxiliary_4 = Some(Value::u64(ref_val_flattened_len as u64));
 
                         // update container headers
@@ -1085,13 +1085,13 @@ impl<F: FieldExt> Frame<F> {
                             locals::emit_locals_ops(flattened_value, RW::READ, rw_operations);
                             execution_step.auxiliary_5 = Some(Value::bool(false));
                         }
-                        let word_element_count = FlattenedValue::from(&value).0.len();
+                        let flattened_value_len = FlattenedValue::from(&value).0.len();
 
                         execution_step.auxiliary_1 = Some(Value::u64(si.0 as u64));
                         // auxiliary_2 is multiplexed by header_len and value_index.
                         let val = (value_idx << 8) + headers.len();
                         execution_step.auxiliary_2 = Some(Value::u64(val as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         execution_step.auxiliary_4 = Some(Value::u64(ref_val_flattened_len as u64));
 
                         let val = vec_ref.pop()?;
@@ -1138,7 +1138,7 @@ impl<F: FieldExt> Frame<F> {
                         Ok(())
                     }
                     Bytecode::VecUnpack(si, num) => {
-                        let (vec, word_element_count) =
+                        let (vec, flattened_value_len) =
                             interp.stack.pop_as_container(rw_operations)?;
                         //fixme: need type check?
                         let _ty = resolver
@@ -1154,7 +1154,7 @@ impl<F: FieldExt> Frame<F> {
 
                         execution_step.auxiliary_1 = Some(Value::u64(*num));
                         execution_step.auxiliary_2 = Some(Value::u64(si.0 as u64));
-                        execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                        execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                         Ok(())
                     }
                     Bytecode::VecSwap(si) => {

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -6,7 +6,7 @@ use movelang::value::{
     AddressPath, GlobalLocation, GlobalResourceDefIndex, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
-use movelang::extended_value::LocatedExtendedValue;
+use movelang::flattened_value::LocatedFlattenedValue;
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_op<F: FieldExt>(
@@ -33,11 +33,11 @@ pub fn emit_global_op<F: FieldExt>(
 
 #[allow(clippy::type_complexity)]
 pub fn emit_global_ops<F: FieldExt>(
-    extended_value: LocatedExtendedValue<F>,
+    flattened_value: LocatedFlattenedValue<F>,
     rw: RW,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) {
-    for (address_path, val) in extended_value.0 {
+    for (address_path, val) in flattened_value.0 {
         emit_global_op(address_path, val, rw, rw_operations);
     }
 }
@@ -53,10 +53,10 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
         address: addr,
         sd_index,
     };
-    let extended_value: LocatedExtendedValue<F> =
+    let flattened_value: LocatedFlattenedValue<F> =
         LocatedValue(ValueLocation::Global(value_addr), &resource_value).into();
-    let word_elem_num = extended_value.0.len();
-    for (address_path, val) in extended_value.0.clone() {
+    let word_elem_num = flattened_value.0.len();
+    for (address_path, val) in flattened_value.0.clone() {
         let op = GlobalOp {
             address: addr,
             sd_index: sd_index.to_u128() as usize,
@@ -69,7 +69,7 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
     }
     // if this is move_from, we need to write an invalid back.
     if write_invalid {
-        for (address_path, _) in extended_value.0 {
+        for (address_path, _) in flattened_value.0 {
             let op = GlobalOp {
                 address: addr,
                 sd_index: sd_index.to_u128() as usize,

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -55,7 +55,7 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
     };
     let flattened_value: LocatedFlattenedValue<F> =
         LocatedValue(ValueLocation::Global(value_addr), &resource_value).into();
-    let word_elem_num = flattened_value.0.len();
+    let flattened_value_len = flattened_value.0.len();
     for (address_path, val) in flattened_value.0.clone() {
         let op = GlobalOp {
             address: addr,
@@ -81,5 +81,5 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
             rw_operations.push(RWOperation::GlobalOp(op));
         }
     }
-    Ok(word_elem_num)
+    Ok(flattened_value_len)
 }

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -3,7 +3,7 @@ use halo2_proofs::arithmetic::FieldExt;
 
 use movelang::account_address::AccountAddress;
 use movelang::value::{
-    AddressPath, GlobalLocation, GlobalResourceDefIndex, LocatedValue, PrimitiveValue, Value,
+    AddressPath, GlobalLocation, GlobalResourceDefIndex, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
 use movelang::word::LocatedWord;
@@ -11,7 +11,7 @@ use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_op<F: FieldExt>(
     address_path: AddressPath<F>,
-    value: PrimitiveValue<F>,
+    value: SimpleValue<F>,
     rw: RW,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) {

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -6,7 +6,7 @@ use movelang::value::{
     AddressPath, GlobalLocation, GlobalResourceDefIndex, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
-use movelang::word::LocatedWord;
+use movelang::extended_value::LocatedExtendedValue;
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_op<F: FieldExt>(
@@ -32,12 +32,12 @@ pub fn emit_global_op<F: FieldExt>(
 }
 
 #[allow(clippy::type_complexity)]
-pub fn emit_global_ops_for_word<F: FieldExt>(
-    word: LocatedWord<F>,
+pub fn emit_global_ops<F: FieldExt>(
+    extended_value: LocatedExtendedValue<F>,
     rw: RW,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) {
-    for (address_path, val) in word.0 {
+    for (address_path, val) in extended_value.0 {
         emit_global_op(address_path, val, rw, rw_operations);
     }
 }
@@ -53,10 +53,10 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
         address: addr,
         sd_index,
     };
-    let word: LocatedWord<F> =
+    let extended_value: LocatedExtendedValue<F> =
         LocatedValue(ValueLocation::Global(value_addr), &resource_value).into();
-    let word_len = word.0.len();
-    for (address_path, val) in word.0.clone() {
+    let word_elem_num = extended_value.0.len();
+    for (address_path, val) in extended_value.0.clone() {
         let op = GlobalOp {
             address: addr,
             sd_index: sd_index.to_u128() as usize,
@@ -69,7 +69,7 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
     }
     // if this is move_from, we need to write an invalid back.
     if write_invalid {
-        for (address_path, _) in word.0 {
+        for (address_path, _) in extended_value.0 {
             let op = GlobalOp {
                 address: addr,
                 sd_index: sd_index.to_u128() as usize,
@@ -81,5 +81,5 @@ pub fn emit_ops_for_global_value<F: FieldExt>(
             rw_operations.push(RWOperation::GlobalOp(op));
         }
     }
-    Ok(word_len)
+    Ok(word_elem_num)
 }

--- a/vm/src/globals.rs
+++ b/vm/src/globals.rs
@@ -6,7 +6,7 @@ use movelang::value::{
     AddressPath, GlobalLocation, GlobalResourceDefIndex, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
-use movelang::flattened_value::LocatedFlattenedValue;
+use movelang::value_ext::LocatedFlattenedValue;
 use vm_circuit::witness::rw_operations::{GlobalOp, RWOperation, RW};
 
 pub fn emit_global_op<F: FieldExt>(

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -233,8 +233,8 @@ impl<F: FieldExt> Interpreter<F> {
                         frame_index + 1,
                         rw_operations,
                     )?;
-                    let word_element_count = (rw_operations.len() - rw_op_count) / 2;
-                    execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                    let flattened_value_len = (rw_operations.len() - rw_op_count) / 2;
+                    execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                     exec_steps.push(execution_step);
 
                     callee_frame.print_frame();
@@ -275,8 +275,8 @@ impl<F: FieldExt> Interpreter<F> {
                         frame_index + 1,
                         rw_operations,
                     )?;
-                    let word_element_count = (rw_operations.len() - rw_op_count) / 2;
-                    execution_step.auxiliary_3 = Some(Value::u64(word_element_count as u64));
+                    let flattened_value_len = (rw_operations.len() - rw_op_count) / 2;
+                    execution_step.auxiliary_3 = Some(Value::u64(flattened_value_len as u64));
                     let caller_pc = if self.frames.size() == 0 {
                         0
                     } else {

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -6,7 +6,7 @@ use movelang::value::{
     AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
-use movelang::flattened_value::LocatedFlattenedValue;
+use movelang::value_ext::LocatedFlattenedValue;
 use std::ops::Deref;
 use std::{cell::RefCell, rc::Rc};
 use vm_circuit::witness::rw_operations::{LocalsOp, RWOperation, RW};
@@ -158,7 +158,8 @@ impl<F: FieldExt> Locals<F> {
                     frame_index: FrameIndex(frame_index),
                     index,
                 };
-                let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
+                let flattened_value: LocatedFlattenedValue<F> =
+                    LocatedValue(ValueLocation::Local(loc), v).into();
                 emit_locals_ops(flattened_value, RW::READ, rw_operations);
                 Ok(LocalRef {
                     loc,
@@ -186,7 +187,8 @@ impl<F: FieldExt> Locals<F> {
         match &*value_cell.borrow() {
             Value::Invalid => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
             v => {
-                let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
+                let flattened_value: LocatedFlattenedValue<F> =
+                    LocatedValue(ValueLocation::Local(loc), v).into();
                 emit_locals_ops(flattened_value, RW::READ, rw_operations);
                 Ok(v.copy_value())
             }

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -3,7 +3,7 @@
 use error::{RuntimeError, StatusCode, VmResult};
 use halo2_proofs::arithmetic::FieldExt;
 use movelang::value::{
-    AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, PrimitiveValue, Value,
+    AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
 use movelang::word::LocatedWord;
@@ -206,7 +206,7 @@ impl<F: FieldExt> Locals<F> {
 
 pub fn emit_locals_op<F: FieldExt>(
     address_path: AddressPath<F>,
-    value: PrimitiveValue<F>,
+    value: SimpleValue<F>,
     rw: RW,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) {

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -6,7 +6,7 @@ use movelang::value::{
     AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
-use movelang::extended_value::LocatedExtendedValue;
+use movelang::flattened_value::LocatedFlattenedValue;
 use std::ops::Deref;
 use std::{cell::RefCell, rc::Rc};
 use vm_circuit::witness::rw_operations::{LocalsOp, RWOperation, RW};
@@ -36,7 +36,7 @@ impl<F: FieldExt> Locals<F> {
                     Err(RuntimeError::new(StatusCode::CopyLocalError))
                 } else {
                     let copied_value = v.borrow().copy_value();
-                    let extended_value: LocatedExtendedValue<F> = LocatedValue(
+                    let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                         ValueLocation::Local(LocalLocation {
                             frame_index: FrameIndex(frame_index),
                             index,
@@ -45,7 +45,7 @@ impl<F: FieldExt> Locals<F> {
                     )
                     .into();
 
-                    emit_locals_ops(extended_value, RW::READ, rw_operations);
+                    emit_locals_ops(flattened_value, RW::READ, rw_operations);
                     Ok(copied_value)
                 }
             }
@@ -72,7 +72,7 @@ impl<F: FieldExt> Locals<F> {
                         );
                     }
                 }
-                let extended_value: LocatedExtendedValue<F> = LocatedValue(
+                let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                     ValueLocation::Local(LocalLocation {
                         frame_index: FrameIndex(frame_index),
                         index,
@@ -80,7 +80,7 @@ impl<F: FieldExt> Locals<F> {
                     &value,
                 )
                 .into();
-                emit_locals_ops(extended_value, RW::WRITE, rw_operations);
+                emit_locals_ops(flattened_value, RW::WRITE, rw_operations);
                 *v.borrow_mut() = value;
                 Ok(())
             }
@@ -102,7 +102,7 @@ impl<F: FieldExt> Locals<F> {
         match old_value {
             Value::Invalid => Err(RuntimeError::new(StatusCode::MoveLocalError)),
             v => {
-                let extended_value: LocatedExtendedValue<F> = LocatedValue(
+                let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                     ValueLocation::Local(LocalLocation {
                         frame_index: FrameIndex(frame_index),
                         index,
@@ -111,9 +111,9 @@ impl<F: FieldExt> Locals<F> {
                 )
                 .into();
                 // LocalsOP Read
-                emit_locals_ops(extended_value.clone(), RW::READ, rw_operations);
+                emit_locals_ops(flattened_value.clone(), RW::READ, rw_operations);
                 // LocalsOP Write
-                for (address_path, _) in extended_value.0 {
+                for (address_path, _) in flattened_value.0 {
                     let locals_op_2 = LocalsOp {
                         frame_index: *address_path
                             .0
@@ -158,8 +158,8 @@ impl<F: FieldExt> Locals<F> {
                     frame_index: FrameIndex(frame_index),
                     index,
                 };
-                let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
-                emit_locals_ops(extended_value, RW::READ, rw_operations);
+                let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
+                emit_locals_ops(flattened_value, RW::READ, rw_operations);
                 Ok(LocalRef {
                     loc,
                     refer: value_cell.clone(),
@@ -186,8 +186,8 @@ impl<F: FieldExt> Locals<F> {
         match &*value_cell.borrow() {
             Value::Invalid => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
             v => {
-                let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
-                emit_locals_ops(extended_value, RW::READ, rw_operations);
+                let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
+                emit_locals_ops(flattened_value, RW::READ, rw_operations);
                 Ok(v.copy_value())
             }
         }
@@ -226,7 +226,7 @@ pub fn emit_locals_op<F: FieldExt>(
 
 #[allow(clippy::type_complexity)]
 pub fn emit_locals_ops<F: FieldExt>(
-    value: LocatedExtendedValue<F>,
+    value: LocatedFlattenedValue<F>,
     rw: RW,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) {

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -6,7 +6,7 @@ use movelang::value::{
     AddressPath, FrameIndex, LocalLocation, LocalRef, LocatedValue, SimpleValue, Value,
     ValueLocation,
 };
-use movelang::word::LocatedWord;
+use movelang::extended_value::LocatedExtendedValue;
 use std::ops::Deref;
 use std::{cell::RefCell, rc::Rc};
 use vm_circuit::witness::rw_operations::{LocalsOp, RWOperation, RW};
@@ -36,7 +36,7 @@ impl<F: FieldExt> Locals<F> {
                     Err(RuntimeError::new(StatusCode::CopyLocalError))
                 } else {
                     let copied_value = v.borrow().copy_value();
-                    let word: LocatedWord<F> = LocatedValue(
+                    let extended_value: LocatedExtendedValue<F> = LocatedValue(
                         ValueLocation::Local(LocalLocation {
                             frame_index: FrameIndex(frame_index),
                             index,
@@ -45,7 +45,7 @@ impl<F: FieldExt> Locals<F> {
                     )
                     .into();
 
-                    emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                    emit_locals_ops(extended_value, RW::READ, rw_operations);
                     Ok(copied_value)
                 }
             }
@@ -72,7 +72,7 @@ impl<F: FieldExt> Locals<F> {
                         );
                     }
                 }
-                let word: LocatedWord<F> = LocatedValue(
+                let extended_value: LocatedExtendedValue<F> = LocatedValue(
                     ValueLocation::Local(LocalLocation {
                         frame_index: FrameIndex(frame_index),
                         index,
@@ -80,7 +80,7 @@ impl<F: FieldExt> Locals<F> {
                     &value,
                 )
                 .into();
-                emit_locals_ops_for_word(word, RW::WRITE, rw_operations);
+                emit_locals_ops(extended_value, RW::WRITE, rw_operations);
                 *v.borrow_mut() = value;
                 Ok(())
             }
@@ -102,7 +102,7 @@ impl<F: FieldExt> Locals<F> {
         match old_value {
             Value::Invalid => Err(RuntimeError::new(StatusCode::MoveLocalError)),
             v => {
-                let word: LocatedWord<F> = LocatedValue(
+                let extended_value: LocatedExtendedValue<F> = LocatedValue(
                     ValueLocation::Local(LocalLocation {
                         frame_index: FrameIndex(frame_index),
                         index,
@@ -111,9 +111,9 @@ impl<F: FieldExt> Locals<F> {
                 )
                 .into();
                 // LocalsOP Read
-                emit_locals_ops_for_word(word.clone(), RW::READ, rw_operations);
+                emit_locals_ops(extended_value.clone(), RW::READ, rw_operations);
                 // LocalsOP Write
-                for (address_path, _) in word.0 {
+                for (address_path, _) in extended_value.0 {
                     let locals_op_2 = LocalsOp {
                         frame_index: *address_path
                             .0
@@ -158,8 +158,8 @@ impl<F: FieldExt> Locals<F> {
                     frame_index: FrameIndex(frame_index),
                     index,
                 };
-                let word: LocatedWord<F> = LocatedValue(ValueLocation::Local(loc), v).into();
-                emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
+                emit_locals_ops(extended_value, RW::READ, rw_operations);
                 Ok(LocalRef {
                     loc,
                     refer: value_cell.clone(),
@@ -186,8 +186,8 @@ impl<F: FieldExt> Locals<F> {
         match &*value_cell.borrow() {
             Value::Invalid => Err(RuntimeError::new(StatusCode::ImmBorrowLocalError)),
             v => {
-                let word: LocatedWord<F> = LocatedValue(ValueLocation::Local(loc), v).into();
-                emit_locals_ops_for_word(word, RW::READ, rw_operations);
+                let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Local(loc), v).into();
+                emit_locals_ops(extended_value, RW::READ, rw_operations);
                 Ok(v.copy_value())
             }
         }
@@ -225,12 +225,12 @@ pub fn emit_locals_op<F: FieldExt>(
 }
 
 #[allow(clippy::type_complexity)]
-pub fn emit_locals_ops_for_word<F: FieldExt>(
-    word: LocatedWord<F>,
+pub fn emit_locals_ops<F: FieldExt>(
+    value: LocatedExtendedValue<F>,
     rw: RW,
     rw_operations: &mut Vec<RWOperation<F>>,
 ) {
-    for (address_path, val) in word.0 {
+    for (address_path, val) in value.0 {
         emit_locals_op(address_path, val, rw, rw_operations)
     }
 }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -8,7 +8,7 @@ use movelang::value::{
     Container, ContainerValue, LocatedValue, Reference, StackLocation, Value, ValueLocation,
     VectorRef,
 };
-use movelang::extended_value::LocatedExtendedValue;
+use movelang::flattened_value::LocatedFlattenedValue;
 use std::rc::Rc;
 use vm_circuit::witness::rw_operations::{RWOperation, StackOp, RW};
 
@@ -24,11 +24,11 @@ impl<F: FieldExt> EvalStack<F> {
 
     #[allow(clippy::type_complexity)]
     pub fn emit_stack_ops(
-        extended_value: LocatedExtendedValue<F>,
+        flattened_value: LocatedFlattenedValue<F>,
         rw: RW,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) {
-        for (address_path, val) in extended_value.0 {
+        for (address_path, val) in flattened_value.0 {
             let stack_op = StackOp {
                 address: *address_path.0.get(1).expect("address should not be None") as usize,
                 address_ext: address_path.addr_ext(),
@@ -46,14 +46,14 @@ impl<F: FieldExt> EvalStack<F> {
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<()> {
         if self.0.len() < EVAL_STACK_SIZE {
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops(extended_value, RW::WRITE, rw_operations);
+            Self::emit_stack_ops(flattened_value, RW::WRITE, rw_operations);
 
             self.0.push(value);
             Ok(())
@@ -67,14 +67,14 @@ impl<F: FieldExt> EvalStack<F> {
             Err(RuntimeError::new(StatusCode::StackUnderflow))
         } else {
             let value = self.0.pop().unwrap();
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             Ok(value)
         }
@@ -93,20 +93,20 @@ impl<F: FieldExt> EvalStack<F> {
         let values = self.0.split_off(remaining_stack_size);
 
         for (i, value) in values.iter().enumerate() {
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: (remaining_stack_size + i),
                 }),
                 value,
             )
             .into();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
         }
 
         Ok(values)
     }
 
-    // return values of a container and its extended_value field count
+    // return values of a container and its flattened_value field count
     pub fn pop_as_container(
         &mut self,
         rw_operations: &mut Vec<RWOperation<F>>,
@@ -118,9 +118,9 @@ impl<F: FieldExt> EvalStack<F> {
             let loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Stack(loc), &value).into();
-            let word_element_count = extended_value.0.len();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(loc), &value).into();
+            let word_element_count = flattened_value.0.len();
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
                 Value::Container(Container(struct_)) => {
@@ -149,14 +149,14 @@ impl<F: FieldExt> EvalStack<F> {
         } else {
             let value = self.0.pop().unwrap();
 
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
                 Value::GlobalRef(r) => Ok(Reference::GlobalRef(r)),
@@ -177,14 +177,14 @@ impl<F: FieldExt> EvalStack<F> {
         } else {
             let value = self.0.pop().unwrap();
 
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
                 Value::LocalRef(r) => Ok(VectorRef::LocalRef(r)),
@@ -206,8 +206,8 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
                 Value::Address(addr) => Ok(addr),
@@ -225,8 +225,8 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
-            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
+            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
+            Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
                 Value::U64(v) => Ok(v.0.get_lower_128() as u64),

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -8,7 +8,7 @@ use movelang::value::{
     Container, ContainerValue, LocatedValue, Reference, StackLocation, Value, ValueLocation,
     VectorRef,
 };
-use movelang::word::LocatedWord;
+use movelang::extended_value::LocatedExtendedValue;
 use std::rc::Rc;
 use vm_circuit::witness::rw_operations::{RWOperation, StackOp, RW};
 
@@ -23,12 +23,12 @@ impl<F: FieldExt> EvalStack<F> {
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn emit_stack_ops_for_word(
-        word: LocatedWord<F>,
+    pub fn emit_stack_ops(
+        extended_value: LocatedExtendedValue<F>,
         rw: RW,
         rw_operations: &mut Vec<RWOperation<F>>,
     ) {
-        for (address_path, val) in word.0 {
+        for (address_path, val) in extended_value.0 {
             let stack_op = StackOp {
                 address: *address_path.0.get(1).expect("address should not be None") as usize,
                 address_ext: address_path.addr_ext(),
@@ -46,14 +46,14 @@ impl<F: FieldExt> EvalStack<F> {
         rw_operations: &mut Vec<RWOperation<F>>,
     ) -> VmResult<()> {
         if self.0.len() < EVAL_STACK_SIZE {
-            let word: LocatedWord<F> = LocatedValue(
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops_for_word(word, RW::WRITE, rw_operations);
+            Self::emit_stack_ops(extended_value, RW::WRITE, rw_operations);
 
             self.0.push(value);
             Ok(())
@@ -67,14 +67,14 @@ impl<F: FieldExt> EvalStack<F> {
             Err(RuntimeError::new(StatusCode::StackUnderflow))
         } else {
             let value = self.0.pop().unwrap();
-            let word: LocatedWord<F> = LocatedValue(
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
 
             Ok(value)
         }
@@ -93,20 +93,20 @@ impl<F: FieldExt> EvalStack<F> {
         let values = self.0.split_off(remaining_stack_size);
 
         for (i, value) in values.iter().enumerate() {
-            let word: LocatedWord<F> = LocatedValue(
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: (remaining_stack_size + i),
                 }),
                 value,
             )
             .into();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
         }
 
         Ok(values)
     }
 
-    // return values of a container and its word field count
+    // return values of a container and its extended_value field count
     pub fn pop_as_container(
         &mut self,
         rw_operations: &mut Vec<RWOperation<F>>,
@@ -118,9 +118,9 @@ impl<F: FieldExt> EvalStack<F> {
             let loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let word: LocatedWord<F> = LocatedValue(ValueLocation::Stack(loc), &value).into();
-            let word_element_count = word.0.len();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Stack(loc), &value).into();
+            let word_element_count = extended_value.0.len();
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
 
             match value {
                 Value::Container(Container(struct_)) => {
@@ -149,14 +149,14 @@ impl<F: FieldExt> EvalStack<F> {
         } else {
             let value = self.0.pop().unwrap();
 
-            let word: LocatedWord<F> = LocatedValue(
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
 
             match value {
                 Value::GlobalRef(r) => Ok(Reference::GlobalRef(r)),
@@ -177,14 +177,14 @@ impl<F: FieldExt> EvalStack<F> {
         } else {
             let value = self.0.pop().unwrap();
 
-            let word: LocatedWord<F> = LocatedValue(
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(
                 ValueLocation::Stack(StackLocation {
                     stack_index: self.0.len(),
                 }),
                 &value,
             )
             .into();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
 
             match value {
                 Value::LocalRef(r) => Ok(VectorRef::LocalRef(r)),
@@ -206,8 +206,8 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let word: LocatedWord<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
 
             match value {
                 Value::Address(addr) => Ok(addr),
@@ -225,8 +225,8 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let word: LocatedWord<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
-            Self::emit_stack_ops_for_word(word, RW::READ, rw_operations);
+            let extended_value: LocatedExtendedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
+            Self::emit_stack_ops(extended_value, RW::READ, rw_operations);
 
             match value {
                 Value::U64(v) => Ok(v.0.get_lower_128() as u64),

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -119,7 +119,7 @@ impl<F: FieldExt> EvalStack<F> {
                 stack_index: self.0.len(),
             };
             let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(loc), &value).into();
-            let word_element_count = flattened_value.0.len();
+            let flattened_value_len = flattened_value.0.len();
             Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
@@ -132,7 +132,7 @@ impl<F: FieldExt> EvalStack<F> {
                         )
                         .with_message(format!("moving value {:?} with dangling references", v))),
                     };
-                    Ok((ContainerValue::pack(fields?), word_element_count))
+                    Ok((ContainerValue::pack(fields?), flattened_value_len))
                 }
                 v => Err(RuntimeError::new(StatusCode::TypeMismatch)
                     .with_message(format!("cannot pop {:?} as struct", v))),

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -8,7 +8,7 @@ use movelang::value::{
     Container, ContainerValue, LocatedValue, Reference, StackLocation, Value, ValueLocation,
     VectorRef,
 };
-use movelang::flattened_value::LocatedFlattenedValue;
+use movelang::value_ext::LocatedFlattenedValue;
 use std::rc::Rc;
 use vm_circuit::witness::rw_operations::{RWOperation, StackOp, RW};
 
@@ -118,7 +118,8 @@ impl<F: FieldExt> EvalStack<F> {
             let loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(loc), &value).into();
+            let flattened_value: LocatedFlattenedValue<F> =
+                LocatedValue(ValueLocation::Stack(loc), &value).into();
             let flattened_value_len = flattened_value.0.len();
             Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
@@ -206,7 +207,8 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
+            let flattened_value: LocatedFlattenedValue<F> =
+                LocatedValue(ValueLocation::Stack(v_loc), &value).into();
             Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {
@@ -225,7 +227,8 @@ impl<F: FieldExt> EvalStack<F> {
             let v_loc = StackLocation {
                 stack_index: self.0.len(),
             };
-            let flattened_value: LocatedFlattenedValue<F> = LocatedValue(ValueLocation::Stack(v_loc), &value).into();
+            let flattened_value: LocatedFlattenedValue<F> =
+                LocatedValue(ValueLocation::Stack(v_loc), &value).into();
             Self::emit_stack_ops(flattened_value, RW::READ, rw_operations);
 
             match value {

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -11,7 +11,7 @@ use move_binary_format::file_format::Bytecode as MoveBytecode;
 use move_binary_format::CompiledModule;
 use movelang::state::StateStore;
 use movelang::value::{SimpleValue, Value};
-use movelang::extended_value::ValueHeader;
+use movelang::flattened_value::ValueHeader;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::arith_operations::ArithOperations;

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -11,7 +11,7 @@ use move_binary_format::file_format::Bytecode as MoveBytecode;
 use move_binary_format::CompiledModule;
 use movelang::state::StateStore;
 use movelang::value::{SimpleValue, Value};
-use movelang::flattened_value::ValueHeader;
+use movelang::value_ext::ValueHeader;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::arith_operations::ArithOperations;

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -10,7 +10,7 @@ use move_binary_format::file_format::empty_script;
 use move_binary_format::file_format::Bytecode as MoveBytecode;
 use move_binary_format::CompiledModule;
 use movelang::state::StateStore;
-use movelang::value::{PrimitiveValue, Value};
+use movelang::value::{SimpleValue, Value};
 use movelang::word::ValueHeader;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::circuit::VmCircuit;
@@ -190,7 +190,7 @@ fn test_execution_step() -> VmResult<()> {
     let expected_rw_op_1 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: WRITE,
         gc: 1,
@@ -206,7 +206,7 @@ fn test_execution_step() -> VmResult<()> {
     let expected_rw_op_3 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: WRITE,
         gc: 3,
@@ -222,7 +222,7 @@ fn test_execution_step() -> VmResult<()> {
     let expected_rw_op_5 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: READ,
         gc: 5,
@@ -238,7 +238,7 @@ fn test_execution_step() -> VmResult<()> {
     let expected_rw_op_7 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: READ,
         gc: 7,
@@ -254,7 +254,7 @@ fn test_execution_step() -> VmResult<()> {
     let expected_rw_op_9 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: WRITE,
         gc: 9,
@@ -270,7 +270,7 @@ fn test_execution_step() -> VmResult<()> {
     let expected_rw_op_11 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: READ,
         gc: 11,
@@ -484,7 +484,7 @@ fn test_nop_step() -> VmResult<()> {
     let rw_op_1 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: WRITE,
         gc: 1,
@@ -500,7 +500,7 @@ fn test_nop_step() -> VmResult<()> {
     let rw_op_3 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: WRITE,
         gc: 3,
@@ -516,7 +516,7 @@ fn test_nop_step() -> VmResult<()> {
     let rw_op_5 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: READ,
         gc: 5,
@@ -532,7 +532,7 @@ fn test_nop_step() -> VmResult<()> {
     let rw_op_7 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: READ,
         gc: 7,
@@ -548,7 +548,7 @@ fn test_nop_step() -> VmResult<()> {
     let rw_op_9 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: WRITE,
         gc: 9,
@@ -564,7 +564,7 @@ fn test_nop_step() -> VmResult<()> {
     let rw_op_11 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: READ,
         gc: 11,
@@ -573,7 +573,7 @@ fn test_nop_step() -> VmResult<()> {
         frame_index: 0,
         index: 0,
         address_ext: 0,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: WRITE,
         gc: 12,
@@ -758,7 +758,7 @@ fn test_nop_steps() -> VmResult<()> {
     let expected_rw_op_1 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: WRITE,
         gc: 1,
@@ -774,7 +774,7 @@ fn test_nop_steps() -> VmResult<()> {
     let expected_rw_op_3 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: WRITE,
         gc: 3,
@@ -790,7 +790,7 @@ fn test_nop_steps() -> VmResult<()> {
     let expected_rw_op_5 = RWOperation::<Fp>::StackOp(StackOp {
         address: 1,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(2)),
+        value: Some(SimpleValue::u64(2)),
 
         rw: READ,
         gc: 5,
@@ -806,7 +806,7 @@ fn test_nop_steps() -> VmResult<()> {
     let expected_rw_op_7 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(1)),
+        value: Some(SimpleValue::u64(1)),
 
         rw: READ,
         gc: 7,
@@ -822,7 +822,7 @@ fn test_nop_steps() -> VmResult<()> {
     let expected_rw_op_9 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: WRITE,
         gc: 9,
@@ -838,7 +838,7 @@ fn test_nop_steps() -> VmResult<()> {
     let expected_rw_op_11 = RWOperation::<Fp>::StackOp(StackOp {
         address: 0,
         address_ext: 1,
-        value: Some(PrimitiveValue::u64(3)),
+        value: Some(SimpleValue::u64(3)),
 
         rw: READ,
         gc: 11,

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -11,7 +11,7 @@ use move_binary_format::file_format::Bytecode as MoveBytecode;
 use move_binary_format::CompiledModule;
 use movelang::state::StateStore;
 use movelang::value::{SimpleValue, Value};
-use movelang::word::ValueHeader;
+use movelang::extended_value::ValueHeader;
 use vm_circuit::chips::execution_chip::opcode::Opcode;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::arith_operations::ArithOperations;


### PR DESCRIPTION
We are confusing the use of Word, which is a fixed-length space to hold Value, and Value, which is not fixed-length; we use len and flattened_len to denote the original and flattened lengths of Value, respectively.

Word -> FlattenedValue
SimpleValueWord -> FlattenedSimpleValue
ReferenceValueWord -> FlattenedReferenceValue

word_element_num -> flattened_value_len
WordGadget -> ValueGadget