### PR TITLE
allow entry function to have a return value

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -169,7 +169,10 @@ impl Arguments {
             circuit_config.clone(),
         )?;
 
-        let vm_circuit = VmCircuit { witness };
+        let vm_circuit = VmCircuit {
+            witness,
+            public_input: None,
+        };
         info!("find the best k...");
         let k = find_best_k(&vm_circuit, vec![])?;
         info!("k = {}", k);
@@ -220,6 +223,7 @@ impl Arguments {
             )?;
             let new_vm_circuit = VmCircuit {
                 witness: new_witness,
+                public_input: None,
             };
             info!("prove the new execution with old proving key...");
             prove_vm_circuit_kzg(new_vm_circuit, &[], &params, pk)?;
@@ -286,7 +290,10 @@ impl Arguments {
             trace,
             circuit_config.clone(),
         )?;
-        let vm_circuit = VmCircuit { witness };
+        let vm_circuit = VmCircuit {
+            witness,
+            public_input: None,
+        };
         info!("find the best k...");
         let k = find_best_k(&vm_circuit, vec![])?;
         info!("k = {}", k);
@@ -337,6 +344,7 @@ impl Arguments {
             )?;
             let new_vm_circuit = VmCircuit {
                 witness: new_witness,
+                public_input: None,
             };
             info!("prove the new execution with old proving key...");
             prove_vm_circuit_ipa(new_vm_circuit, &[], &params, pk)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -174,12 +174,12 @@ impl Arguments {
             public_input: None,
         };
         info!("find the best k...");
-        let k = find_best_k(&vm_circuit, vec![])?;
+        let k = find_best_k(&vm_circuit, vec![vec![Fr::zero()]])?;
         info!("k = {}", k);
 
         if use_mock {
             info!("run with mock prover...");
-            mock_prove_circuit(&vm_circuit, vec![], k)?;
+            mock_prove_circuit(&vm_circuit, vec![vec![Fr::zero()]], k)?;
         }
 
         if print_layout {
@@ -193,7 +193,7 @@ impl Arguments {
         let (_, pk) = setup_vm_circuit(&vm_circuit, &params)?;
 
         info!("prove vm circuit...");
-        prove_vm_circuit_kzg(vm_circuit, &[], &params, pk.clone())?;
+        prove_vm_circuit_kzg(vm_circuit, &[&[Fr::zero()]], &params, pk.clone())?;
         #[allow(clippy::or_fun_call)]
         if let Some(new_args) = new_args
             .as_ref()
@@ -226,7 +226,7 @@ impl Arguments {
                 public_input: None,
             };
             info!("prove the new execution with old proving key...");
-            prove_vm_circuit_kzg(new_vm_circuit, &[], &params, pk)?;
+            prove_vm_circuit_kzg(new_vm_circuit, &[&[Fr::zero()]], &params, pk)?;
         }
 
         Ok(())
@@ -295,12 +295,12 @@ impl Arguments {
             public_input: None,
         };
         info!("find the best k...");
-        let k = find_best_k(&vm_circuit, vec![])?;
+        let k = find_best_k(&vm_circuit, vec![vec![Fp::zero()]])?;
         info!("k = {}", k);
 
         if use_mock {
             info!("run with mock prover...");
-            mock_prove_circuit(&vm_circuit, vec![], k)?;
+            mock_prove_circuit(&vm_circuit, vec![vec![Fp::zero()]], k)?;
         }
 
         if print_layout {
@@ -313,7 +313,7 @@ impl Arguments {
         let (_, pk) = setup_vm_circuit(&vm_circuit, &params)?;
 
         info!("prove vm circuit...");
-        prove_vm_circuit_ipa(vm_circuit, &[], &params, pk.clone())?;
+        prove_vm_circuit_ipa(vm_circuit, &[&[Fp::zero()]], &params, pk.clone())?;
         #[allow(clippy::or_fun_call)]
         if let Some(new_args) = new_args
             .as_ref()
@@ -347,7 +347,7 @@ impl Arguments {
                 public_input: None,
             };
             info!("prove the new execution with old proving key...");
-            prove_vm_circuit_ipa(new_vm_circuit, &[], &params, pk)?;
+            prove_vm_circuit_ipa(new_vm_circuit, &[&[Fp::zero()]], &params, pk)?;
         }
 
         Ok(())

--- a/common/error/src/lib.rs
+++ b/common/error/src/lib.rs
@@ -34,6 +34,7 @@ pub enum StatusCode {
     ResourceAlreadyExists,
     InvalidValue,
     WrongArgumentsNumber,
+    WrongReturnValueNumber,
     ArgumentsTypeMismatch,
     VecUnpackParityMismatch,
     InstantiateTypeFailed,

--- a/functional-tests/benches/circuit_benchmark.rs
+++ b/functional-tests/benches/circuit_benchmark.rs
@@ -121,7 +121,13 @@ fn circuit_benchmark(c: &mut Criterion) {
                 b.iter_batched(
                     || {},
                     |_| {
-                        prove_vm_circuit_kzg(vm_circuit.clone(), &[&[Fr::zero()]], params, pk.clone()).unwrap();
+                        prove_vm_circuit_kzg(
+                            vm_circuit.clone(),
+                            &[&[Fr::zero()]],
+                            params,
+                            pk.clone(),
+                        )
+                        .unwrap();
                     },
                     BatchSize::PerIteration,
                 );

--- a/functional-tests/benches/circuit_benchmark.rs
+++ b/functional-tests/benches/circuit_benchmark.rs
@@ -79,7 +79,10 @@ fn setup(
         circuit_config,
     )?;
 
-    let vm_circuit = VmCircuit { witness };
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: None,
+    };
     let k = find_best_k(&vm_circuit, vec![])?;
     info!("use vm circuit, k = {}", k);
 

--- a/functional-tests/benches/circuit_benchmark.rs
+++ b/functional-tests/benches/circuit_benchmark.rs
@@ -83,10 +83,10 @@ fn setup(
         witness,
         public_input: None,
     };
-    let k = find_best_k(&vm_circuit, vec![])?;
+    let k = find_best_k(&vm_circuit, vec![vec![Fr::zero()]])?;
     info!("use vm circuit, k = {}", k);
 
-    mock_prove_circuit(&vm_circuit, vec![], k)?;
+    mock_prove_circuit(&vm_circuit, vec![vec![Fr::zero()]], k)?;
 
     debug!("Generate parameters for execution trace");
     let rng = StdRng::from_entropy();
@@ -121,7 +121,7 @@ fn circuit_benchmark(c: &mut Criterion) {
                 b.iter_batched(
                     || {},
                     |_| {
-                        prove_vm_circuit_kzg(vm_circuit.clone(), &[], params, pk.clone()).unwrap();
+                        prove_vm_circuit_kzg(vm_circuit.clone(), &[&[Fr::zero()]], params, pk.clone()).unwrap();
                     },
                     BatchSize::PerIteration,
                 );

--- a/functional-tests/tests/modules/entry_fun_return.move
+++ b/functional-tests/tests/modules/entry_fun_return.move
@@ -5,9 +5,9 @@
 address 0x1 {
 module Entry_Fun_Test {
     use 0x1::M;
-    public entry fun entry_function_test(x: u8, y: u8) {
+    public entry fun entry_function_test(x: u8, y: u8): u8 {
         let z = M::add_u8(x, y);
-        z;
+        z
     }
 }
 }

--- a/functional-tests/tests/modules/eth_data.move
+++ b/functional-tests/tests/modules/eth_data.move
@@ -1,3 +1,6 @@
+//! word_capacity: 65
+//! module_id: 0x1::EthData
+//! entry_fun: eth_data
 module 0x1::EthData {
     /// get the block hash at a specific block_number
     native public fun get_block_hash(block_number: u64): vector<u8>;
@@ -5,4 +8,13 @@ module 0x1::EthData {
     /// TODO: change slot and return value to u256
     native public fun get_slot(block_number: u64, address: vector<u8>, slot: u128): u128;
 
+    public entry fun  eth_data(): vector<u8> {
+        let block_number = 17000000;
+        let block_hash = get_block_hash(block_number);
+        let expected = x"96cfa0fb5e50b0a3f6cc76f3299cfbf48f17e8b41798d1394474e67ec8a97e9f";
+        assert!(block_hash == expected, 101);
+        // FIXME: Error::InstanceTooLarge
+        // block_hash
+        x"96cf"
+    }
  }

--- a/functional-tests/tests/modules/eth_data.move
+++ b/functional-tests/tests/modules/eth_data.move
@@ -1,4 +1,4 @@
-//! word_capacity: 65
+//! word_capacity: 97
 //! module_id: 0x1::EthData
 //! entry_fun: eth_data
 module 0x1::EthData {

--- a/functional-tests/tests/scripts/eth_data_test.move
+++ b/functional-tests/tests/scripts/eth_data_test.move
@@ -2,7 +2,6 @@
 //! word_capacity: 97
 script {
     use 0x1::EthData;
-    use 0x1::vector;
     fun main() {
         let block_number = 17000000;
         let block_hash = EthData::get_block_hash(block_number);

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -12,6 +12,7 @@ use vm::state::StateStore;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::CircuitConfig;
 
+use movelang::value_ext::FlattenedValue;
 use rand::{rngs::StdRng, SeedableRng};
 use vm_circuit::{find_best_k, mock_prove_circuit, prove_vm_circuit_kzg, setup_vm_circuit};
 
@@ -52,7 +53,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
         .global_ops_num(config.global_ops_num)
         .word_size(config.word_capacity);
 
-    let witness = match compiled_script.clone() {
+    let (witness, ret) = match compiled_script.clone() {
         Some(script) => {
             let trace = runtime.execute_script(
                 script.clone(),
@@ -61,14 +62,15 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
                 config.args,
                 &mut state,
             )?;
-            runtime.process_execution_trace(
+            let witness = runtime.process_execution_trace(
                 config.ty_args.clone(),
                 Some(script),
                 None,
                 compiled_modules.clone(),
                 trace,
                 circuit_config.clone(),
-            )?
+            )?;
+            (witness, None)
         }
         None => {
             if let Some(function_name) = config.entry_fun_name.clone() {
@@ -76,7 +78,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
                     .module_id
                     .clone()
                     .expect("module_id should not be None.");
-                let trace = runtime.execute_entry_function(
+                let (trace, ret) = runtime.execute_entry_function(
                     &module_id,
                     &function_name,
                     config.ty_args.clone(),
@@ -84,14 +86,15 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
                     config.args,
                     &mut state,
                 )?;
-                runtime.process_execution_trace(
+                let witness = runtime.process_execution_trace(
                     config.ty_args.clone(),
                     None,
                     Some((&module_id, &function_name)),
                     compiled_modules.clone(),
                     trace,
                     circuit_config.clone(),
-                )?
+                )?;
+                (witness, ret)
             } else {
                 return Ok(());
             }
@@ -100,11 +103,19 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
 
     debug!("{:?}", witness);
 
-    let vm_circuit = VmCircuit { witness };
-    let k = find_best_k(&vm_circuit, vec![])?;
+    let instance = match &ret {
+        Some(v) => FlattenedValue::from(v).field_values(),
+        None => vec![Fr::zero()],
+    };
+    debug!("Instance: {:?}", instance);
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: ret,
+    };
+    let k = find_best_k(&vm_circuit, vec![instance.clone()])?;
     info!("use vm circuit, k = {}", k);
 
-    mock_prove_circuit(&vm_circuit, vec![], k)?;
+    mock_prove_circuit(&vm_circuit, vec![instance.clone()], k)?;
 
     debug!("Generate parameters for execution trace");
     let rng = StdRng::from_entropy();
@@ -112,7 +123,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
     let (_, pk) = setup_vm_circuit(&vm_circuit, &params)?;
 
     debug!("Generate zk proof for execution trace");
-    prove_vm_circuit_kzg(vm_circuit, &[], &params, pk.clone())?;
+    prove_vm_circuit_kzg(vm_circuit, &[&instance], &params, pk.clone())?;
     if let Some(new_args) = config.new_args.as_ref() {
         info!("execute with new arguments");
         let new_ty_args = if config.new_ty_args.is_empty() {
@@ -120,7 +131,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
         } else {
             config.new_ty_args
         };
-        let new_witness = match compiled_script {
+        let (new_witness, new_ret) = match compiled_script {
             Some(script) => {
                 let trace = runtime.execute_script(
                     script.clone(),
@@ -129,14 +140,15 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
                     Some(new_args.clone()),
                     &mut state,
                 )?;
-                runtime.process_execution_trace(
+                let witness = runtime.process_execution_trace(
                     new_ty_args,
                     Some(script),
                     None,
                     compiled_modules,
                     trace,
                     circuit_config,
-                )?
+                )?;
+                (witness, None)
             }
             None => {
                 if let Some(function_name) = config.entry_fun_name.clone() {
@@ -144,7 +156,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
                         .module_id
                         .clone()
                         .expect("module_id should not be None.");
-                    let trace = runtime.execute_entry_function(
+                    let (trace, ret) = runtime.execute_entry_function(
                         &module_id,
                         &function_name,
                         new_ty_args.clone(),
@@ -152,24 +164,30 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
                         Some(new_args.clone()),
                         &mut state,
                     )?;
-                    runtime.process_execution_trace(
+                    let witness = runtime.process_execution_trace(
                         new_ty_args,
                         None,
                         Some((&module_id, &function_name)),
                         compiled_modules,
                         trace,
                         circuit_config,
-                    )?
+                    )?;
+                    (witness, ret)
                 } else {
                     return Ok(());
                 }
             }
         };
+        let instance = match &new_ret {
+            Some(v) => FlattenedValue::from(v).field_values(),
+            None => vec![Fr::zero()],
+        };
         let new_vm_circuit = VmCircuit {
             witness: new_witness,
+            public_input: new_ret,
         };
         info!("prove the new execution with old proving key...");
-        prove_vm_circuit_kzg(new_vm_circuit, &[], &params, pk)?;
+        prove_vm_circuit_kzg(new_vm_circuit, &[&instance], &params, pk)?;
     }
 
     Ok(())

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -12,8 +12,8 @@ use vm::state::StateStore;
 use vm_circuit::circuit::VmCircuit;
 use vm_circuit::witness::CircuitConfig;
 
-use movelang::value_ext::FlattenedValue;
 use rand::{rngs::StdRng, SeedableRng};
+use vm_circuit::chips::execution_chip::lookup_tables::pi_lookup_table::PIFieldValues;
 use vm_circuit::{find_best_k, mock_prove_circuit, prove_vm_circuit_kzg, setup_vm_circuit};
 
 pub const TEST_MODULE_PATH: &str = "tests/modules";
@@ -104,7 +104,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
     debug!("{:?}", witness);
 
     let instance = match &ret {
-        Some(v) => FlattenedValue::from(v).field_values(),
+        Some(v) => PIFieldValues::from(v).0,
         None => vec![Fr::zero()],
     };
     debug!("Instance: {:?}", instance);
@@ -112,7 +112,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
         witness,
         public_input: ret,
     };
-    let k = find_best_k(&vm_circuit, vec![instance.clone()])?;
+    let k = find_best_k(&vm_circuit, vec![vec![Fr::zero()]])?;
     info!("use vm circuit, k = {}", k);
 
     mock_prove_circuit(&vm_circuit, vec![instance.clone()], k)?;
@@ -179,7 +179,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
             }
         };
         let instance = match &new_ret {
-            Some(v) => FlattenedValue::from(v).field_values(),
+            Some(v) => PIFieldValues::from(v).0,
             None => vec![Fr::zero()],
         };
         let new_vm_circuit = VmCircuit {

--- a/movelang/src/value_ext.rs
+++ b/movelang/src/value_ext.rs
@@ -62,6 +62,16 @@ impl<F: FieldExt> FlattenedValue<F> {
         }
         None
     }
+
+    pub fn field_values(&self) -> Vec<F> {
+        self.0
+            .iter()
+            .flat_map(|(addr_ext, simple)| {
+                let addr_path: AddressPath<F> = AddressPath::from(addr_ext.clone());
+                vec![F::from_u128(addr_path.fold()), simple.value().unwrap()]
+            })
+            .collect::<Vec<_>>()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/movelang/src/value_ext.rs
+++ b/movelang/src/value_ext.rs
@@ -63,6 +63,8 @@ impl<F: FieldExt> FlattenedValue<F> {
         None
     }
 
+    // flatten addr_ext and simples into one vector
+    // vec[i*2] = addr_ext[i], vec[i*2+1] = simple[i]
     pub fn field_values(&self) -> Vec<F> {
         self.0
             .iter()

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -341,7 +341,10 @@ fn test_fake_rw_operation() -> VmResult<()> {
         Default::default(),
         circuit_config,
     );
-    let vm_circuit = VmCircuit { witness };
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: None,
+    };
     let k = 10;
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
         debug!("Prover Error: {:?}", e);

--- a/vm-circuit/src/chips/chip_tests.rs
+++ b/vm-circuit/src/chips/chip_tests.rs
@@ -106,7 +106,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         gc: 18,
         module_index: 0,
         function_index: 0,
-        auxiliary_1: None,
+        auxiliary_1: Some(Value::u64(0)),
         auxiliary_2: None,
         auxiliary_3: None,
         auxiliary_4: None,
@@ -346,7 +346,7 @@ fn test_fake_rw_operation() -> VmResult<()> {
         public_input: None,
     };
     let k = 10;
-    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
+    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![vec![Fp::zero()]]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
         RuntimeError::new(StatusCode::ProofSystemError(e))
     })?;

--- a/vm-circuit/src/chips/execution_chip.rs
+++ b/vm-circuit/src/chips/execution_chip.rs
@@ -66,8 +66,8 @@ use crate::witness::execution_steps::ExecutionStep;
 use crate::witness::rw_operations::ConvertedRWOperation;
 use crate::witness::rw_operations::RWOperations;
 use crate::witness::Witness;
-use halo2_proofs::circuit::{AssignedCell, Chip, Region, Value};
-use halo2_proofs::plonk::Constraints;
+use halo2_proofs::circuit::{AssignedCell, Chip, Region, Value as CircuitValue};
+use halo2_proofs::plonk::{Constraints, Instance};
 use halo2_proofs::poly::Rotation;
 use halo2_proofs::{
     arithmetic::FieldExt,
@@ -76,7 +76,7 @@ use halo2_proofs::{
 };
 use logger::{error, trace};
 use movelang::value::{
-    NUM_OF_BYTES_U128, NUM_OF_BYTES_U16, NUM_OF_BYTES_U32, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
+    Value, NUM_OF_BYTES_U128, NUM_OF_BYTES_U16, NUM_OF_BYTES_U32, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
 };
 use std::collections::HashMap;
 
@@ -180,11 +180,14 @@ pub struct ExecutionChipConfig<F: FieldExt> {
 
     // lookup table
     lookup_table: LookupTableConfig<F>,
+    // instance column to store public input
+    instance: Column<Instance>,
 }
 
 #[derive(Clone, Debug)]
 pub struct ExecutionChip<F: FieldExt> {
     pub(crate) witness: Witness<F>,
+    pub(crate) public_input: Option<Value<F>>,
     pub(crate) config: ExecutionChipConfig<F>,
 }
 
@@ -204,10 +207,15 @@ impl<F: FieldExt> Chip<F> for ExecutionChip<F> {
 impl<F: FieldExt> ExecutionChip<F> {
     pub fn construct(
         witness: Witness<F>,
+        public_input: Option<Value<F>>,
         config: <Self as Chip<F>>::Config,
         _loaded: <Self as Chip<F>>::Loaded,
     ) -> Self {
-        Self { witness, config }
+        Self {
+            witness,
+            public_input,
+            config,
+        }
     }
 
     pub fn configure(meta: &mut ConstraintSystem<F>) -> <Self as Chip<F>>::Config {
@@ -302,6 +310,9 @@ impl<F: FieldExt> ExecutionChip<F> {
             };
         }
 
+        let instance = meta.instance_column();
+        meta.enable_equality(instance);
+
         ExecutionChipConfig {
             s_usable,
             s_step_first,
@@ -390,6 +401,7 @@ impl<F: FieldExt> ExecutionChip<F> {
             step: step_curr,
             height_map,
             lookup_table: LookupTableConfig::configure(meta, lookups, s_usable, s_step),
+            instance,
         }
     }
 
@@ -590,22 +602,27 @@ impl<F: FieldExt> ExecutionChip<F> {
                 region.assign_advice(
                     || "step height",
                     self.config.num_rows_until_next_step,
-                    offset + 1,
-                    || Value::known(F::zero()),
+                    offset + self.step_height_get(&Opcode::Stop),
+                    || CircuitValue::known(F::zero()),
                 )?;
                 region.assign_advice(
                     || "step height inv",
                     self.config.num_rows_inv,
-                    offset + 1,
-                    || Value::known(F::zero()),
+                    offset + self.step_height_get(&Opcode::Stop),
+                    || CircuitValue::known(F::zero()),
                 )?;
 
                 Ok(last_step_gc_cell)
             },
         )?;
 
-        let (stack_operations, locals_operations, global_operations) =
+        let (stack_operations, locals_operations, global_operations, pi_cells) =
             LookupTableConfig::assign(layouter, self)?;
+
+        // expose public
+        for (i, cell) in pi_cells.iter().enumerate() {
+            layouter.constrain_instance(cell.cell(), self.config.instance, i)?;
+        }
 
         Ok((
             last_step_gc_cell,
@@ -634,7 +651,7 @@ impl<F: FieldExt> ExecutionChip<F> {
                 || "step selector",
                 self.config.s_step,
                 offset + idx,
-                || Value::known(if idx == 0 { F::one() } else { F::zero() }),
+                || CircuitValue::known(if idx == 0 { F::one() } else { F::zero() }),
             )?;
             let num_rows_until_next_step = if idx == 0 {
                 F::zero()
@@ -645,13 +662,13 @@ impl<F: FieldExt> ExecutionChip<F> {
                 || "step height",
                 self.config.num_rows_until_next_step,
                 offset + idx,
-                || Value::known(num_rows_until_next_step),
+                || CircuitValue::known(num_rows_until_next_step),
             )?;
             region.assign_advice(
                 || "step height inv",
                 self.config.num_rows_inv,
                 offset + idx,
-                || Value::known(num_rows_until_next_step.invert().unwrap_or(F::zero())),
+                || CircuitValue::known(num_rows_until_next_step.invert().unwrap_or(F::zero())),
             )?;
         }
         Ok(())

--- a/vm-circuit/src/chips/execution_chip/instructions/ret.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ret.rs
@@ -107,6 +107,7 @@ impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
                 stop_and_has_ret_val.clone()
                     * (1u64.expr() - self.value.cells.word_mask[i].expression.clone()),
                 |cb| {
+                    // see PILookupTable for details
                     cb.add_lookup(
                         "lookup pi",
                         PILookup {

--- a/vm-circuit/src/chips/execution_chip/instructions/ret.rs
+++ b/vm-circuit/src/chips/execution_chip/instructions/ret.rs
@@ -1,8 +1,11 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip::instructions::common::LookupBytecode;
+use crate::chips::execution_chip::instructions::common::value_gadget::ValueGadget;
+use crate::chips::execution_chip::instructions::common::{LookupBytecode, Word};
 use crate::chips::execution_chip::instructions::InstructionGadget;
 use crate::chips::execution_chip::lookup_tables::call_lookup_table::CallLookup;
+use crate::chips::execution_chip::lookup_tables::pi_lookup_table::PILookup;
+use crate::chips::execution_chip::lookup_tables::rw_table::RWLookup;
 use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::step_chip::StepChipCells;
 use crate::chips::execution_chip::utils::constraint_builder::ConstraintBuilder;
@@ -13,11 +16,10 @@ use crate::witness::rw_operations::RWOperations;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Region;
 use halo2_proofs::plonk::Error;
-use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
 pub struct Ret<F: FieldExt> {
-    _marker: PhantomData<F>,
+    value: ValueGadget<F>,
 }
 
 impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
@@ -25,8 +27,15 @@ impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
 
     const OPCODE: Opcode = Opcode::Ret;
     fn configure(&self, cells: &StepChipCells<F>, cb: &mut ConstraintBuilder<F>) {
+        let stop_and_has_ret_val = cells.auxiliary_1.expression.clone();
+        let flattened_value_len = cells.auxiliary_3.expression.clone();
+
+        let constraint =
+            stop_and_has_ret_val.clone() * (1u64.expr() - stop_and_has_ret_val.clone());
+        cb.add_constraint("stop_and_has_ret_val is bool", constraint);
+
         let frame_index = cells.frame_index.expression.clone();
-        let inverse = cells.auxiliary_1.expression.clone();
+        let inverse = cells.auxiliary_2.expression.clone();
 
         // constrain the inverse, if frame_index != 0, frame_index * inverse(frame_index) == 1
         let frame_index_expr =
@@ -38,12 +47,18 @@ impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
         let pc_expr = (frame_index.clone() * inverse.clone() - 1u64.expr())
             * (cb.next.cells.pc.expression.clone() - cells.pc.expression.clone());
 
-        // gc should not change
-        let gc_expr = cells.gc.expression.clone() - cb.next.cells.gc.expression.clone();
+        let gc_expr_1 = (1u64.expr() - stop_and_has_ret_val.clone())
+            * (cells.gc.expression.clone() - cb.next.cells.gc.expression.clone());
+        // gc will change if there is a return value
+        let gc_expr_2 = stop_and_has_ret_val.clone()
+            * (cells.gc.expression.clone() - cb.next.cells.gc.expression.clone()
+                + flattened_value_len.clone());
+
         cb.add_constraints(vec![
-            ("frame_index", frame_index_expr),
             ("pc", pc_expr),
-            ("gc", gc_expr),
+            ("frame index", frame_index_expr),
+            ("gc_1", gc_expr_1),
+            ("gc_2", gc_expr_2),
         ]);
 
         // if frame_index != 0, the next step will be a normal bytecode,
@@ -65,6 +80,51 @@ impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
             );
         });
 
+        //stop, has return value
+        cb.condition(stop_and_has_ret_val.clone(), |cb| {
+            self.value.configure(cb, flattened_value_len.clone());
+        });
+        for (i, _) in self.value.cells.word.iter().enumerate() {
+            cb.condition(
+                stop_and_has_ret_val.clone()
+                    * (1u64.expr() - self.value.cells.word_mask[i].expression.clone()),
+                |cb| {
+                    cb.add_lookup(
+                        "ret pop(stack)",
+                        RWLookup::stack_pop(
+                            cells.gc.expression.clone() + (i as u64).expr(),
+                            cells.stack_size.expression.clone(),
+                            self.value.cells.word_addr_ext[i].expression.clone(),
+                            self.value.cells.word[i].expression.clone(),
+                        ),
+                    );
+                },
+            );
+        }
+
+        for (i, _) in self.value.cells.word.iter().enumerate() {
+            cb.condition(
+                stop_and_has_ret_val.clone()
+                    * (1u64.expr() - self.value.cells.word_mask[i].expression.clone()),
+                |cb| {
+                    cb.add_lookup(
+                        "lookup pi",
+                        PILookup {
+                            idx: ((i * 2 + 1) as u64).expr(),
+                            pi: self.value.cells.word_addr_ext[i].expression.clone(),
+                        },
+                    );
+                    cb.add_lookup(
+                        "lookup pi",
+                        PILookup {
+                            idx: ((i * 2 + 2) as u64).expr(),
+                            pi: self.value.cells.word[i].expression.clone(),
+                        },
+                    );
+                },
+            );
+        }
+
         LookupBytecode::lookup_bytecode(cb, cells, Opcode::Ret, 0u64.expr());
     }
 
@@ -73,19 +133,29 @@ impl<F: FieldExt> InstructionGadget<F> for Ret<F> {
         region: &mut Region<'_, F>,
         offset: usize,
         step: &ExecutionStep<F>,
-        _rw_table: &RWOperations<F>,
+        rw_operations: &RWOperations<F>,
         cells: &StepChipCells<F>,
     ) -> Result<(), Error> {
         cells
-            .auxiliary_1
+            .auxiliary_2
             .assign(region, offset, (step.frame_index).sub_invert(0))?;
 
+        let stop_and_has_return_value =
+            Word::assign_step_value(region, offset, &step.auxiliary_1, &cells.auxiliary_1)?;
+
+        if stop_and_has_return_value == F::one() {
+            let flattened_value_len =
+                Word::assign_step_value(region, offset, &step.auxiliary_3, &cells.auxiliary_3)?
+                    .get_lower_128() as usize;
+            self.value
+                .assign(region, offset, rw_operations, step.gc, flattened_value_len)?;
+        }
         Ok(())
     }
 
-    fn construct(_cb: &mut ConstraintBuilder<F>) -> Self {
-        Self {
-            _marker: PhantomData,
-        }
+    fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
+        let value = ValueGadget::construct(cb);
+
+        Self { value }
     }
 }

--- a/vm-circuit/src/chips/execution_chip/lookup_tables.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables.rs
@@ -28,8 +28,8 @@ use crate::chips::execution_chip::opcode::Opcode;
 use crate::chips::execution_chip::utils::constraint_builder::{mul_exprs, ConditionalLookup};
 use crate::chips::execution_chip::ExecutionChip;
 use crate::witness::rw_operations::ConvertedRWOperation;
-use halo2_proofs::circuit::Region;
 use halo2_proofs::circuit::Value as CircuitValue;
+use halo2_proofs::circuit::{AssignedCell, Region};
 use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::Layouter,
@@ -37,6 +37,8 @@ use halo2_proofs::{
     poly::Rotation,
 };
 
+use crate::chips::execution_chip::lookup_tables::pi_lookup_table::{PILookup, PILookupTable};
+use crate::chips::execution_chip::lookup_tables::rvr_index_table::RVRIndexTable;
 use logger::prelude::*;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
@@ -48,7 +50,9 @@ pub mod call_lookup_table;
 pub mod call_trace_table;
 pub mod constant_lookup_table;
 pub mod input_type_element_table;
+pub mod pi_lookup_table;
 pub mod pow2_fixed_table;
+mod rvr_index_table;
 pub mod rw_table;
 pub mod type_instantiation_table;
 pub mod utils;
@@ -65,6 +69,7 @@ pub enum Lookup<F: FieldExt> {
     CallTrace(CallTraceLookup<F>),
     TypeInstantiation(TypeInstantiationLookup<F>),
     InputTypeArg(InputTypeElementLookup<F>),
+    PI(PILookup<F>),
 }
 
 impl<F: FieldExt> From<BytecodeLookup<F>> for Lookup<F> {
@@ -120,6 +125,11 @@ impl<F: FieldExt> From<InputTypeElementLookup<F>> for Lookup<F> {
         Self::InputTypeArg(l)
     }
 }
+impl<F: FieldExt> From<PILookup<F>> for Lookup<F> {
+    fn from(l: PILookup<F>) -> Self {
+        Self::PI(l)
+    }
+}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum TableKind {
@@ -133,6 +143,7 @@ pub enum TableKind {
     CallTrace,
     TypeInstantiation,
     InputTypeArg,
+    PI,
 }
 
 impl<F: FieldExt> Lookup<F> {
@@ -148,6 +159,7 @@ impl<F: FieldExt> Lookup<F> {
             Lookup::CallTrace(l) => l.exprs(),
             Lookup::TypeInstantiation(l) => l.exprs(),
             Lookup::InputTypeArg(l) => l.exprs(),
+            Lookup::PI(l) => l.exprs(),
         }
     }
 
@@ -163,6 +175,7 @@ impl<F: FieldExt> Lookup<F> {
             Lookup::CallTrace(_) => TableKind::CallTrace,
             Lookup::TypeInstantiation(_) => TableKind::TypeInstantiation,
             Lookup::InputTypeArg(_) => TableKind::InputTypeArg,
+            Lookup::PI(_) => TableKind::PI,
         }
     }
 }
@@ -179,6 +192,8 @@ pub struct LookupTableConfig<F: FieldExt> {
     pub call_trace_table: CallTraceTable,
     pub type_instantiation_table: TypeInstantiationTable,
     pub input_type_element_table: InputTypeElementTable,
+    pub pi_table: PILookupTable,
+    rvr_index_table: RVRIndexTable,
     _marker: PhantomData<F>,
 }
 impl<F: FieldExt> LookupTableConfig<F> {
@@ -193,6 +208,8 @@ impl<F: FieldExt> LookupTableConfig<F> {
         let call_trace_table = CallTraceTable::construct(meta);
         let type_instantiation_table = TypeInstantiationTable::construct(meta);
         let input_type_element_table = InputTypeElementTable::construct(meta);
+        let pi_table = PILookupTable::construct(meta);
+        let rvr_index_table = RVRIndexTable::construct(meta);
         LookupTableConfig {
             rw_table,
             constant_table,
@@ -204,6 +221,8 @@ impl<F: FieldExt> LookupTableConfig<F> {
             call_trace_table,
             type_instantiation_table,
             input_type_element_table,
+            pi_table,
+            rvr_index_table,
             _marker: PhantomData,
         }
     }
@@ -266,13 +285,14 @@ impl<F: FieldExt> LookupTableConfig<F> {
             TableKind::InputTypeArg,
             lookup_table.input_type_element_table.columns(),
         );
+        advice_tables.insert(TableKind::PI, lookup_table.pi_table.columns());
 
         for (name, mut lookup) in lookups {
             let mut fixed_table_columns = Vec::new();
             let mut advice_table_columns = Vec::new();
 
             match lookup.as_ref().table() {
-                t @ (TableKind::RW | TableKind::InputTypeArg) => {
+                t @ (TableKind::RW | TableKind::InputTypeArg | TableKind::PI) => {
                     advice_table_columns = advice_tables.get(&t).cloned().unwrap();
                 }
                 t => {
@@ -338,6 +358,7 @@ impl<F: FieldExt> LookupTableConfig<F> {
             Vec<ConvertedRWOperation<F>>,
             Vec<ConvertedRWOperation<F>>,
             Vec<ConvertedRWOperation<F>>,
+            Vec<AssignedCell<F, F>>, // pi cells
         ),
         Error,
     > {
@@ -479,6 +500,13 @@ impl<F: FieldExt> LookupTableConfig<F> {
             execution_chip.witness.type_instantiations.0.clone(),
         )?;
 
+        let rvr_index_table = lookup_table.rvr_index_table.assign_table(layouter)?;
+        let pi_cells = lookup_table.pi_table.assign_table(
+            layouter,
+            execution_chip.public_input.clone(),
+            rvr_index_table,
+        )?;
+
         // bitwise table
         // only 4 bits bitwised every time. so table size is 16*16
         let mut bitwise_values = Vec::new();
@@ -509,7 +537,12 @@ impl<F: FieldExt> LookupTableConfig<F> {
         )?;
         lookup_table.pow2_table.assign_table(layouter)?;
 
-        Ok((stack_operations, locals_operations, global_operations))
+        Ok((
+            stack_operations,
+            locals_operations,
+            global_operations,
+            pi_cells,
+        ))
     }
 
     pub(crate) fn assign_rw_ops(

--- a/vm-circuit/src/chips/execution_chip/lookup_tables.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables.rs
@@ -37,8 +37,8 @@ use halo2_proofs::{
     poly::Rotation,
 };
 
+use crate::chips::execution_chip::lookup_tables::pi_index_table::PIIndexTable;
 use crate::chips::execution_chip::lookup_tables::pi_lookup_table::{PILookup, PILookupTable};
-use crate::chips::execution_chip::lookup_tables::rvr_index_table::RVRIndexTable;
 use logger::prelude::*;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
@@ -50,9 +50,9 @@ pub mod call_lookup_table;
 pub mod call_trace_table;
 pub mod constant_lookup_table;
 pub mod input_type_element_table;
+mod pi_index_table;
 pub mod pi_lookup_table;
 pub mod pow2_fixed_table;
-mod rvr_index_table;
 pub mod rw_table;
 pub mod type_instantiation_table;
 pub mod utils;
@@ -193,7 +193,7 @@ pub struct LookupTableConfig<F: FieldExt> {
     pub type_instantiation_table: TypeInstantiationTable,
     pub input_type_element_table: InputTypeElementTable,
     pub pi_table: PILookupTable,
-    rvr_index_table: RVRIndexTable,
+    pi_index_table: PIIndexTable,
     _marker: PhantomData<F>,
 }
 impl<F: FieldExt> LookupTableConfig<F> {
@@ -209,7 +209,7 @@ impl<F: FieldExt> LookupTableConfig<F> {
         let type_instantiation_table = TypeInstantiationTable::construct(meta);
         let input_type_element_table = InputTypeElementTable::construct(meta);
         let pi_table = PILookupTable::construct(meta);
-        let rvr_index_table = RVRIndexTable::construct(meta);
+        let pi_index_table = PIIndexTable::construct(meta);
         LookupTableConfig {
             rw_table,
             constant_table,
@@ -222,7 +222,7 @@ impl<F: FieldExt> LookupTableConfig<F> {
             type_instantiation_table,
             input_type_element_table,
             pi_table,
-            rvr_index_table,
+            pi_index_table,
             _marker: PhantomData,
         }
     }
@@ -500,11 +500,11 @@ impl<F: FieldExt> LookupTableConfig<F> {
             execution_chip.witness.type_instantiations.0.clone(),
         )?;
 
-        let rvr_index_table = lookup_table.rvr_index_table.assign_table(layouter)?;
+        let pi_index_table = lookup_table.pi_index_table.assign_table(layouter)?;
         let pi_cells = lookup_table.pi_table.assign_table(
             layouter,
             execution_chip.public_input.clone(),
-            rvr_index_table,
+            pi_index_table,
         )?;
 
         // bitwise table

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/pi_index_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/pi_index_table.rs
@@ -1,14 +1,14 @@
-use crate::chips::execution_chip::param::word_capacity;
+use crate::chips::execution_chip::lookup_tables::pi_lookup_table::PILookupTable;
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::circuit::Layouter;
 use halo2_proofs::circuit::{AssignedCell, Value};
 use halo2_proofs::plonk::{Column, ConstraintSystem, Error, Fixed};
 
 #[derive(Clone, Debug)]
-pub struct RVRIndexTable {
+pub struct PIIndexTable {
     pub index_column: Column<Fixed>,
 }
-impl RVRIndexTable {
+impl PIIndexTable {
     pub fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
         let index_column = meta.fixed_column();
         meta.enable_equality(index_column);
@@ -19,13 +19,13 @@ impl RVRIndexTable {
         &self,
         layouter: &mut impl Layouter<F>,
     ) -> Result<Vec<AssignedCell<F, F>>, Error> {
-        let rvr_index_cells = layouter.assign_region(
-            || "rvr_index_table",
+        let pi_index_cells = layouter.assign_region(
+            || "pi_index_table",
             |mut region| {
                 let mut cells = Vec::new();
-                for i in 0..=word_capacity() {
+                for i in 0..PILookupTable::num_of_rows() {
                     let cell = region.assign_fixed(
-                        || format!("rvr_index_table[{}]", i),
+                        || format!("pi_index_table[{}]", i),
                         self.index_column,
                         i,
                         || Value::known(F::from_u128(i as u128)),
@@ -37,6 +37,6 @@ impl RVRIndexTable {
             },
         )?;
 
-        Ok(rvr_index_cells)
+        Ok(pi_index_cells)
     }
 }

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/pi_lookup_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/pi_lookup_table.rs
@@ -1,0 +1,96 @@
+use crate::chips::execution_chip::param::word_capacity;
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{AssignedCell, Layouter, Value as CircuitValue};
+use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error, Expression};
+use movelang::value::Value;
+use movelang::value_ext::FlattenedValue;
+
+#[derive(Clone, Debug)]
+pub struct PILookupTable {
+    pub idx_column: Column<Advice>,
+    pub pi_column: Column<Advice>,
+}
+
+impl PILookupTable {
+    pub fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        let idx_column = meta.advice_column();
+        let pi_column = meta.advice_column();
+        meta.enable_equality(idx_column);
+        meta.enable_equality(pi_column);
+
+        PILookupTable {
+            idx_column,
+            pi_column,
+        }
+    }
+
+    pub fn columns(&self) -> Vec<Column<Advice>> {
+        vec![self.idx_column, self.pi_column]
+    }
+
+    pub fn pi_column(&self) -> Column<Advice> {
+        self.pi_column
+    }
+
+    pub fn idx_column(&self) -> Column<Advice> {
+        self.idx_column
+    }
+
+    pub fn assign_table<F: FieldExt>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        pi: Option<Value<F>>,
+        rvr_index_table: Vec<AssignedCell<F, F>>,
+    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
+        let values = match &pi {
+            Some(v) => FlattenedValue::from(v).field_values(),
+            None => vec![],
+        };
+
+        let pi_cells = layouter.assign_region(
+            || "pi_table",
+            |mut region| {
+                for (i, _) in rvr_index_table.iter().enumerate().take(word_capacity() + 1) {
+                    let cell = region.assign_advice(
+                        || format!("pi_table[{}][0]", i),
+                        self.idx_column(),
+                        i,
+                        || CircuitValue::known(F::from_u128(i as u128)),
+                    )?;
+                    region.constrain_equal(cell.cell(), rvr_index_table[i].cell())?;
+                }
+
+                region.assign_advice(
+                    || "pi_table[0][1]",
+                    self.pi_column(),
+                    0,
+                    || CircuitValue::known(F::zero()),
+                )?;
+                let mut cells = Vec::new();
+                for (idx, value) in values.iter().enumerate() {
+                    let cell = region.assign_advice(
+                        || format!("pi_table[{}][1]", idx + 1),
+                        self.pi_column(),
+                        idx + 1,
+                        || CircuitValue::known(*value),
+                    )?;
+                    cells.push(cell);
+                }
+                Ok(cells)
+            },
+        )?;
+        Ok(pi_cells)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PILookup<F: FieldExt> {
+    pub idx: Expression<F>,
+    pub pi: Expression<F>,
+}
+
+impl<F: FieldExt> PILookup<F> {
+    pub fn exprs(&self) -> Vec<Expression<F>> {
+        vec![self.idx.clone(), self.pi.clone()]
+    }
+}

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/pi_lookup_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/pi_lookup_table.rs
@@ -5,6 +5,20 @@ use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error, Expression};
 use movelang::value::Value;
 use movelang::value_ext::FlattenedValue;
 
+pub struct PIFieldValues<F: FieldExt>(pub Vec<F>);
+
+impl<F: FieldExt> From<&Value<F>> for PIFieldValues<F> {
+    fn from(v: &Value<F>) -> Self {
+        let mut field_values = FlattenedValue::from(v).field_values();
+
+        // fill up with 0
+        while field_values.len() < word_capacity() * 2 {
+            field_values.push(F::zero());
+        }
+        Self(field_values)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PILookupTable {
     pub idx_column: Column<Advice>,
@@ -36,28 +50,32 @@ impl PILookupTable {
         self.idx_column
     }
 
+    pub fn num_of_rows() -> usize {
+        word_capacity() * 2 + 1
+    }
+
     pub fn assign_table<F: FieldExt>(
         &self,
         layouter: &mut impl Layouter<F>,
         pi: Option<Value<F>>,
-        rvr_index_table: Vec<AssignedCell<F, F>>,
+        pi_index_table: Vec<AssignedCell<F, F>>,
     ) -> Result<Vec<AssignedCell<F, F>>, Error> {
         let values = match &pi {
-            Some(v) => FlattenedValue::from(v).field_values(),
+            Some(v) => PIFieldValues::from(v).0,
             None => vec![],
         };
 
         let pi_cells = layouter.assign_region(
             || "pi_table",
             |mut region| {
-                for (i, _) in rvr_index_table.iter().enumerate().take(word_capacity() + 1) {
+                for (i, index_cell) in pi_index_table.iter().enumerate() {
                     let cell = region.assign_advice(
                         || format!("pi_table[{}][0]", i),
                         self.idx_column(),
                         i,
                         || CircuitValue::known(F::from_u128(i as u128)),
                     )?;
-                    region.constrain_equal(cell.cell(), rvr_index_table[i].cell())?;
+                    region.constrain_equal(cell.cell(), index_cell.cell())?;
                 }
 
                 region.assign_advice(

--- a/vm-circuit/src/chips/execution_chip/lookup_tables/rvr_index_table.rs
+++ b/vm-circuit/src/chips/execution_chip/lookup_tables/rvr_index_table.rs
@@ -1,0 +1,42 @@
+use crate::chips::execution_chip::param::word_capacity;
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::Layouter;
+use halo2_proofs::circuit::{AssignedCell, Value};
+use halo2_proofs::plonk::{Column, ConstraintSystem, Error, Fixed};
+
+#[derive(Clone, Debug)]
+pub struct RVRIndexTable {
+    pub index_column: Column<Fixed>,
+}
+impl RVRIndexTable {
+    pub fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        let index_column = meta.fixed_column();
+        meta.enable_equality(index_column);
+        Self { index_column }
+    }
+
+    pub fn assign_table<F: FieldExt>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
+        let rvr_index_cells = layouter.assign_region(
+            || "rvr_index_table",
+            |mut region| {
+                let mut cells = Vec::new();
+                for i in 0..=word_capacity() {
+                    let cell = region.assign_fixed(
+                        || format!("rvr_index_table[{}]", i),
+                        self.index_column,
+                        i,
+                        || Value::known(F::from_u128(i as u128)),
+                    )?;
+
+                    cells.push(cell);
+                }
+                Ok(cells)
+            },
+        )?;
+
+        Ok(rvr_index_cells)
+    }
+}

--- a/vm-circuit/src/circuit.rs
+++ b/vm-circuit/src/circuit.rs
@@ -8,6 +8,7 @@ use halo2_proofs::{
     plonk::{Circuit, ConstraintSystem, Error},
 };
 use logger::prelude::*;
+use movelang::value::Value;
 
 #[derive(Clone)]
 pub struct VmCircuitConfig<F: FieldExt> {
@@ -18,6 +19,7 @@ pub struct VmCircuitConfig<F: FieldExt> {
 #[derive(Clone, Default)]
 pub struct VmCircuit<F: FieldExt> {
     pub witness: Witness<F>,
+    pub public_input: Option<Value<F>>,
 }
 
 impl<F: FieldExt> Circuit<F> for VmCircuit<F> {
@@ -40,8 +42,12 @@ impl<F: FieldExt> Circuit<F> for VmCircuit<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        let execution_chip =
-            ExecutionChip::<F>::construct(self.witness.clone(), config.execution_chip_config, ());
+        let execution_chip = ExecutionChip::<F>::construct(
+            self.witness.clone(),
+            self.public_input.clone(),
+            config.execution_chip_config,
+            (),
+        );
         let (last_step_gc_cell_opt, stack_operations, locals_operations, global_operations) =
             execution_chip.assign(&mut layouter)?;
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -233,10 +233,7 @@ impl<F: FieldExt> Frame<F> {
                         &mut execution_step,
                     ),
                     Bytecode::Ret => {
-                        trace!("step #{}, {:?}", interp.step, execution_step);
-                        exec_steps.push(execution_step);
-                        interp.step += 1;
-                        return Ok(ExitStatus::Return);
+                        return Ok(ExitStatus::Return(execution_step));
                     }
                     Bytecode::Call(index) => {
                         return Ok(ExitStatus::Call(*index, execution_step));
@@ -1282,7 +1279,7 @@ impl<F: FieldExt> Frame<F> {
 }
 
 pub enum ExitStatus<F: FieldExt> {
-    Return,
+    Return(ExecutionStep<F>),
     Call(FunctionHandleIndex, ExecutionStep<F>),
     CallGeneric(FunctionInstantiationIndex, ExecutionStep<F>),
 }

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -157,7 +157,7 @@ impl<F: FieldExt> Interpreter<F> {
         rw_operations: &mut Vec<RWOperation<F>>,
         generic_types: &mut Vec<GenericTypeMaterialization>,
         generic_graph: &GenericCallGraph,
-    ) -> VmResult<()> {
+    ) -> VmResult<Option<Value<F>>> {
         //println!("{}", generic_graph.to_dot());
 
         let mut locals = Locals::new(entry.local_count());
@@ -187,33 +187,79 @@ impl<F: FieldExt> Interpreter<F> {
                 generic_types,
             )?;
             match status {
-                ExitStatus::Return => {
-                    let step_current = exec_steps
-                        .last()
-                        .ok_or_else(|| RuntimeError::new(StatusCode::ShouldNotReachHere))?;
+                ExitStatus::Return(mut execution_step) => {
                     if let Some(caller_frame) = self.frames.pop() {
+                        execution_step.auxiliary_1 = Some(Value::u64(0)); // return to caller
+                        trace!("step #{}, {:?}", self.step, execution_step);
+                        exec_steps.push(execution_step);
+                        self.step += 1;
                         frame = caller_frame;
                         frame.add_pc();
                     } else {
-                        let stop = ExecutionStep {
-                            context_id: step_current.context_id,
-                            opcode: Opcode::Stop,
-                            pc: step_current.pc,
-                            stack_size: step_current.stack_size,
-                            frame_index: step_current.frame_index,
-                            locals_index: step_current.locals_index,
-                            gc: step_current.gc,
-                            module_index: step_current.module_index,
-                            function_index: step_current.function_index,
-                            auxiliary_1: step_current.auxiliary_1.clone(),
-                            auxiliary_2: step_current.auxiliary_2.clone(),
-                            auxiliary_3: step_current.auxiliary_3.clone(),
-                            auxiliary_4: step_current.auxiliary_4.clone(),
-                            auxiliary_5: step_current.auxiliary_5.clone(),
-                            data: None,
+                        return match self.stack.size() {
+                            0 => {
+                                execution_step.auxiliary_1 = Some(Value::u64(0)); // stop, no return value
+
+                                let stop = ExecutionStep {
+                                    context_id: execution_step.context_id,
+                                    opcode: Opcode::Stop,
+                                    pc: execution_step.pc,
+                                    stack_size: execution_step.stack_size,
+                                    frame_index: execution_step.frame_index,
+                                    locals_index: execution_step.locals_index,
+                                    gc: execution_step.gc,
+                                    module_index: execution_step.module_index,
+                                    function_index: execution_step.function_index,
+                                    auxiliary_1: None,
+                                    auxiliary_2: None,
+                                    auxiliary_3: None,
+                                    auxiliary_4: None,
+                                    auxiliary_5: None,
+                                    data: None,
+                                };
+
+                                trace!("step #{}, {:?}", self.step, execution_step);
+                                exec_steps.push(execution_step);
+                                self.step += 1;
+                                exec_steps.push(stop);
+                                self.step += 1;
+                                Ok(None)
+                            }
+                            1 => {
+                                execution_step.auxiliary_1 = Some(Value::u64(1)); // stop, has return value
+                                let value = self.stack.pop(rw_operations)?;
+                                let flattened_value_len = FlattenedValue::from(&value).0.len();
+                                execution_step.auxiliary_3 =
+                                    Some(Value::u64(flattened_value_len as u64));
+
+                                let stop = ExecutionStep {
+                                    context_id: execution_step.context_id,
+                                    opcode: Opcode::Stop,
+                                    pc: execution_step.pc,
+                                    stack_size: execution_step.stack_size - 1,
+                                    frame_index: execution_step.frame_index,
+                                    locals_index: execution_step.locals_index,
+                                    gc: execution_step.gc + flattened_value_len,
+                                    module_index: execution_step.module_index,
+                                    function_index: execution_step.function_index,
+                                    auxiliary_1: None,
+                                    auxiliary_2: None,
+                                    auxiliary_3: None,
+                                    auxiliary_4: None,
+                                    auxiliary_5: None,
+                                    data: None,
+                                };
+
+                                trace!("step #{}, {:?}", self.step, execution_step);
+                                exec_steps.push(execution_step);
+                                self.step += 1;
+                                exec_steps.push(stop);
+                                self.step += 1;
+                                Ok(Some(value))
+                            }
+                            // only one return value is allowed
+                            _ => Err(RuntimeError::new(StatusCode::WrongReturnValueNumber)),
                         };
-                        exec_steps.push(stop);
-                        return Ok(());
                     }
                 }
                 ExitStatus::Call(index, mut execution_step) => {

--- a/vm/src/runtime.rs
+++ b/vm/src/runtime.rs
@@ -16,7 +16,7 @@ use move_vm_runtime::native_extensions::NativeContextExtensions;
 use movelang::argument::{convert_type_tag_to_type, ScriptArguments, Signer};
 use movelang::generic_call_graph::{generate, generate_for_script, GenericCallGraph};
 use movelang::utility::MoveValueType;
-use movelang::value::{ModuleId, TypeTag};
+use movelang::value::{ModuleId, TypeTag, Value};
 
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -100,7 +100,7 @@ impl<F: FieldExt> Runtime<F> {
         signer: Option<Signer>,
         args: Option<ScriptArguments>,
         data_store: &mut StateStore<F>,
-    ) -> VmResult<ExecutionTrace<F>> {
+    ) -> VmResult<(ExecutionTrace<F>, Option<Value<F>>)> {
         // TODO return VMResult<SerializedReturnValues>
         let (
             module,
@@ -152,14 +152,16 @@ impl<F: FieldExt> Runtime<F> {
                 RuntimeError::new(StatusCode::ScriptLoadingError)
             })?;
         trace!("script entry {:?}", entry.name());
-        self.execute_function(
+        let (trace, ret) = self.execute_function(
             entry,
             type_arguments,
             signer,
             args,
             data_store,
             &generic_graph,
-        )
+        )?;
+        assert_eq!(ret, None);
+        Ok(trace)
     }
 
     pub fn execute_function(
@@ -170,7 +172,7 @@ impl<F: FieldExt> Runtime<F> {
         args: Option<ScriptArguments>,
         data_store: &mut StateStore<F>,
         generic_graph: &GenericCallGraph,
-    ) -> VmResult<ExecutionTrace<F>> {
+    ) -> VmResult<(ExecutionTrace<F>, Option<Value<F>>)> {
         let mut interp = Interpreter::<F>::new();
         let arg_types = entry
             .parameter_types()
@@ -184,7 +186,7 @@ impl<F: FieldExt> Runtime<F> {
         let mut exec_steps = Vec::new();
         let mut rw_operations = Vec::new();
         let mut generic_types = Vec::new();
-        interp.execute_function(
+        let ret = interp.execute_function(
             entry,
             type_arguments,
             signer,
@@ -199,11 +201,14 @@ impl<F: FieldExt> Runtime<F> {
             &mut generic_types,
             generic_graph,
         )?;
-        Ok(ExecutionTrace {
-            exec_steps,
-            rw_operations,
-            generic_types,
-        })
+        Ok((
+            ExecutionTrace {
+                exec_steps,
+                rw_operations,
+                generic_types,
+            },
+            ret,
+        ))
     }
 
     pub fn process_execution_trace(

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -385,7 +385,10 @@ fn test_execution_step() -> VmResult<()> {
         Default::default(),
         circuit_config,
     );
-    let vm_circuit = VmCircuit { witness };
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: None,
+    };
     let k = 10;
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
@@ -722,7 +725,10 @@ fn test_nop_step() -> VmResult<()> {
         Default::default(),
         circuit_config,
     );
-    let vm_circuit = VmCircuit { witness };
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: None,
+    };
     let k = 10;
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
@@ -758,7 +764,10 @@ fn test_nop_steps() -> VmResult<()> {
         circuit_config,
     )?;
 
-    let vm_circuit = VmCircuit { witness };
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: None,
+    };
     let k = find_best_k(&vm_circuit, vec![])?;
 
     let expected_step_0 = ExecutionStep {
@@ -1098,7 +1107,10 @@ fn test_empty_ops() -> VmResult<()> {
         circuit_config,
     )?;
 
-    let vm_circuit = VmCircuit { witness };
+    let vm_circuit = VmCircuit {
+        witness,
+        public_input: None,
+    };
     let k = find_best_k(&vm_circuit, vec![])?;
 
     let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {

--- a/vm/src/tests.rs
+++ b/vm/src/tests.rs
@@ -152,7 +152,7 @@ fn test_execution_step() -> VmResult<()> {
         gc: 18,
         module_index: 0,
         function_index: 0,
-        auxiliary_1: None,
+        auxiliary_1: Some(Value::u64(0)),
         auxiliary_2: None,
         auxiliary_3: None,
         auxiliary_4: None,
@@ -390,7 +390,7 @@ fn test_execution_step() -> VmResult<()> {
         public_input: None,
     };
     let k = 10;
-    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
+    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![vec![Fp::zero()]]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
         RuntimeError::new(StatusCode::ProofSystemError(e))
     })?;
@@ -490,7 +490,7 @@ fn test_nop_step() -> VmResult<()> {
         gc: 18,
         module_index: 0,
         function_index: 0,
-        auxiliary_1: None,
+        auxiliary_1: Some(Value::u64(0)),
         auxiliary_2: None,
         auxiliary_3: None,
         auxiliary_4: None,
@@ -730,7 +730,7 @@ fn test_nop_step() -> VmResult<()> {
         public_input: None,
     };
     let k = 10;
-    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
+    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![vec![Fp::zero()]]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
         RuntimeError::new(StatusCode::ProofSystemError(e))
     })?;
@@ -768,7 +768,7 @@ fn test_nop_steps() -> VmResult<()> {
         witness,
         public_input: None,
     };
-    let k = find_best_k(&vm_circuit, vec![])?;
+    let k = find_best_k(&vm_circuit, vec![vec![Fp::zero()]])?;
 
     let expected_step_0 = ExecutionStep {
         context_id: 1,
@@ -848,7 +848,7 @@ fn test_nop_steps() -> VmResult<()> {
         gc: 18,
         module_index: 0,
         function_index: 0,
-        auxiliary_1: None,
+        auxiliary_1: Some(Value::u64(0)),
         auxiliary_2: None,
         auxiliary_3: None,
         auxiliary_4: None,
@@ -1071,7 +1071,7 @@ fn test_nop_steps() -> VmResult<()> {
         "result is not expected"
     );
 
-    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
+    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![vec![Fp::zero()]]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
         RuntimeError::new(StatusCode::ProofSystemError(e))
     })?;
@@ -1111,9 +1111,9 @@ fn test_empty_ops() -> VmResult<()> {
         witness,
         public_input: None,
     };
-    let k = find_best_k(&vm_circuit, vec![])?;
+    let k = find_best_k(&vm_circuit, vec![vec![Fp::zero()]])?;
 
-    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![]).map_err(|e| {
+    let prover = MockProver::<Fp>::run(k, &vm_circuit, vec![vec![Fp::zero()]]).map_err(|e| {
         debug!("Prover Error: {:?}", e);
         RuntimeError::new(StatusCode::ProofSystemError(e))
     })?;


### PR DESCRIPTION
The detailed solution is described in the associated issue. We only implemented solution #2:

1.VM

Entry function can return one Move value:
(tx, args) -> vm -> EXE_RESULT{witness, pi} ，where pi is the returned value.

2.Circuit

```
// RVR popped from the stack
Instruction::Ret::value

// advice table
PITable[index_column, pi_column]

// a special table with solo column and the value same as index.
// which is to garantuee value is among [0, word_capacity].
RVRIndexTable[index_column]

// public input
instance_table
```
Expose Ret::value to public:
1). Lookup(Ret::value, PITable), ensure value is in PITable.
2). constrain_equal(PITalbe[index_column], RVRIndexTable[index_column]), ensure each PITable element is unique, then Ret::value is equal to PITable.
3). constrain_equal(PITalbe[pi_column], instance)

3.Limitations:

only one return value
limited flattened length
length of returned array can not change (can not exceed array length when setup circuit)