### PR TITLE
implement add & sub 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,18 @@ field-exts = { git = "https://github.com/zkmove/zkevm-circuits.git", rev = "8969
 subtle = "2.5"
 rayon = "1.10"
 bytes = { version = "1.5" }
-move-compiler = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-compiler-v2 = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-binary-format = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-core-types = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-vm-runtime = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-vm-types = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-bytecode-verifier = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
-move-package = { git = "https://github.com/zkmove/aptos-core", rev = "bfab761c61" }
+move-compiler = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-compiler-v2 = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-binary-format = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-core-types = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-vm-runtime = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-vm-types = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-bytecode-verifier = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
+move-package = { git = "https://github.com/zkmove/aptos-core", rev = "48ce58c96" }
 
 strum_macros = "0.26"
 strum = "0.26"
+anyhow = "1.0.38"
 
 [profile.dev]
 opt-level = 3

--- a/aptos-move-witnesses/Cargo.toml
+++ b/aptos-move-witnesses/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 
 [dependencies]
 move-vm-runtime = { workspace = true }
+move-core-types = { workspace = true }
 types = { path = "../common/types" }
 serde = { version = "1.0.203", features = ["derive"] }
 strum_macros = { workspace = true }
 strum = { workspace = true }
+anyhow = { workspace = true }

--- a/aptos-move-witnesses/src/exec_state.rs
+++ b/aptos-move-witnesses/src/exec_state.rs
@@ -2,6 +2,7 @@ use strum_macros::EnumIter;
 #[derive(Copy, Clone, Debug, PartialEq, Hash, Eq, EnumIter)]
 pub enum ExecutionState {
     Start,
+    AddSub,
     BrTrue,
     BrFalse,
     VecSwapStage1,

--- a/aptos-move-witnesses/src/witness_preprocessor.rs
+++ b/aptos-move-witnesses/src/witness_preprocessor.rs
@@ -8,8 +8,10 @@ use crate::step_state::{
 };
 use crate::sub_index;
 use crate::utils::{SubIndexUtils, ValueHeader};
-use move_vm_runtime::witnessing::traced_value::{Reference, SimpleValue, ValueItem};
-use move_vm_runtime::witnessing::{Footprint, Operation};
+use crate::witness_preprocessor::to_u256::ToU256;
+use move_core_types::{u256, u256::U256};
+use move_vm_runtime::witnessing::traced_value::{Integer, Reference, SimpleValue, ValueItem};
+use move_vm_runtime::witnessing::{BinaryIntegerOperationType, Footprint, Operation};
 use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 
@@ -1020,6 +1022,66 @@ impl WitnessPreProcessor {
                     }],
                 }]
             }
+            Operation::BinaryOp { ty, rhs, lhs } => {
+                let num_bytes = match (lhs, rhs) {
+                    (Integer::U8(l), Integer::U8(r)) => 1usize,
+                    (Integer::U16(l), Integer::U16(r)) => 2usize,
+                    (Integer::U32(l), Integer::U32(r)) => 4usize,
+                    (Integer::U64(l), Integer::U64(r)) => 8usize,
+                    (Integer::U128(l), Integer::U128(r)) => 16usize,
+                    (Integer::U256(l), Integer::U256(r)) => 32usize,
+                    _ => unreachable!(),
+                };
+
+                // while calculating the result, wrapping around at the boundary of the u256,
+                // to prevent overflow from stopping the computing.
+                let out = match ty {
+                    BinaryIntegerOperationType::Add => {
+                        let output = U256::wrapping_add(lhs.to_u256(), rhs.to_u256());
+                        SimpleValue::U256(output)
+                    }
+                    BinaryIntegerOperationType::Sub => {
+                        let output = U256::wrapping_sub(lhs.to_u256(), rhs.to_u256());
+                        SimpleValue::U256(output)
+                    }
+                    _ => todo!(),
+                };
+
+                let step_state = StepState::new(self.clk, ExecutionState::AddSub, trace)
+                    .set_aux0(num_bytes as u128);
+                let stack_pop_rhs = StackPop {
+                    index: sp,
+                    sub_index: vec![0],
+                    value: rhs.clone().into(),
+                    value_header: false,
+                    version: self.version_stack.pop().unwrap(),
+                };
+                let stack_pop_lhs = StackPop {
+                    index: sp - 1,
+                    sub_index: vec![0],
+                    value: lhs.clone().into(),
+                    value_header: false,
+                    version: self.version_stack.pop().unwrap(),
+                };
+                self.version_stack.push(self.clk);
+                let stack_push = StackPush {
+                    index: sp - 1,
+                    sub_index: vec![0],
+                    value: out,
+                    value_header: false,
+                    version: *self.version_stack.last().unwrap(),
+                };
+                let memory_ops = vec![
+                    MemoryOp(Some(stack_pop_rhs), None, None),
+                    MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
+                ];
+                vec![StageState {
+                    step_states: vec![ExecStepState {
+                        step_state,
+                        memory_ops,
+                    }],
+                }]
+            }
             _ => unimplemented!(),
         }
     }
@@ -1152,5 +1214,47 @@ impl Deref for Local {
 impl DerefMut for Local {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.data
+    }
+}
+
+///TODO: move to other place
+
+pub mod to_u256 {
+    use move_core_types::{u256, u256::U256};
+    use move_vm_runtime::witnessing::traced_value::Integer;
+
+    pub trait ToU256 {
+        fn to_u256(&self) -> U256;
+    }
+
+    impl ToU256 for Integer {
+        fn to_u256(&self) -> U256 {
+            match self {
+                Integer::U8(v) => U256::from(*v),
+                Integer::U16(v) => U256::from(*v),
+                Integer::U32(v) => U256::from(*v),
+                Integer::U64(v) => U256::from(*v),
+                Integer::U128(v) => U256::from(*v),
+                Integer::U256(v) => U256::from(*v),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use move_core_types::{u256, u256::U256};
+
+    #[test]
+    fn test_overflowing_sub() {
+        let a = U256::from(0u8);
+        let b = U256::max_value();
+        let c = U256::from(1u8);
+        assert_eq!(U256::wrapping_sub(a, b), c);
+
+        let a = U256::from(0u8);
+        let b = U256::from(1u8);
+        let c = U256::max_value();
+        assert_eq!(U256::wrapping_sub(a, b), c);
     }
 }

--- a/specs/opcodes.rs
+++ b/specs/opcodes.rs
@@ -152,39 +152,45 @@ mod pop {
     }
 }
 
-// TODO: support u256
 mod add {
-    fn constraint_add() {
-        let is_first = super::common::on_first_row();
-        let is_last = super::common::on_last_row();
-
-        if is_first {
-            // first row
-            table_opcode.contain(pc(0), opcode(0), aux0(0), aux0(1));
+    pub fn constrain(is_add: bool) {
+        if super::common::on_first_row() {
+            if is_add {
+                opcode(0) == OpCode::Add;
+            } else {
+                opcode(0) == OpCode::Sub;
+            }
             step_counter(0) == 2;
-            super::common::fake_empty_stack_push();
-        } else {
-            stack_push_index(0) == stack_pop_index(0);
-            stack_push_sub_index(0) == stack_pop_sub_index(0);
-            // TODO: add overflow check
-            // second row is write a+b to a
-            stack_push_value(0) == stack_pop_value(0) + stack_pop_value(-1);
-            stack_push_value_header(0) == false;
-            stack_push_version(0) == clk(0);
-            stack_push_version(0) > stack_pop_version(0);
+            super::common::fake_empty_stack_push(0);
+            stack_pop_index(0) == sp(0);
+            sp(1) == sp(0); //keep sp unchanged to make assign easier
         }
-        stack_pop_index(0) == sp(0);
-        stack_pop_sub_index(0) == 0;
 
+        stack_pop_sub_index(0) == 0;
+        stack_pop_value_header(0) == false;
+        stack_pop_version(0) < clk(0);
         super::common::fake_local_read_zero();
 
-        if is_last {
-            sp(1) == sp(0);
-        } else {
-            aux0(1) == aux0(0);
-            aux1(1) == aux1(0);
+        if super::common::on_last_row() {
+            stack_pop_index(0) == sp(0) - 1;
+            stack_push_index(0) == sp(0) - 1;
+            stack_push_sub_index(0) == 0;
+            let out = if is_add {
+                stack_pop_value(0) + stack_pop_value(-1)
+            } else {
+                stack_pop_value(0) - stack_pop_value(-1)
+            };
+            common::super::range_check();
+            common::super::overflow_check();
+            stack_push_value(0) == out;
+            stack_push_value_header(0) == false;
+            stack_push_version(0) == clk(0);
+
+            module_index(1) == module_index(0);
+            function_index(1) == function_index(0);
+            frame_index(1) == frame_index(0);
+            pc(1) == pc(0) + 1;
             sp(1) == sp(0) - 1;
-            step_counter(1) == step_counter(0) - 1;
         }
     }
 }

--- a/vm-circuit/Cargo.toml
+++ b/vm-circuit/Cargo.toml
@@ -17,6 +17,7 @@ types = { path = "../common/types" }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-package = { workspace = true }
+move-vm-runtime = { workspace = true }
 halo2_proofs = { workspace = true, features = ["dev-graph"] }
 halo2_poseidon.workspace = true
 field-exts.workspace = true

--- a/vm-circuit/src/chips/execution_chip_v2/executions.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions.rs
@@ -23,6 +23,7 @@ pub(crate) mod vec_pop_back;
 pub(crate) mod vec_push_back;
 pub(crate) mod vec_swap;
 pub(crate) mod write_ref;
+pub use add_sub::*;
 pub use borrow_loc::*;
 pub use br_bool::*;
 pub use ld::*;
@@ -31,7 +32,6 @@ pub(crate) use move_or_copy_loc::*;
 pub use pack::*;
 pub use unpack::*;
 pub use vec_len::*;
-pub use add_sub::*;
 
 use crate::chips::execution_chip::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip::utils::constraint_builder_v2::ConstraintBuilderV2;

--- a/vm-circuit/src/chips/execution_chip_v2/executions.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions.rs
@@ -1,3 +1,4 @@
+pub(crate) mod add_sub;
 pub(crate) mod and_or;
 pub(crate) mod base;
 pub(crate) mod borrow_field;
@@ -30,6 +31,7 @@ pub(crate) use move_or_copy_loc::*;
 pub use pack::*;
 pub use unpack::*;
 pub use vec_len::*;
+pub use add_sub::*;
 
 use crate::chips::execution_chip::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip::utils::constraint_builder_v2::ConstraintBuilderV2;

--- a/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
@@ -8,6 +8,7 @@ use crate::chips::execution_chip_v2::math_gadgets::range_check::IntegerRangeChec
 use crate::chips::execution_chip_v2::step_v2::{
     StepState, FRAME_INDEX, FUNCTION_INDEX, MODULE_INDEX, PC, SP,
 };
+use crate::chips::execution_chip_v2::value::Integer as IntegerExpr;
 use crate::chips::execution_chip_v2::value::{
     INTEGER_NUM_OF_BYTES_SET, NUM_OF_BYTES_U128, NUM_OF_BYTES_U16, NUM_OF_BYTES_U256,
     NUM_OF_BYTES_U32, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
@@ -17,25 +18,15 @@ use crate::chips::utilities::Expr;
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
 use aptos_move_witnesses::step_state::StageState;
-use aptos_move_witnesses::utils::SubIndexUtils;
-use halo2_proofs::{circuit::Value, plonk::Error};
-use move_core_types::{u256, u256::U256};
+use halo2_proofs::{circuit::Value, plonk::{Error, Expression},};
+use move_core_types::{u256::U256};
 use move_vm_runtime::witnessing::traced_value::Integer;
 use types::Field;
 
 #[derive(Clone, Debug)]
 pub struct AddSub<F> {
-    range_check_lo_opt: Option<IntegerRangeCheck<F>>,
-    range_check_hi_opt: Option<IntegerRangeCheck<F>>,
-    add_opt: Option<AddGadget<F>>,
-    is_add_opt: Option<IsZeroGadget<F>>,
-    is_u8_opt: Option<IsZeroGadget<F>>,
-    is_u16_opt: Option<IsZeroGadget<F>>,
-    is_u32_opt: Option<IsZeroGadget<F>>,
-    is_u64_opt: Option<IsZeroGadget<F>>,
-    is_u128_opt: Option<IsZeroGadget<F>>,
-    is_u256_opt: Option<IsZeroGadget<F>>,
-    overflow_opt: Option<Cell<F>>,
+    add_sub_gadget: Option<AddSubGadget<F>>,
+    is_add: IsZeroGadget<F>,
 }
 impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
     const NAME: &'static str = "AddSub";
@@ -45,17 +36,9 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
         let step_prev = cb.step_state_at_offset(-1);
-        let mut range_check_lo_opt = None;
-        let mut range_check_hi_opt = None;
-        let mut add_opt = None;
-        let mut is_add_opt = None;
-        let mut is_u8_opt = None;
-        let mut is_u16_opt = None;
-        let mut is_u32_opt = None;
-        let mut is_u64_opt = None;
-        let mut is_u128_opt = None;
-        let mut is_u256_opt = None;
-        let mut overflow_opt = None;
+        let mut add_sub_gadget = None;
+        let is_add =
+            IsZeroGadget::construct(cb, step_curr.opcode.expr() - (Opcode::Add as u64).expr());
 
         cb.first_row(|cb| {
             cb.require_in_set(
@@ -91,37 +74,6 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
         cb.require_no_local_op();
 
         cb.last_row(|cb| {
-            let range_check_lo = IntegerRangeCheck::construct(cb);
-            let range_check_hi = IntegerRangeCheck::construct(cb);
-            let add = AddGadget::construct(cb);
-            let is_add =
-                IsZeroGadget::construct(cb, step_curr.opcode.expr() - (Opcode::Add as u64).expr());
-            let is_u8 = IsZeroGadget::construct(
-                cb,
-                step_curr.aux0.expr() - (NUM_OF_BYTES_U8 as u64).expr(),
-            );
-            let is_u16 = IsZeroGadget::construct(
-                cb,
-                step_curr.aux0.expr() - (NUM_OF_BYTES_U16 as u64).expr(),
-            );
-            let is_u32 = IsZeroGadget::construct(
-                cb,
-                step_curr.aux0.expr() - (NUM_OF_BYTES_U32 as u64).expr(),
-            );
-            let is_u64 = IsZeroGadget::construct(
-                cb,
-                step_curr.aux0.expr() - (NUM_OF_BYTES_U64 as u64).expr(),
-            );
-            let is_u128 = IsZeroGadget::construct(
-                cb,
-                step_curr.aux0.expr() - (NUM_OF_BYTES_U128 as u64).expr(),
-            );
-            let is_u256 = IsZeroGadget::construct(
-                cb,
-                step_curr.aux0.expr() - (NUM_OF_BYTES_U256 as u64).expr(),
-            );
-            let overflow = cb.query_bool();
-
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0) - 1", Self::NAME),
                 step_curr.stack_pop_index.expr(),
@@ -146,80 +98,14 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 step_curr.clk.expr(),
             );
 
-            // configure add gadget
-
             let lhs = step_curr.stack_pop_value.as_integer();
             let rhs = step_prev.stack_pop_value.as_integer();
             let out = step_curr.stack_push_value.as_integer();
-            add.expr(cb, lhs, rhs, out.clone(), is_add.expr());
+            let add_sub = AddSubGadget::construct(cb, is_add.expr(), step_curr.aux0.expr(), lhs, rhs, out);
+            let overflow = add_sub.overflow();
+            add_sub_gadget = Some(add_sub);
 
-            // overflow check
-
-            // U8,U16,U32,U64
-            cb.require_zero(
-                "out_hi == 0",
-                (is_u8.expr() + is_u16.expr() + is_u32.expr() + is_u64.expr()) * out.hi(),
-            );
-            cb.condition(is_u8.expr(), |cb| {
-                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U8);
-                cb.require_equal(
-                    "overflow == !in_range(out_lo)",
-                    overflow.expr(),
-                    1u64.expr() - in_range,
-                );
-            });
-            cb.condition(is_u16.expr(), |cb| {
-                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U16);
-                cb.require_equal(
-                    "overflow == !in_range(out_lo)",
-                    overflow.expr(),
-                    1u64.expr() - in_range,
-                );
-            });
-            cb.condition(is_u32.expr(), |cb| {
-                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U32);
-                cb.require_equal(
-                    "overflow == !in_range(out_lo)",
-                    overflow.expr(),
-                    1u64.expr() - in_range,
-                );
-            });
-            cb.condition(is_u64.expr(), |cb| {
-                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U64);
-                cb.require_equal(
-                    "overflow == !in_range(out_lo)",
-                    overflow.expr(),
-                    1u64.expr() - in_range,
-                );
-            });
-
-            // U128
-            cb.condition(is_u128.expr(), |cb| {
-                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U128);
-                cb.require_true("out_lo < 2^128", in_range);
-                //OVERFLOW if out_hi == 1
-                cb.require_in_set(
-                    "out_hi == 0 | 1",
-                    out.hi(),
-                    (0u64..2).map(|v| v.expr()).collect(),
-                );
-                cb.require_equal("overflow == out_hi", overflow.expr(), out.hi());
-            });
-
-            // U256
-            cb.condition(is_u256.expr(), |cb| {
-                let in_range_lo = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U128);
-                let in_range_hi = range_check_hi.expr(cb, out.hi(), NUM_OF_BYTES_U128);
-                cb.require_true("out_lo < 2^128", in_range_lo);
-                cb.require_true("out_hi < 2^128", in_range_hi);
-                cb.require_equal(
-                    "overflow == add_gadget.overflow()",
-                    overflow.expr(),
-                    add.overflow(),
-                );
-            });
-
-            cb.condition(overflow.expr(), |_cb| {
+            cb.condition(overflow, |_cb| {
                 // cb.require_next_state(ExecutionState::ErrorState);
                 // ErrorCode == StatusCode::ArithmeticError
             });
@@ -231,45 +117,23 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 (SP, Transition::Delta((-1).expr())),
                 (PC, Transition::Delta(1.expr())),
             ]);
-
-            range_check_lo_opt = Some(range_check_lo);
-            range_check_hi_opt = Some(range_check_hi);
-            add_opt = Some(add);
-            is_add_opt = Some(is_add);
-            is_u8_opt = Some(is_u8);
-            is_u16_opt = Some(is_u16);
-            is_u32_opt = Some(is_u32);
-            is_u64_opt = Some(is_u64);
-            is_u128_opt = Some(is_u128);
-            is_u256_opt = Some(is_u256);
-            overflow_opt = Some(overflow);
         });
 
         AddSub {
-            range_check_lo_opt,
-            range_check_hi_opt,
-            add_opt,
-            is_add_opt,
-            is_u8_opt,
-            is_u16_opt,
-            is_u32_opt,
-            is_u64_opt,
-            is_u128_opt,
-            is_u256_opt,
-            overflow_opt,
+            add_sub_gadget,
+            is_add,
         }
     }
 
     fn assign(
         &self,
-        step: StepState<F>,
+        _step: StepState<F>,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         stage_state: &StageState,
     ) -> Result<usize, Error> {
         debug_assert!(!stage_state.step_states.is_empty());
         let step_state = stage_state.step_states.first().unwrap();
-        debug_assert_eq!(step_state.memory_ops.len(), 1);
         let is_add = if step_state.step_state.opcode == Opcode::Add as u16 {
             true
         } else {
@@ -283,50 +147,227 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
         let (lhs_lo, lhs_hi) = Integer::try_from(lhs).unwrap().into();
         let (out_lo, out_hi) = Integer::try_from(out).unwrap().into();
 
-        //NOTICE: No private cells in the first row, only assign the second row.
-        let offset = offset + 1;
-        self.is_add_opt.clone().unwrap().assign(
-            region,
-            offset,
-            F::from(step_state.step_state.opcode as u64) - F::from(Opcode::Add as u64),
-        )?;
-        self.is_u8_opt.clone().unwrap().assign(
+        debug_assert_eq!(step_state.memory_ops.len(), 2);
+        for i in 0..step_state.memory_ops.len() {
+            self.is_add.assign(
+                region,
+                offset + i,
+                F::from(step_state.step_state.opcode as u64) - F::from(Opcode::Add as u64),
+            )?;
+            self.is_add.assign(
+                region,
+                offset + i,
+                F::from(step_state.step_state.opcode as u64) - F::from(Opcode::Add as u64),
+            )?;
+        }
+
+        self.add_sub_gadget.as_ref().unwrap().assign(region, offset + 1, is_add, num_bytes, lhs_lo, lhs_hi, rhs_lo, rhs_hi, out_lo, out_hi)?;
+        //TODO: we need assign row 'offset' too, since add_sub_gadget is also allocated in row 'offset'
+
+        Ok(step_state.memory_ops.len())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AddSubGadget<F> {
+    range_check_lo: IntegerRangeCheck<F>,
+    range_check_hi: IntegerRangeCheck<F>,
+    add: AddGadget<F>,
+    is_u8: IsZeroGadget<F>,
+    is_u16: IsZeroGadget<F>,
+    is_u32: IsZeroGadget<F>,
+    is_u64: IsZeroGadget<F>,
+    is_u128: IsZeroGadget<F>,
+    is_u256: IsZeroGadget<F>,
+    overflow: Cell<F>,
+}
+
+impl<F: Field> AddSubGadget<F> {
+    fn construct(
+        cb: &mut ConstraintBuilderV2<F>,
+        is_add: Expression<F>,
+        n_bytes: Expression<F>,
+        lhs: IntegerExpr<F>,
+        rhs: IntegerExpr<F>,
+        out: IntegerExpr<F>,
+    ) -> Self {
+        let range_check_lo = IntegerRangeCheck::construct(cb);
+        let range_check_hi = IntegerRangeCheck::construct(cb);
+        let add = AddGadget::construct(cb);
+        let is_u8 = IsZeroGadget::construct(
+            cb,
+            n_bytes.clone() - (NUM_OF_BYTES_U8 as u64).expr(),
+        );
+        let is_u16 = IsZeroGadget::construct(
+            cb,
+            n_bytes.clone() - (NUM_OF_BYTES_U16 as u64).expr(),
+        );
+        let is_u32 = IsZeroGadget::construct(
+            cb,
+            n_bytes.clone() - (NUM_OF_BYTES_U32 as u64).expr(),
+        );
+        let is_u64 = IsZeroGadget::construct(
+            cb,
+            n_bytes.clone() - (NUM_OF_BYTES_U64 as u64).expr(),
+        );
+        let is_u128 = IsZeroGadget::construct(
+            cb,
+            n_bytes.clone() - (NUM_OF_BYTES_U128 as u64).expr(),
+        );
+        let is_u256 = IsZeroGadget::construct(
+            cb,
+            n_bytes - (NUM_OF_BYTES_U256 as u64).expr(),
+        );
+        let overflow = cb.query_bool();
+
+        // configure add gadget
+        add.expr(
+            cb,
+            IntegerExpr::select(is_add.clone(), lhs.clone(), out.clone()),
+            rhs,
+            IntegerExpr::select(is_add, out.clone(), lhs),
+        );
+
+        // overflow and range check
+
+        // U8,U16,U32,U64
+        cb.require_zero(
+            "out_hi == 0",
+            (is_u8.expr() + is_u16.expr() + is_u32.expr() + is_u64.expr()) * out.hi(),
+        );
+        cb.condition(is_u8.expr(), |cb| {
+            let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U8);
+            cb.require_equal(
+                "overflow == !in_range(out_lo)",
+                overflow.expr(),
+                1u64.expr() - in_range,
+            );
+        });
+        cb.condition(is_u16.expr(), |cb| {
+            let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U16);
+            cb.require_equal(
+                "overflow == !in_range(out_lo)",
+                overflow.expr(),
+                1u64.expr() - in_range,
+            );
+        });
+        cb.condition(is_u32.expr(), |cb| {
+            let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U32);
+            cb.require_equal(
+                "overflow == !in_range(out_lo)",
+                overflow.expr(),
+                1u64.expr() - in_range,
+            );
+        });
+        cb.condition(is_u64.expr(), |cb| {
+            let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U64);
+            cb.require_equal(
+                "overflow == !in_range(out_lo)",
+                overflow.expr(),
+                1u64.expr() - in_range,
+            );
+        });
+
+        // U128
+        cb.condition(is_u128.expr(), |cb| {
+            let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U128);
+            cb.require_true("out_lo < 2^128", in_range);
+            //OVERFLOW if out_hi == 1
+            cb.require_in_set(
+                "out_hi == 0 | 1",
+                out.hi(),
+                (0u64..2).map(|v| v.expr()).collect(),
+            );
+            cb.require_equal("overflow == out_hi", overflow.expr(), out.hi());
+        });
+
+        // U256
+        cb.condition(is_u256.expr(), |cb| {
+            let in_range_lo = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U128);
+            let in_range_hi = range_check_hi.expr(cb, out.hi(), NUM_OF_BYTES_U128);
+            cb.require_true("out_lo < 2^128", in_range_lo);
+            cb.require_true("out_hi < 2^128", in_range_hi);
+            cb.require_equal(
+                "overflow == add_gadget.overflow()",
+                overflow.expr(),
+                add.overflow(),
+            );
+        });
+
+        AddSubGadget {
+            range_check_lo,
+            range_check_hi,
+            add,
+            is_u8,
+            is_u16,
+            is_u32,
+            is_u64,
+            is_u128,
+            is_u256,
+            overflow,
+        }
+    }
+
+    fn overflow(&self) -> Expression<F> {
+        self.overflow.expr()
+    }
+
+    fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        is_add: bool,
+        num_bytes: usize,
+        lhs_lo: u128,
+        lhs_hi: u128,
+        rhs_lo: u128,
+        rhs_hi: u128,
+        out_lo: u128,
+        out_hi: u128,
+    ) -> Result<(), Error> {
+        self.is_u8.assign(
             region,
             offset,
             F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U8 as u64),
         )?;
-        self.is_u16_opt.clone().unwrap().assign(
+        self.is_u16.assign(
             region,
             offset,
             F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U16 as u64),
         )?;
-        self.is_u32_opt.clone().unwrap().assign(
+        self.is_u32.assign(
             region,
             offset,
             F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U32 as u64),
         )?;
-        self.is_u64_opt.clone().unwrap().assign(
+        self.is_u64.assign(
             region,
             offset,
             F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U64 as u64),
         )?;
-        self.is_u128_opt.clone().unwrap().assign(
+        self.is_u128.assign(
             region,
             offset,
             F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U128 as u64),
         )?;
-        self.is_u256_opt.clone().unwrap().assign(
+        self.is_u256.assign(
             region,
             offset,
             F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U256 as u64),
         )?;
-        self.add_opt.clone().unwrap().assign(
-            region, offset, lhs_lo, lhs_hi, rhs_lo, rhs_hi, out_lo, out_hi, is_add,
-        )?;
+        if is_add {
+            self.add.assign(
+                region, offset, lhs_lo, lhs_hi, rhs_lo, rhs_hi, out_lo, out_hi,
+            )?;
+        } else {
+            self.add.assign(
+                region, offset, out_lo, out_hi, rhs_lo, rhs_hi, lhs_lo, lhs_hi,
+            )?;
+        }
 
         match num_bytes {
             NUM_OF_BYTES_U8 => {
-                self.range_check_lo_opt.clone().unwrap().assign(
+                self.range_check_lo.assign(
                     region,
                     offset,
                     F::from_u128(out_lo),
@@ -338,14 +379,14 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow_opt.clone().unwrap().assign(
+                self.overflow.assign(
                     region,
                     offset,
                     Value::known(overflow),
                 )?;
             }
             NUM_OF_BYTES_U16 => {
-                self.range_check_lo_opt.clone().unwrap().assign(
+                self.range_check_lo.assign(
                     region,
                     offset,
                     F::from_u128(out_lo),
@@ -357,14 +398,14 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow_opt.clone().unwrap().assign(
+                self.overflow.assign(
                     region,
                     offset,
                     Value::known(overflow),
                 )?;
             }
             NUM_OF_BYTES_U32 => {
-                self.range_check_lo_opt.clone().unwrap().assign(
+                self.range_check_lo.assign(
                     region,
                     offset,
                     F::from_u128(out_lo),
@@ -376,14 +417,14 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow_opt.clone().unwrap().assign(
+                self.overflow.assign(
                     region,
                     offset,
                     Value::known(overflow),
                 )?;
             }
             NUM_OF_BYTES_U64 => {
-                self.range_check_lo_opt.clone().unwrap().assign(
+                self.range_check_lo.assign(
                     region,
                     offset,
                     F::from_u128(out_lo),
@@ -395,14 +436,14 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow_opt.clone().unwrap().assign(
+                self.overflow.assign(
                     region,
                     offset,
                     Value::known(overflow),
                 )?;
             }
             NUM_OF_BYTES_U128 => {
-                self.range_check_lo_opt.clone().unwrap().assign(
+                self.range_check_lo.assign(
                     region,
                     offset,
                     F::from_u128(out_lo),
@@ -410,20 +451,20 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 )?;
                 debug_assert!(out_hi == 0u128 || out_hi == 1u128);
                 let overflow = if out_hi == 1u128 { F::one() } else { F::zero() };
-                self.overflow_opt.clone().unwrap().assign(
+                self.overflow.assign(
                     region,
                     offset,
                     Value::known(overflow),
                 )?;
             }
             NUM_OF_BYTES_U256 => {
-                self.range_check_lo_opt.clone().unwrap().assign(
+                self.range_check_lo.assign(
                     region,
                     offset,
                     F::from_u128(out_lo),
                     NUM_OF_BYTES_U128,
                 )?;
-                self.range_check_hi_opt.clone().unwrap().assign(
+                self.range_check_hi.assign(
                     region,
                     offset,
                     F::from_u128(out_hi),
@@ -456,7 +497,7 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow_opt.clone().unwrap().assign(
+                self.overflow.assign(
                     region,
                     offset,
                     Value::known(overflow),
@@ -464,7 +505,6 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
             }
             _ => unreachable!(),
         }
-
-        Ok(step_state.memory_ops.len())
+        Ok(())
     }
 }

--- a/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
@@ -1,0 +1,467 @@
+use crate::chips::execution_chip::opcode::Opcode;
+use crate::chips::execution_chip::utils::base_constraint_builder::ConstrainBuilderCommon;
+use crate::chips::execution_chip::utils::constraint_builder_v2::{ConstraintBuilderV2, Transition};
+use crate::chips::execution_chip_v2::executions::ExecutionState;
+use crate::chips::execution_chip_v2::math_gadgets::add::AddGadget;
+use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
+use crate::chips::execution_chip_v2::math_gadgets::range_check::IntegerRangeCheck;
+use crate::chips::execution_chip_v2::step_v2::{
+    StepState, FRAME_INDEX, FUNCTION_INDEX, MODULE_INDEX, PC, SP,
+};
+use crate::chips::execution_chip_v2::value::{
+    NUM_OF_BYTES_U128, NUM_OF_BYTES_U16, NUM_OF_BYTES_U256, NUM_OF_BYTES_U32, NUM_OF_BYTES_U64,
+    NUM_OF_BYTES_U8,
+};
+use crate::chips::execution_chip_v2::InstructionGadgetV2;
+use crate::chips::utilities::Expr;
+use crate::utils::cached_region::CachedRegion;
+use crate::utils::cell_manager::Cell;
+use aptos_move_witnesses::step_state::StageState;
+use aptos_move_witnesses::utils::SubIndexUtils;
+use halo2_proofs::{circuit::Value, plonk::Error};
+use move_core_types::{u256, u256::U256};
+use move_vm_runtime::witnessing::traced_value::Integer;
+use types::Field;
+
+#[derive(Clone, Debug)]
+pub struct AddSub<F> {
+    range_check_lo_opt: Option<IntegerRangeCheck<F>>,
+    range_check_hi_opt: Option<IntegerRangeCheck<F>>,
+    add_opt: Option<AddGadget<F>>,
+    is_add_opt: Option<IsZeroGadget<F>>,
+    is_u8_opt: Option<IsZeroGadget<F>>,
+    is_u16_opt: Option<IsZeroGadget<F>>,
+    is_u32_opt: Option<IsZeroGadget<F>>,
+    is_u64_opt: Option<IsZeroGadget<F>>,
+    is_u128_opt: Option<IsZeroGadget<F>>,
+    is_u256_opt: Option<IsZeroGadget<F>>,
+    overflow_opt: Option<Cell<F>>,
+}
+impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
+    const NAME: &'static str = "AddSub";
+    const OPCODES: &'static [Opcode] = &[Opcode::Add, Opcode::Sub];
+    const EXECUTION_STATE: ExecutionState = ExecutionState::AddSub;
+
+    fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        let step_curr = cb.curr.state.clone();
+        let step_prev = cb.step_state_at_offset(-1);
+        let mut range_check_lo_opt = None;
+        let mut range_check_hi_opt = None;
+        let mut add_opt = None;
+        let mut is_add_opt = None;
+        let mut is_u8_opt = None;
+        let mut is_u16_opt = None;
+        let mut is_u32_opt = None;
+        let mut is_u64_opt = None;
+        let mut is_u128_opt = None;
+        let mut is_u256_opt = None;
+        let mut overflow_opt = None;
+
+        cb.first_row(|cb| {
+            cb.require_in_set(
+                "opcode in OPCODES",
+                step_curr.opcode.expr(),
+                Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
+            );
+            cb.require_equal(
+                "step_counter(0) == 2",
+                step_curr.step_counter.expr(),
+                2u64.expr(),
+            );
+            cb.require_no_stack_push();
+            cb.require_equal(
+                format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
+                step_curr.stack_pop_index.expr(),
+                step_curr.sp.expr(),
+            );
+            cb.require_state_transition(vec![(SP, Transition::Same)]);
+        });
+
+        cb.require_zero(
+            format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
+            step_curr.stack_pop_sub_index.expr(),
+        );
+        cb.require_zero(
+            format!("{}, stack_pop_value_header(0) == false", Self::NAME),
+            step_curr.stack_pop_value_header.expr(),
+        );
+        cb.require_no_local_op();
+
+        cb.last_row(|cb| {
+            let range_check_lo = IntegerRangeCheck::construct(cb);
+            let range_check_hi = IntegerRangeCheck::construct(cb);
+            let add = AddGadget::construct(cb);
+            let is_add =
+                IsZeroGadget::construct(cb, step_curr.opcode.expr() - (Opcode::Add as u64).expr());
+            let is_u8 = IsZeroGadget::construct(
+                cb,
+                step_curr.aux0.expr() - (NUM_OF_BYTES_U8 as u64).expr(),
+            );
+            let is_u16 = IsZeroGadget::construct(
+                cb,
+                step_curr.aux0.expr() - (NUM_OF_BYTES_U16 as u64).expr(),
+            );
+            let is_u32 = IsZeroGadget::construct(
+                cb,
+                step_curr.aux0.expr() - (NUM_OF_BYTES_U32 as u64).expr(),
+            );
+            let is_u64 = IsZeroGadget::construct(
+                cb,
+                step_curr.aux0.expr() - (NUM_OF_BYTES_U64 as u64).expr(),
+            );
+            let is_u128 = IsZeroGadget::construct(
+                cb,
+                step_curr.aux0.expr() - (NUM_OF_BYTES_U128 as u64).expr(),
+            );
+            let is_u256 = IsZeroGadget::construct(
+                cb,
+                step_curr.aux0.expr() - (NUM_OF_BYTES_U256 as u64).expr(),
+            );
+            let overflow = cb.query_bool();
+
+            cb.require_equal(
+                format!("{}, stack_pop_index(0) == sp(0) - 1", Self::NAME),
+                step_curr.stack_pop_index.expr(),
+                step_curr.sp.expr() - 1u64.expr(),
+            );
+            cb.require_equal(
+                format!("{}, stack_push_index(0) == sp(0) - 1", Self::NAME),
+                step_curr.stack_push_index.expr(),
+                step_curr.sp.expr() - 1u64.expr(),
+            );
+            cb.require_zero(
+                format!("{}, stack_push_sub_index(0) == 0", Self::NAME),
+                step_curr.stack_push_sub_index.expr(),
+            );
+            cb.require_zero(
+                format!("{}, stack_push_value_header(0) == false", Self::NAME),
+                step_curr.stack_push_value_header.expr(),
+            );
+            cb.require_equal(
+                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
+                step_curr.stack_push_version.expr(),
+                step_curr.clk.expr(),
+            );
+
+            // configure add gadget
+
+            let lhs = step_curr.stack_pop_value.as_integer();
+            let rhs = step_prev.stack_pop_value.as_integer();
+            let out = step_curr.stack_push_value.as_integer();
+            add.expr(cb, lhs, rhs, out.clone(), is_add.expr());
+
+            // overflow check
+
+            // U8,U16,U32,U64
+            cb.require_zero(
+                "out_hi == 0",
+                (is_u8.expr() + is_u16.expr() + is_u32.expr() + is_u64.expr()) * out.hi(),
+            );
+            cb.condition(is_u8.expr(), |cb| {
+                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U8);
+                cb.require_equal(
+                    "overflow == !in_range(out_lo)",
+                    overflow.expr(),
+                    1u64.expr() - in_range,
+                );
+            });
+            cb.condition(is_u16.expr(), |cb| {
+                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U16);
+                cb.require_equal(
+                    "overflow == !in_range(out_lo)",
+                    overflow.expr(),
+                    1u64.expr() - in_range,
+                );
+            });
+            cb.condition(is_u32.expr(), |cb| {
+                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U32);
+                cb.require_equal(
+                    "overflow == !in_range(out_lo)",
+                    overflow.expr(),
+                    1u64.expr() - in_range,
+                );
+            });
+            cb.condition(is_u64.expr(), |cb| {
+                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U64);
+                cb.require_equal(
+                    "overflow == !in_range(out_lo)",
+                    overflow.expr(),
+                    1u64.expr() - in_range,
+                );
+            });
+
+            // U128
+            cb.condition(is_u128.expr(), |cb| {
+                let in_range = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U128);
+                cb.require_true("out_lo < 2^128", in_range);
+                //OVERFLOW if out_hi == 1
+                cb.require_in_set(
+                    "out_hi == 0 | 1",
+                    out.hi(),
+                    (0u64..2).map(|v| v.expr()).collect(),
+                );
+                cb.require_equal("overflow == out_hi", overflow.expr(), out.hi());
+            });
+
+            // U256
+            cb.condition(is_u256.expr(), |cb| {
+                let in_range_lo = range_check_lo.expr(cb, out.lo(), NUM_OF_BYTES_U128);
+                let in_range_hi = range_check_hi.expr(cb, out.hi(), NUM_OF_BYTES_U128);
+                cb.require_true("out_lo < 2^128", in_range_lo);
+                cb.require_true("out_hi < 2^128", in_range_hi);
+                cb.require_equal(
+                    "overflow == add_gadget.overflow()",
+                    overflow.expr(),
+                    add.overflow(),
+                );
+            });
+
+            cb.condition(overflow.expr(), |_cb| {
+                // cb.require_next_state(ExecutionState::ErrorState);
+                // ErrorCode == StatusCode::ArithmeticError
+            });
+
+            cb.require_state_transition(vec![
+                (FRAME_INDEX, Transition::Same),
+                (MODULE_INDEX, Transition::Same),
+                (FUNCTION_INDEX, Transition::Same),
+                (SP, Transition::Delta((-1).expr())),
+                (PC, Transition::Delta(1.expr())),
+            ]);
+
+            range_check_lo_opt = Some(range_check_lo);
+            range_check_hi_opt = Some(range_check_hi);
+            add_opt = Some(add);
+            is_add_opt = Some(is_add);
+            is_u8_opt = Some(is_u8);
+            is_u16_opt = Some(is_u16);
+            is_u32_opt = Some(is_u32);
+            is_u64_opt = Some(is_u64);
+            is_u128_opt = Some(is_u128);
+            is_u256_opt = Some(is_u256);
+            overflow_opt = Some(overflow);
+        });
+
+        AddSub {
+            range_check_lo_opt,
+            range_check_hi_opt,
+            add_opt,
+            is_add_opt,
+            is_u8_opt,
+            is_u16_opt,
+            is_u32_opt,
+            is_u64_opt,
+            is_u128_opt,
+            is_u256_opt,
+            overflow_opt,
+        }
+    }
+
+    fn assign(
+        &self,
+        step: StepState<F>,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        stage_state: &StageState,
+    ) -> Result<usize, Error> {
+        debug_assert!(!stage_state.step_states.is_empty());
+        let step_state = stage_state.step_states.first().unwrap();
+        debug_assert_eq!(step_state.memory_ops.len(), 1);
+        let is_add = if step_state.step_state.opcode == Opcode::Add as u16 {
+            true
+        } else {
+            false
+        };
+        let num_bytes = step_state.step_state.aux0 as usize;
+        let rhs = step_state.memory_ops[0].0.clone().unwrap().value;
+        let lhs = step_state.memory_ops[1].0.clone().unwrap().value;
+        let out = step_state.memory_ops[1].1.clone().unwrap().value;
+        let (rhs_lo, rhs_hi) = Integer::try_from(rhs).unwrap().into();
+        let (lhs_lo, lhs_hi) = Integer::try_from(lhs).unwrap().into();
+        let (out_lo, out_hi) = Integer::try_from(out).unwrap().into();
+
+        //NOTICE: No private cells in the first row, only assign the second row.
+        let offset = offset + 1;
+        self.is_add_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(step_state.step_state.opcode as u64) - F::from(Opcode::Add as u64),
+        )?;
+        self.is_u8_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U8 as u64),
+        )?;
+        self.is_u16_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U16 as u64),
+        )?;
+        self.is_u32_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U32 as u64),
+        )?;
+        self.is_u64_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U64 as u64),
+        )?;
+        self.is_u128_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U128 as u64),
+        )?;
+        self.is_u256_opt.clone().unwrap().assign(
+            region,
+            offset,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U256 as u64),
+        )?;
+        self.add_opt.clone().unwrap().assign(
+            region, offset, lhs_lo, lhs_hi, rhs_lo, rhs_hi, out_lo, out_hi, is_add,
+        )?;
+
+        match num_bytes {
+            NUM_OF_BYTES_U8 => {
+                self.range_check_lo_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_lo),
+                    NUM_OF_BYTES_U8,
+                )?;
+                debug_assert!(out_hi == 0u128);
+                let overflow = if out_lo > u8::MAX as u128 {
+                    F::one()
+                } else {
+                    F::zero()
+                };
+                self.overflow_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    Value::known(overflow),
+                )?;
+            }
+            NUM_OF_BYTES_U16 => {
+                self.range_check_lo_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_lo),
+                    NUM_OF_BYTES_U16,
+                )?;
+                debug_assert!(out_hi == 0u128);
+                let overflow = if out_lo > u16::MAX as u128 {
+                    F::one()
+                } else {
+                    F::zero()
+                };
+                self.overflow_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    Value::known(overflow),
+                )?;
+            }
+            NUM_OF_BYTES_U32 => {
+                self.range_check_lo_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_lo),
+                    NUM_OF_BYTES_U32,
+                )?;
+                debug_assert!(out_hi == 0u128);
+                let overflow = if out_lo > u32::MAX as u128 {
+                    F::one()
+                } else {
+                    F::zero()
+                };
+                self.overflow_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    Value::known(overflow),
+                )?;
+            }
+            NUM_OF_BYTES_U64 => {
+                self.range_check_lo_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_lo),
+                    NUM_OF_BYTES_U64,
+                )?;
+                debug_assert!(out_hi == 0u128);
+                let overflow = if out_lo > u64::MAX as u128 {
+                    F::one()
+                } else {
+                    F::zero()
+                };
+                self.overflow_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    Value::known(overflow),
+                )?;
+            }
+            NUM_OF_BYTES_U128 => {
+                self.range_check_lo_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_lo),
+                    NUM_OF_BYTES_U128,
+                )?;
+                debug_assert!(out_hi == 0u128 || out_hi == 1u128);
+                let overflow = if out_hi == 1u128 { F::one() } else { F::zero() };
+                self.overflow_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    Value::known(overflow),
+                )?;
+            }
+            NUM_OF_BYTES_U256 => {
+                self.range_check_lo_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_lo),
+                    NUM_OF_BYTES_U128,
+                )?;
+                self.range_check_hi_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    F::from_u128(out_hi),
+                    NUM_OF_BYTES_U128,
+                )?;
+                let lhs_lo = U256::from(lhs_lo);
+                let lhs_hi = U256::from(lhs_hi);
+                let rhs_lo = U256::from(rhs_lo);
+                let rhs_hi = U256::from(rhs_hi);
+                let out_lo = U256::from(out_lo);
+                let out_hi = U256::from(out_hi);
+                let carry_lo = if is_add {
+                    (lhs_lo + rhs_lo - out_lo).checked_shr(128).unwrap()
+                } else {
+                    (out_lo + rhs_lo - lhs_lo).checked_shr(128).unwrap()
+                };
+                debug_assert!(carry_lo == U256::zero() || carry_lo == U256::one());
+                let carry_hi = if is_add {
+                    (lhs_hi + rhs_hi + carry_lo - out_hi)
+                        .checked_shr(128)
+                        .unwrap()
+                } else {
+                    (out_hi + rhs_hi + carry_lo - lhs_hi)
+                        .checked_shr(128)
+                        .unwrap()
+                };
+                debug_assert!(carry_hi == U256::zero() || carry_hi == U256::one());
+                let overflow = if carry_hi == U256::one() {
+                    F::one()
+                } else {
+                    F::zero()
+                };
+                self.overflow_opt.clone().unwrap().assign(
+                    region,
+                    offset,
+                    Value::known(overflow),
+                )?;
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(step_state.memory_ops.len())
+    }
+}

--- a/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
@@ -18,14 +18,17 @@ use crate::chips::utilities::Expr;
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
 use aptos_move_witnesses::step_state::StageState;
-use halo2_proofs::{circuit::Value, plonk::{Error, Expression},};
-use move_core_types::{u256::U256};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
+use move_core_types::u256::U256;
 use move_vm_runtime::witnessing::traced_value::Integer;
 use types::Field;
 
 #[derive(Clone, Debug)]
 pub struct AddSub<F> {
-    add_sub_gadget: Option<AddSubGadget<F>>,
+    add_sub_gadget: AddSubGadget<F>,
     is_add: IsZeroGadget<F>,
 }
 impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
@@ -101,7 +104,8 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
             let lhs = step_curr.stack_pop_value.as_integer();
             let rhs = step_prev.stack_pop_value.as_integer();
             let out = step_curr.stack_push_value.as_integer();
-            let add_sub = AddSubGadget::construct(cb, is_add.expr(), step_curr.aux0.expr(), lhs, rhs, out);
+            let add_sub =
+                AddSubGadget::construct(cb, is_add.expr(), step_curr.aux0.expr(), lhs, rhs, out);
             let overflow = add_sub.overflow();
             add_sub_gadget = Some(add_sub);
 
@@ -120,7 +124,7 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
         });
 
         AddSub {
-            add_sub_gadget,
+            add_sub_gadget: add_sub_gadget.unwrap(),
             is_add,
         }
     }
@@ -161,7 +165,18 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
             )?;
         }
 
-        self.add_sub_gadget.as_ref().unwrap().assign(region, offset + 1, is_add, num_bytes, lhs_lo, lhs_hi, rhs_lo, rhs_hi, out_lo, out_hi)?;
+        self.add_sub_gadget.assign(
+            region,
+            offset + 1,
+            is_add,
+            num_bytes,
+            lhs_lo,
+            lhs_hi,
+            rhs_lo,
+            rhs_hi,
+            out_lo,
+            out_hi,
+        )?;
         //TODO: we need assign row 'offset' too, since add_sub_gadget is also allocated in row 'offset'
 
         Ok(step_state.memory_ops.len())
@@ -194,30 +209,16 @@ impl<F: Field> AddSubGadget<F> {
         let range_check_lo = IntegerRangeCheck::construct(cb);
         let range_check_hi = IntegerRangeCheck::construct(cb);
         let add = AddGadget::construct(cb);
-        let is_u8 = IsZeroGadget::construct(
-            cb,
-            n_bytes.clone() - (NUM_OF_BYTES_U8 as u64).expr(),
-        );
-        let is_u16 = IsZeroGadget::construct(
-            cb,
-            n_bytes.clone() - (NUM_OF_BYTES_U16 as u64).expr(),
-        );
-        let is_u32 = IsZeroGadget::construct(
-            cb,
-            n_bytes.clone() - (NUM_OF_BYTES_U32 as u64).expr(),
-        );
-        let is_u64 = IsZeroGadget::construct(
-            cb,
-            n_bytes.clone() - (NUM_OF_BYTES_U64 as u64).expr(),
-        );
-        let is_u128 = IsZeroGadget::construct(
-            cb,
-            n_bytes.clone() - (NUM_OF_BYTES_U128 as u64).expr(),
-        );
-        let is_u256 = IsZeroGadget::construct(
-            cb,
-            n_bytes - (NUM_OF_BYTES_U256 as u64).expr(),
-        );
+        let is_u8 = IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U8 as u64).expr());
+        let is_u16 =
+            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U16 as u64).expr());
+        let is_u32 =
+            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U32 as u64).expr());
+        let is_u64 =
+            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U64 as u64).expr());
+        let is_u128 =
+            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U128 as u64).expr());
+        let is_u256 = IsZeroGadget::construct(cb, n_bytes - (NUM_OF_BYTES_U256 as u64).expr());
         let overflow = cb.query_bool();
 
         // configure add gadget
@@ -379,11 +380,8 @@ impl<F: Field> AddSubGadget<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow.assign(
-                    region,
-                    offset,
-                    Value::known(overflow),
-                )?;
+                self.overflow
+                    .assign(region, offset, Value::known(overflow))?;
             }
             NUM_OF_BYTES_U16 => {
                 self.range_check_lo.assign(
@@ -398,11 +396,8 @@ impl<F: Field> AddSubGadget<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow.assign(
-                    region,
-                    offset,
-                    Value::known(overflow),
-                )?;
+                self.overflow
+                    .assign(region, offset, Value::known(overflow))?;
             }
             NUM_OF_BYTES_U32 => {
                 self.range_check_lo.assign(
@@ -417,11 +412,8 @@ impl<F: Field> AddSubGadget<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow.assign(
-                    region,
-                    offset,
-                    Value::known(overflow),
-                )?;
+                self.overflow
+                    .assign(region, offset, Value::known(overflow))?;
             }
             NUM_OF_BYTES_U64 => {
                 self.range_check_lo.assign(
@@ -436,11 +428,8 @@ impl<F: Field> AddSubGadget<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow.assign(
-                    region,
-                    offset,
-                    Value::known(overflow),
-                )?;
+                self.overflow
+                    .assign(region, offset, Value::known(overflow))?;
             }
             NUM_OF_BYTES_U128 => {
                 self.range_check_lo.assign(
@@ -451,11 +440,8 @@ impl<F: Field> AddSubGadget<F> {
                 )?;
                 debug_assert!(out_hi == 0u128 || out_hi == 1u128);
                 let overflow = if out_hi == 1u128 { F::one() } else { F::zero() };
-                self.overflow.assign(
-                    region,
-                    offset,
-                    Value::known(overflow),
-                )?;
+                self.overflow
+                    .assign(region, offset, Value::known(overflow))?;
             }
             NUM_OF_BYTES_U256 => {
                 self.range_check_lo.assign(
@@ -497,11 +483,8 @@ impl<F: Field> AddSubGadget<F> {
                 } else {
                     F::zero()
                 };
-                self.overflow.assign(
-                    region,
-                    offset,
-                    Value::known(overflow),
-                )?;
+                self.overflow
+                    .assign(region, offset, Value::known(overflow))?;
             }
             _ => unreachable!(),
         }

--- a/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
@@ -9,8 +9,8 @@ use crate::chips::execution_chip_v2::step_v2::{
     StepState, FRAME_INDEX, FUNCTION_INDEX, MODULE_INDEX, PC, SP,
 };
 use crate::chips::execution_chip_v2::value::{
-    NUM_OF_BYTES_U128, NUM_OF_BYTES_U16, NUM_OF_BYTES_U256, NUM_OF_BYTES_U32, NUM_OF_BYTES_U64,
-    NUM_OF_BYTES_U8,
+    INTEGER_NUM_OF_BYTES_SET, NUM_OF_BYTES_U128, NUM_OF_BYTES_U16, NUM_OF_BYTES_U256,
+    NUM_OF_BYTES_U32, NUM_OF_BYTES_U64, NUM_OF_BYTES_U8,
 };
 use crate::chips::execution_chip_v2::InstructionGadgetV2;
 use crate::chips::utilities::Expr;
@@ -39,7 +39,7 @@ pub struct AddSub<F> {
 }
 impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
     const NAME: &'static str = "AddSub";
-    const OPCODES: &'static [Opcode] = &[Opcode::Add, Opcode::Sub];
+    const OPCODE: Opcode = Opcode::Add; // TODO: remove this const?
     const EXECUTION_STATE: ExecutionState = ExecutionState::AddSub;
 
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
@@ -59,9 +59,12 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
 
         cb.first_row(|cb| {
             cb.require_in_set(
-                "opcode in OPCODES",
-                step_curr.opcode.expr(),
-                Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
+                "aux(0) in set INTEGER_NUM_OF_BYTES",
+                step_curr.aux0.expr(),
+                INTEGER_NUM_OF_BYTES_SET
+                    .iter()
+                    .map(|n| (*n as u64).expr())
+                    .collect(),
             );
             cb.require_equal(
                 "step_counter(0) == 2",

--- a/vm-circuit/src/chips/execution_chip_v2/executions/cast.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/cast.rs
@@ -16,7 +16,7 @@ use types::Field;
 
 #[derive(Clone, Debug)]
 pub struct Cast<F, const N_BYTES: usize> {
-    in_range_lo: Option<IntegerRangeCheck<F, N_BYTES>>,
+    in_range_lo: Option<IntegerRangeCheck<F>>,
     is_zero_hi: Option<IsZeroGadget<F>>,
 }
 impl<F: Field, const N_BYTES: usize> InstructionGadgetV2<F> for Cast<F, N_BYTES> {
@@ -98,10 +98,7 @@ impl<F: Field, const N_BYTES: usize> InstructionGadgetV2<F> for Cast<F, N_BYTES>
         cb.require_no_local_op();
 
         let in_range_lo = if N_BYTES != NUM_OF_BYTES_U256 {
-            Some(IntegerRangeCheck::<_, N_BYTES>::construct(
-                cb,
-                step_curr.stack_pop_value.as_integer().lo(),
-            ))
+            Some(IntegerRangeCheck::construct(cb))
         } else {
             None
         };
@@ -115,7 +112,11 @@ impl<F: Field, const N_BYTES: usize> InstructionGadgetV2<F> for Cast<F, N_BYTES>
         };
         let castable = if N_BYTES != NUM_OF_BYTES_U256 {
             and::expr([
-                in_range_lo.clone().unwrap().expr(),
+                in_range_lo.clone().unwrap().expr(
+                    cb,
+                    step_curr.stack_pop_value.as_integer().lo(),
+                    N_BYTES,
+                ),
                 is_zero_hi.clone().unwrap().expr(),
             ])
         } else {

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets.rs
@@ -1,3 +1,4 @@
+pub(crate) mod add;
 pub(crate) mod is_zero;
 pub(crate) mod lt;
 pub(crate) mod range_check;

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/add.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/add.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
 };
-use move_core_types::{u256::U256};
+use move_core_types::u256::U256;
 use types::Field;
 
 #[derive(Clone, Debug)]

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/add.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/add.rs
@@ -1,0 +1,133 @@
+use crate::chips::execution_chip::utils::base_constraint_builder::ConstrainBuilderCommon;
+use crate::chips::execution_chip::utils::constraint_builder_v2::ConstraintBuilderV2;
+use crate::chips::execution_chip_v2::value::Integer;
+use crate::chips::utilities::Expr;
+use crate::utils::cached_region::CachedRegion;
+use crate::utils::cell_manager::Cell;
+use gadgets::util::not;
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
+use move_core_types::{u256, u256::U256};
+use types::Field;
+
+#[derive(Clone, Debug)]
+pub struct AddGadget<F> {
+    carry_lo: Cell<F>,
+    carry_hi: Cell<F>,
+}
+
+impl<F: Field> AddGadget<F> {
+    pub(crate) fn construct(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        let carry_lo = cb.query_cell();
+        let carry_hi = cb.query_cell();
+
+        // we can use query_bool, but the semantics would be a bit fuzzy.
+        cb.require_in_set(
+            "carry_lo == 0 | 1",
+            carry_lo.expr(),
+            (0u64..2).map(|v| v.expr()).collect(),
+        );
+        cb.require_in_set(
+            "carry_hi == 0 | 1",
+            carry_hi.expr(),
+            (0u64..2).map(|v| v.expr()).collect(),
+        );
+
+        Self { carry_lo, carry_hi }
+    }
+
+    pub(crate) fn expr(
+        &self,
+        cb: &mut ConstraintBuilderV2<F>,
+        lhs: Integer<F>,
+        rhs: Integer<F>,
+        out: Integer<F>,
+        is_add: Expression<F>, // boolean
+    ) {
+        cb.condition(is_add.clone(), |cb| {
+            cb.require_equal(
+                "lhs_lo + rhs_lo == out_lo + carry_lo * 2^128",
+                lhs.lo() + rhs.lo(),
+                out.lo().clone() + self.carry_lo.expr() * 2u64.pow(128).expr(),
+            );
+            cb.require_equal(
+                "lhs_hi + rhs_hi + carry_lo == out_hi + carry_hi * 2^128",
+                lhs.hi() + rhs.hi() + self.carry_lo.expr(),
+                out.hi() + self.carry_hi.expr() * 2u64.pow(128).expr(),
+            );
+        });
+
+        cb.condition(not::expr(is_add), |cb| {
+            cb.require_equal(
+                "out_lo + rhs_lo == lhs_lo + carry_lo * 2^128",
+                out.lo().clone() + rhs.lo(),
+                lhs.lo() + self.carry_lo.expr() * 2u64.pow(128).expr(),
+            );
+            cb.require_equal(
+                "out_hi + rhs_hi + carry_lo == lhs_hi + carry_hi * 2^128",
+                out.hi() + rhs.hi() + self.carry_lo.expr(),
+                lhs.hi() + self.carry_hi.expr() * 2u64.pow(128).expr(),
+            );
+        });
+    }
+
+    pub(crate) fn overflow(&self) -> Expression<F> {
+        self.carry_hi.expr() // overflow if carry_hi == 1
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        lhs_lo: u128,
+        lhs_hi: u128,
+        rhs_lo: u128,
+        rhs_hi: u128,
+        out_lo: u128,
+        out_hi: u128,
+        is_add: bool,
+    ) -> Result<(), Error> {
+        let rhs_lo = U256::from(rhs_lo);
+        let rhs_hi = U256::from(rhs_hi);
+        let lhs_lo = if is_add {
+            U256::from(lhs_lo)
+        } else {
+            U256::from(out_lo)
+        };
+        let lhs_hi = if is_add {
+            U256::from(lhs_hi)
+        } else {
+            U256::from(out_hi)
+        };
+        let out_lo = if is_add {
+            U256::from(out_lo)
+        } else {
+            U256::from(lhs_lo)
+        };
+        let out_hi = if is_add {
+            U256::from(out_hi)
+        } else {
+            U256::from(lhs_hi)
+        };
+
+        let sum_lo = U256::wrapping_add(lhs_lo, rhs_lo);
+        let sum_hi = U256::wrapping_add(lhs_hi, rhs_hi);
+        let carry_lo = U256::wrapping_sub(sum_lo, out_lo) >> 128;
+        debug_assert!(carry_lo == U256::zero() || carry_lo == U256::one());
+        let carry_hi = U256::wrapping_sub(U256::wrapping_add(sum_hi, carry_lo), out_hi) >> 128;
+        debug_assert!(carry_hi == U256::zero() || carry_hi == U256::one());
+        self.carry_lo.assign(
+            region,
+            offset,
+            Value::known(F::from_u128(carry_lo.unchecked_as_u128())),
+        )?;
+        self.carry_hi.assign(
+            region,
+            offset,
+            Value::known(F::from_u128(carry_hi.unchecked_as_u128())),
+        )?;
+        Ok(())
+    }
+}

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/add.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/add.rs
@@ -4,12 +4,11 @@ use crate::chips::execution_chip_v2::value::Integer;
 use crate::chips::utilities::Expr;
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
-use gadgets::util::not;
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
 };
-use move_core_types::{u256, u256::U256};
+use move_core_types::{u256::U256};
 use types::Field;
 
 #[derive(Clone, Debug)]
@@ -44,33 +43,17 @@ impl<F: Field> AddGadget<F> {
         lhs: Integer<F>,
         rhs: Integer<F>,
         out: Integer<F>,
-        is_add: Expression<F>, // boolean
     ) {
-        cb.condition(is_add.clone(), |cb| {
-            cb.require_equal(
-                "lhs_lo + rhs_lo == out_lo + carry_lo * 2^128",
-                lhs.lo() + rhs.lo(),
-                out.lo().clone() + self.carry_lo.expr() * 2u64.pow(128).expr(),
-            );
-            cb.require_equal(
-                "lhs_hi + rhs_hi + carry_lo == out_hi + carry_hi * 2^128",
-                lhs.hi() + rhs.hi() + self.carry_lo.expr(),
-                out.hi() + self.carry_hi.expr() * 2u64.pow(128).expr(),
-            );
-        });
-
-        cb.condition(not::expr(is_add), |cb| {
-            cb.require_equal(
-                "out_lo + rhs_lo == lhs_lo + carry_lo * 2^128",
-                out.lo().clone() + rhs.lo(),
-                lhs.lo() + self.carry_lo.expr() * 2u64.pow(128).expr(),
-            );
-            cb.require_equal(
-                "out_hi + rhs_hi + carry_lo == lhs_hi + carry_hi * 2^128",
-                out.hi() + rhs.hi() + self.carry_lo.expr(),
-                lhs.hi() + self.carry_hi.expr() * 2u64.pow(128).expr(),
-            );
-        });
+        cb.require_equal(
+            "lhs_lo + rhs_lo == out_lo + carry_lo * 2^128",
+            lhs.lo() + rhs.lo(),
+            out.lo().clone() + self.carry_lo.expr() * 2u64.pow(128).expr(),
+        );
+        cb.require_equal(
+            "lhs_hi + rhs_hi + carry_lo == out_hi + carry_hi * 2^128",
+            lhs.hi() + rhs.hi() + self.carry_lo.expr(),
+            out.hi() + self.carry_hi.expr() * 2u64.pow(128).expr(),
+        );
     }
 
     pub(crate) fn overflow(&self) -> Expression<F> {
@@ -87,31 +70,13 @@ impl<F: Field> AddGadget<F> {
         rhs_hi: u128,
         out_lo: u128,
         out_hi: u128,
-        is_add: bool,
     ) -> Result<(), Error> {
         let rhs_lo = U256::from(rhs_lo);
         let rhs_hi = U256::from(rhs_hi);
-        let lhs_lo = if is_add {
-            U256::from(lhs_lo)
-        } else {
-            U256::from(out_lo)
-        };
-        let lhs_hi = if is_add {
-            U256::from(lhs_hi)
-        } else {
-            U256::from(out_hi)
-        };
-        let out_lo = if is_add {
-            U256::from(out_lo)
-        } else {
-            U256::from(lhs_lo)
-        };
-        let out_hi = if is_add {
-            U256::from(out_hi)
-        } else {
-            U256::from(lhs_hi)
-        };
-
+        let lhs_lo = U256::from(lhs_lo);
+        let lhs_hi = U256::from(lhs_hi);
+        let out_lo = U256::from(out_lo);
+        let out_hi = U256::from(out_hi);
         let sum_lo = U256::wrapping_add(lhs_lo, rhs_lo);
         let sum_hi = U256::wrapping_add(lhs_hi, rhs_hi);
         let carry_lo = U256::wrapping_sub(sum_lo, out_lo) >> 128;

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/is_zero.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/is_zero.rs
@@ -56,3 +56,49 @@ impl<F: Field> IsZeroGadget<F> {
         })
     }
 }
+
+/// Returns `1` when `value == 0`, and returns `0` otherwise.
+#[derive(Clone, Debug)]
+pub struct IsZero<F> {
+    inverse: Cell<F>,
+}
+
+impl<F: Field> IsZero<F> {
+    pub(crate) fn construct(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        Self {
+            inverse: cb.query_cell(),
+        }
+    }
+
+    pub(crate) fn expr(
+        &self,
+        cb: &mut ConstraintBuilderV2<F>,
+        value: Expression<F>,
+    ) -> Expression<F> {
+        let is_zero = 1u64.expr() - (value.clone() * self.inverse.expr());
+        cb.require_zero(
+            "value * (1 - value * value_inv)",
+            value.clone() * is_zero.clone(),
+        );
+        cb.require_zero(
+            "value_inv * (1 - value * value_inv)",
+            self.inverse.expr() * is_zero.clone(),
+        );
+        is_zero
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        value: F,
+    ) -> Result<F, Error> {
+        let inverse = value.invert().unwrap_or(F::ZERO);
+        self.inverse.assign(region, offset, Value::known(inverse))?;
+        Ok(if value.is_zero().into() {
+            F::ONE
+        } else {
+            F::ZERO
+        })
+    }
+}

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/range_check.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/range_check.rs
@@ -1,6 +1,6 @@
 use crate::chips::execution_chip::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip::utils::constraint_builder_v2::ConstraintBuilderV2;
-use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
+use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZero;
 use crate::chips::execution_chip_v2::utils::{from_bytes, from_limbs};
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
@@ -49,27 +49,30 @@ impl<F: Field, const N_BYTES: usize> RangeCheckGadget<F, N_BYTES> {
 
 /// Check if the input value is in the range of U8,U16,U32,U64 or U128
 #[derive(Clone, Debug)]
-pub struct IntegerRangeCheck<F, const N_BYTES: usize> {
+pub struct IntegerRangeCheck<F> {
     bytes: [Cell<F>; NUM_OF_BYTES_U128],
-    is_zero: IsZeroGadget<F>,
+    is_zero: IsZero<F>,
 }
 
-impl<F: Field, const N_BYTES: usize> IntegerRangeCheck<F, N_BYTES> {
-    pub(crate) fn construct(cb: &mut ConstraintBuilderV2<F>, value: Expression<F>) -> Self {
+impl<F: Field> IntegerRangeCheck<F> {
+    pub(crate) fn construct(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let bytes = cb.query_bytes();
-
+        let is_zero = IsZero::construct(cb);
+        Self { bytes, is_zero }
+    }
+    pub(crate) fn expr(
+        &self,
+        cb: &mut ConstraintBuilderV2<F>,
+        value: Expression<F>,
+        n_bytes: usize,
+    ) -> Expression<F> {
         cb.require_equal(
             "the input value is well assigned",
             value.clone(),
-            from_bytes::expr(&bytes),
+            from_bytes::expr(&self.bytes),
         );
-
-        let expected_value = from_bytes::expr(&bytes.iter().take(N_BYTES).collect::<Vec<_>>());
-        let is_zero = IsZeroGadget::construct(cb, value - expected_value);
-        Self { bytes, is_zero }
-    }
-    pub(crate) fn expr(&self) -> Expression<F> {
-        self.is_zero.expr()
+        let expected = from_bytes::expr(&self.bytes[..n_bytes]);
+        self.is_zero.expr(cb, value - expected)
     }
 
     pub(crate) fn assign(
@@ -77,11 +80,14 @@ impl<F: Field, const N_BYTES: usize> IntegerRangeCheck<F, N_BYTES> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         value: F,
+        n_bytes: usize,
     ) -> Result<(), Error> {
         let bytes = value.to_repr();
         for (idx, part) in self.bytes.iter().enumerate() {
             part.assign(region, offset, Value::known(F::from(bytes[idx] as u64)))?;
         }
+        let expected: F = from_bytes::value(&bytes[..n_bytes]);
+        let _ = self.is_zero.assign(region, offset, value - expected);
         Ok(())
     }
 }

--- a/vm-circuit/src/chips/execution_chip_v2/value.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/value.rs
@@ -13,6 +13,15 @@ pub const NUM_OF_BYTES_U64: usize = 8;
 pub const NUM_OF_BYTES_U128: usize = 16;
 pub const NUM_OF_BYTES_U256: usize = 32;
 
+pub const INTEGER_NUM_OF_BYTES_SET: [usize; 6] = [
+    NUM_OF_BYTES_U8,
+    NUM_OF_BYTES_U16,
+    NUM_OF_BYTES_U32,
+    NUM_OF_BYTES_U64,
+    NUM_OF_BYTES_U128,
+    NUM_OF_BYTES_U256,
+];
+
 #[derive(Clone, Debug)]
 pub(crate) struct Value<F, const N: usize> {
     cells: [Cell<F>; N],

--- a/vm-circuit/src/chips/execution_chip_v2/value.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/value.rs
@@ -103,6 +103,18 @@ impl<F: Field> Integer<F> {
     pub(crate) fn expr(&self) -> (Expression<F>, Expression<F>) {
         (self.lo.clone(), self.hi.clone())
     }
+    pub(crate) fn select(
+        selector: Expression<F>,
+        when_true: Integer<F>,
+        when_false: Integer<F>,
+    ) -> Integer<F> {
+        let (true_lo, true_hi) = when_true.expr();
+        let (false_lo, false_hi) = when_false.expr();
+        Integer::new(
+            selector.clone() * true_lo + (1u64.expr() - selector.clone()) * false_lo,
+            selector.clone() * true_hi + (1u64.expr() - selector.clone()) * false_hi,
+        )
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/vm-circuit/src/lib.rs
+++ b/vm-circuit/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright (c) zkMove Authors
 #![feature(lint_reasons)]
-#![feature(adt_const_params)]
 
 extern crate aptos_move_witnesses;
 extern crate movelang;


### PR DESCRIPTION
should merge after https://github.com/zkmove/zkmove-vm/pull/240

Core constraints:

```
lhs_lo + rhs_lo == out_lo + carry_lo * 2^128                    (1)
lhs_hi + rhs_hi + carry_lo == out_hi + carry_hi * 2^128         (2)

carry_lo == 0 | 1
carry_hi == 0 | 1

///for SUB, we only need exchange output with lhs
```

Overflow check, for performance purpose, we only do range check on the output.

```
///U256
out_lo < 2^128;
out_hi < 2^128;
OVERFLOW if carry_hi == 1;

///U128
out_lo < 2^128;
OVERFLOW if out_hi == 1;

///U64,U32,U16,U8
out_hi == 0;
// Actually we only need the constraint "out.hi == 0". Coupled with (2), 
// it is guaranteed that both arry_lo and carry_hi are equal to 0.
OVERFLOW if !in_range(out_lo);
```
Finally, we merged Add and Sub into one execution state. We also merged Add/Sub for different Integer types into one state.