### PR TITLE
fill and improve constraints on version and clock

### DIFF
--- a/specs/opcodes.rs
+++ b/specs/opcodes.rs
@@ -415,6 +415,7 @@ mod eq {
 
         if super::common::on_last_row() {
             if is_stage_1 {
+                super::common::fake_empty_stack_push(0);
                 module_index(1) == module_index(0);
                 function_index(1) == function_index(0);
                 frame_index(1) == frame_index(0);

--- a/vm-circuit/src/chips/execution_chip/utils/constraint_builder_v2.rs
+++ b/vm-circuit/src/chips/execution_chip/utils/constraint_builder_v2.rs
@@ -318,17 +318,15 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
         // TODO: add other state variable
     }
 
-    /// FIXME: implement this.
     pub(crate) fn require_no_stack_push(&mut self) {
         self.require_zero("none stack push", self.curr.state.stack_push_version.expr());
     }
-    /// FIXME: implement this.
     pub(crate) fn require_no_stack_pop(&mut self) {
         self.require_zero("none stack pop", self.curr.state.stack_pop_version.expr());
     }
-    /// FIXME: implement this.
     pub(crate) fn require_no_local_op(&mut self) {
         self.require_zero("none local op", self.curr.state.local_read_version.expr());
+        self.require_zero("none local op", self.curr.state.local_write_version.expr());
     }
     /// FIXME: implement this.
     pub(crate) fn require_read_invalid_value(&mut self) {

--- a/vm-circuit/src/chips/execution_chip_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2.rs
@@ -125,7 +125,12 @@ impl<F: Field> ExecChipConfig<F> {
             let mut cb = BaseConstraintBuilder::default();
 
             cb.condition(s_step_first.clone(), |cb| {
-                cb.require_zero("first step, clk = 0", step_curr.state.clk.expr());
+                // 0 is special and represents empty operations, so clk starts at 1
+                cb.require_equal(
+                    "first step, clk = 1",
+                    step_curr.state.clk.expr(),
+                    1u64.expr(),
+                );
                 cb.require_zero("first step, pc = 0", step_curr.state.pc.expr());
                 cb.require_zero(
                     "first step, frame_index = 0",
@@ -438,50 +443,55 @@ impl<F: Field> ExecChipConfig<F> {
         let step_curr = &config.step;
         meta.shuffle("stack consistency check", |meta| {
             let s_usable = meta.query_selector(s_usable);
+            let pop_version = step_curr.state.stack_pop_version.expr();
+            // NOTICE: version is also used as a selector to exclude empty operations
             let pop_set = [
                 step_curr.state.stack_pop_index.expr(),
                 step_curr.state.stack_pop_sub_index.expr(),
                 step_curr.state.stack_pop_value_header.expr(),
-                step_curr.state.stack_pop_version.expr(),
+                pop_version.clone(),
             ]
             .into_iter()
             .chain(step_curr.state.stack_pop_value.exprs())
-            .map(|e| s_usable.clone() * e);
+            .map(|e| s_usable.clone() * pop_version.clone() * e);
+            let push_version = step_curr.state.stack_push_version.expr();
             let push_set = [
                 step_curr.state.stack_push_index.expr(),
                 step_curr.state.stack_push_sub_index.expr(),
                 step_curr.state.stack_push_value_header.expr(),
-                step_curr.state.stack_push_version.expr(),
+                push_version.clone(),
             ]
             .into_iter()
             .chain(step_curr.state.stack_push_value.exprs())
-            .map(|e| s_usable.clone() * e);
+            .map(|e| s_usable.clone() * push_version.clone() * e);
             pop_set.zip(push_set).collect()
         });
         meta.shuffle("local consistency check", |meta| {
             let s_usable = meta.query_selector(s_usable);
+            let read_version = step_curr.state.local_read_version.expr();
             let read_set = [
                 step_curr.state.local_frame_index.expr(),
                 step_curr.state.local_index.expr(),
                 step_curr.state.local_sub_index.expr(),
                 step_curr.state.local_read_value_header.expr(),
                 step_curr.state.local_read_value_invalid.expr(),
-                step_curr.state.local_read_version.expr(),
+                read_version.clone(),
             ]
             .into_iter()
             .chain(step_curr.state.local_read_value.exprs())
-            .map(|e| s_usable.clone() * e);
+            .map(|e| s_usable.clone() * read_version.clone() * e);
+            let write_version = step_curr.state.local_write_version.expr();
             let write_set = [
                 step_curr.state.local_frame_index.expr(),
                 step_curr.state.local_index.expr(),
                 step_curr.state.local_sub_index.expr(),
                 step_curr.state.local_write_value_header.expr(),
                 step_curr.state.local_write_value_invalid.expr(),
-                step_curr.state.local_write_version.expr(),
+                write_version.clone(),
             ]
             .into_iter()
             .chain(step_curr.state.local_write_value.exprs())
-            .map(|e| s_usable.clone() * e);
+            .map(|e| s_usable.clone() * write_version.clone() * e);
             read_set.zip(write_set).collect()
         });
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
@@ -101,11 +101,6 @@ impl<F: Field> InstructionGadgetV2<F> for AddSub<F> {
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             let lhs = step_curr.stack_pop_value.as_integer();
             let rhs = step_prev.stack_pop_value.as_integer();

--- a/vm-circuit/src/chips/execution_chip_v2/executions/and_or.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/and_or.rs
@@ -98,11 +98,6 @@ impl<F: Field> InstructionGadgetV2<F> for AndOr<F> {
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             cb.require_state_transition(vec![
                 (FRAME_INDEX, Transition::Same),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/base.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/base.rs
@@ -10,6 +10,7 @@ use types::Field;
 
 pub(crate) struct BaseConstraintGadget<F> {
     stack_pop_version_range_check: RangeCheckGadget<F, 4>,
+    local_read_version_range_check: RangeCheckGadget<F, 4>,
 }
 
 impl<F: Field> BaseConstraintGadget<F> {
@@ -43,10 +44,20 @@ impl<F: Field> BaseConstraintGadget<F> {
             );
         });
 
-        // clk(0) - stack_pop_version(0) > 0
-        let diff = cb.curr.state.clk.expr() - cb.curr.state.stack_pop_version.expr();
+        // stack_pop_version(0) < clk(0)
+        let stack_pop_version_range_check = RangeCheckGadget::construct(
+            cb,
+            cb.curr.state.clk.expr() - cb.curr.state.stack_pop_version.expr(),
+        );
+        // local_read_version(0) < clk(0)
+        let local_read_version_range_check = RangeCheckGadget::construct(
+            cb,
+            cb.curr.state.clk.expr() - cb.curr.state.local_read_version.expr(),
+        );
+
         Self {
-            stack_pop_version_range_check: RangeCheckGadget::construct(cb, diff),
+            stack_pop_version_range_check,
+            local_read_version_range_check,
         }
     }
 }

--- a/vm-circuit/src/chips/execution_chip_v2/executions/base.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/base.rs
@@ -54,6 +54,18 @@ impl<F: Field> BaseConstraintGadget<F> {
             cb,
             cb.curr.state.clk.expr() - cb.curr.state.local_read_version.expr(),
         );
+        // stack_push_version(0) == clk(0)
+        let pop_version = cb.curr.state.stack_push_version.expr();
+        cb.require_zero(
+            "stack_push_version(0) == clk(0)",
+            pop_version.clone() * (pop_version - cb.curr.state.clk.expr()),
+        );
+        // local_write_version(0) == clk(0)
+        let write_version = cb.curr.state.local_write_version.expr();
+        cb.require_zero(
+            "local_write_version(0) == clk(0)",
+            write_version.clone() * (write_version - cb.curr.state.clk.expr()),
+        );
 
         Self {
             stack_pop_version_range_check,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
@@ -146,11 +146,6 @@ impl<F: Field> InstructionGadgetV2<F> for Bitwise<F> {
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             cb.require_state_transition(vec![
                 (FRAME_INDEX, Transition::Same),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/borrow_field.rs
@@ -77,11 +77,6 @@ impl<F: Field> InstructionGadgetV2<F> for BorrowField<F> {
             format!("{}, stack_push_sub_index(0) == 0", Self::NAME),
             step_curr.stack_push_sub_index.expr(),
         );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
         cb.require_no_local_op();
         cb.require_state_transition(vec![
             (FRAME_INDEX, Transition::Same),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/borrow_loc.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/borrow_loc.rs
@@ -56,11 +56,6 @@ impl<F: Field> InstructionGadgetV2<F> for BorrowLoc<F> {
             format!("{}, stack_push_sub_index(0) == 0", Self::NAME),
             cb.curr.state.stack_push_sub_index.expr(),
         );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            cb.curr.state.stack_push_version.expr(),
-            cb.curr.state.clk.expr(),
-        );
         cb.require_no_stack_pop();
         cb.require_no_local_op();
         cb.require_state_transition(vec![

--- a/vm-circuit/src/chips/execution_chip_v2/executions/call.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/call.rs
@@ -222,11 +222,6 @@ impl<F: Field> InstructionGadgetV2<F> for CallStage2<F> {
             step_curr.local_write_value_header.expr(),
             step_curr.local_read_value_header.expr(),
         );
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.require_state_transition(vec![(SP, Transition::Same)]);
         cb.require_cell_transition(step_curr.local_index.clone(), Transition::Same);
@@ -354,11 +349,6 @@ impl<F: Field> InstructionGadgetV2<F> for CallStage3<F> {
         cb.require_zero(
             format!("{}, local_write_value_invalid == 0", Self::NAME),
             step_curr.local_write_value_invalid.expr(),
-        );
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
         cb.require_no_stack_push();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/call.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/call.rs
@@ -202,7 +202,6 @@ impl<F: Field> InstructionGadgetV2<F> for CallStage2<F> {
             step_curr.local_frame_index.expr(),
             step_curr.frame_index.expr() + 1u64.expr(), //write to local of next frame
         );
-        //TODO: local_read_version(0) < clk(0)
         cb.require_zero(
             format!("{}, local_write_value_invalid == 0", Self::NAME),
             step_curr.local_write_value_invalid.expr(),
@@ -339,7 +338,6 @@ impl<F: Field> InstructionGadgetV2<F> for CallStage3<F> {
             step_curr.local_read_value_invalid.expr(),
             1u64.expr(),
         );
-        //TODO: local_read_version(0) < clk(0)
         cb.require_equal(
             format!("{}, local_write_value(0) == stack_pop_value(0)", Self::NAME),
             step_curr.local_write_value.expr(),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/cast.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/cast.rs
@@ -104,11 +104,6 @@ impl<F: Field> InstructionGadgetV2<F> for Cast<F> {
             format!("{}, stack_push_value_header(0) == false", Self::NAME),
             step_curr.stack_push_value_header.expr(),
         );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.require_no_local_op();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/equality.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/equality.rs
@@ -180,6 +180,7 @@ impl<F: Field, const STAGE1: bool, const EQ: bool> InstructionGadgetV2<F>
 
         cb.last_row(|cb| {
             if STAGE1 {
+                cb.require_no_stack_push();
                 cb.require_state_transition(vec![
                     (FRAME_INDEX, Transition::Same),
                     (MODULE_INDEX, Transition::Same),
@@ -209,11 +210,6 @@ impl<F: Field, const STAGE1: bool, const EQ: bool> InstructionGadgetV2<F>
                 cb.require_zero(
                     format!("{}, stack_push_value_header(0) == false", Self::NAME),
                     cb.curr.state.stack_push_value_header.expr(),
-                );
-                cb.require_equal(
-                    format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                    cb.curr.state.stack_push_version.expr(),
-                    cb.curr.state.clk.expr(),
                 );
 
                 if EQ {

--- a/vm-circuit/src/chips/execution_chip_v2/executions/ld.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/ld.rs
@@ -70,12 +70,6 @@ impl<F: Field> InstructionGadgetV2<F> for LdSimple<F> {
             cb.curr.state.stack_push_value_header.expr(),
         );
 
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            cb.curr.state.stack_push_version.expr(),
-            cb.curr.state.clk.expr(),
-        );
-
         cb.require_no_stack_pop();
         cb.require_no_local_op();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/ld_bool.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/ld_bool.rs
@@ -77,12 +77,6 @@ impl<F: Field, const TRUE: bool> InstructionGadgetV2<F> for LdBool<F, TRUE> {
             cb.curr.state.stack_push_value_header.expr(),
         );
 
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            cb.curr.state.stack_push_version.expr(),
-            cb.curr.state.clk.expr(),
-        );
-
         cb.require_no_stack_pop();
         cb.require_no_local_op();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/ld_const.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/ld_const.rs
@@ -71,11 +71,6 @@ impl<F: Field> InstructionGadgetV2<F> for LdConst<F> {
             step_curr.stack_push_index.expr(),
             step_curr.sp.expr() + 1u64.expr(),
         );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
         cb.require_no_stack_pop();
         cb.require_no_local_op();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/le_gt.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/le_gt.rs
@@ -115,11 +115,6 @@ impl<F: Field, const LE: bool> InstructionGadgetV2<F> for Le<F, LE> {
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             cb.require_state_transition(vec![
                 (FRAME_INDEX, Transition::Same),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/lt_ge.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/lt_ge.rs
@@ -115,11 +115,6 @@ impl<F: Field, const LT: bool> InstructionGadgetV2<F> for Lt<F, LT> {
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             cb.require_state_transition(vec![
                 (FRAME_INDEX, Transition::Same),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/move_or_copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/move_or_copy_loc.rs
@@ -128,9 +128,7 @@ impl<F: Field, const MOVE: bool> InstructionGadgetV2<F> for MoveOrCopyLoc<F, MOV
             step_curr.local_write_version.expr(),
             step_curr.clk.expr(),
         );
-        // TODO: local_read_version(0) < clk(0);
 
-        // nexts
         cb.last_row(|cb| {
             cb.require_state_transition(
                 [FRAME_INDEX, MODULE_INDEX, FUNCTION_INDEX]

--- a/vm-circuit/src/chips/execution_chip_v2/executions/move_or_copy_loc.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/move_or_copy_loc.rs
@@ -63,11 +63,6 @@ impl<F: Field, const MOVE: bool> InstructionGadgetV2<F> for MoveOrCopyLoc<F, MOV
                 step_curr.stack_push_sub_index.expr(),
             );
         });
-        cb.require_equal(
-            "stack_push_version == clk(0)",
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.require_no_stack_pop();
 
@@ -123,11 +118,6 @@ impl<F: Field, const MOVE: bool> InstructionGadgetV2<F> for MoveOrCopyLoc<F, MOV
                 step_curr.local_read_value_invalid.expr(),
             );
         }
-        cb.require_equal(
-            "local_write_version == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.last_row(|cb| {
             cb.require_state_transition(

--- a/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
@@ -130,11 +130,6 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             let lhs = step_curr.stack_pop_value.as_integer();
             let rhs = step_prev.stack_pop_value.as_integer();

--- a/vm-circuit/src/chips/execution_chip_v2/executions/not.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/not.rs
@@ -73,11 +73,6 @@ impl<F: Field> InstructionGadgetV2<F> for Not<F> {
             format!("{}, stack_push_value_header(0) == false", Self::NAME),
             step_curr.stack_push_value_header.expr(),
         );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.require_no_local_op();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/pack.rs
@@ -93,11 +93,6 @@ impl<F: Field, const VEC_PACK: bool> InstructionGadgetV2<F> for Pack<F, VEC_PACK
                 format!("{}, stack_push_value_header(0) == true", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
             );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
-            );
 
             cb.require_no_stack_pop();
             cb.require_no_local_op();
@@ -175,11 +170,6 @@ impl<F: Field, const VEC_PACK: bool> InstructionGadgetV2<F> for Pack<F, VEC_PACK
                 ),
                 step_curr.stack_push_value_header.expr(),
                 step_curr.stack_pop_value_header.expr(),
-            );
-            cb.require_equal(
-                format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-                step_curr.stack_push_version.expr(),
-                step_curr.clk.expr(),
             );
 
             cb.require_no_local_op();

--- a/vm-circuit/src/chips/execution_chip_v2/executions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/pop.rs
@@ -60,7 +60,6 @@ impl<F: Field> InstructionGadgetV2<F> for Pop<F> {
                 step_curr.stack_pop_sub_index.expr(),
             );
         });
-        // TODO: stack_pop_version(0) < clk(0);
         cb.require_no_stack_push();
         cb.require_no_local_op();
 

--- a/vm-circuit/src/chips/execution_chip_v2/executions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/read_ref.rs
@@ -115,11 +115,6 @@ impl<F: Field> InstructionGadgetV2<F> for ReadRef<F> {
             step_curr.local_read_value_header.expr(),
         );
         cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
-        cb.require_equal(
             format!(
                 "{}, local_write_value(0) == local_read_value(0)",
                 Self::NAME
@@ -142,11 +137,6 @@ impl<F: Field> InstructionGadgetV2<F> for ReadRef<F> {
             ),
             step_curr.local_write_value_header.expr(),
             step_curr.local_read_value_header.expr(),
-        );
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
 
         cb.require_state_transition(vec![(SP, Transition::Same)]);

--- a/vm-circuit/src/chips/execution_chip_v2/executions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/read_ref.rs
@@ -119,8 +119,6 @@ impl<F: Field> InstructionGadgetV2<F> for ReadRef<F> {
             step_curr.stack_push_version.expr(),
             step_curr.clk.expr(),
         );
-        //TODO: local_read_version(0) < clk(0);
-
         cb.require_equal(
             format!(
                 "{}, local_write_value(0) == local_read_value(0)",

--- a/vm-circuit/src/chips/execution_chip_v2/executions/store_loc.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/store_loc.rs
@@ -69,7 +69,6 @@ impl<F: Field> InstructionGadgetV2<F> for StoreLocStage1<F> {
         cb.first_row(|cb| {
             cb.require_zero("local_sub_index(0) == 0", step_curr.local_sub_index.expr());
         });
-        // TODO: local_read_version(0) < clk(0);
         cb.require_true(
             "local_write_value_invalid(0) == true",
             step_curr.local_write_value_invalid.expr(),
@@ -160,7 +159,6 @@ impl<F: Field> InstructionGadgetV2<F> for StoreLocStage2<F> {
                 },
             );
         });
-        // TODO: stack_pop_version(0) < clk(0);
         cb.require_equal(
             "local_frame_index(0) == frame_index(0)",
             step_curr.local_frame_index.expr(),
@@ -181,7 +179,6 @@ impl<F: Field> InstructionGadgetV2<F> for StoreLocStage2<F> {
             "local_read_value_invalid(0) == true",
             step_curr.local_read_value_invalid.expr(),
         );
-        // TODO:local_read_version(0) < clk(0)
         cb.require_equal(
             "local_write_value(0) == stack_pop_value(0)",
             step_curr.local_write_value.expr(),
@@ -197,7 +194,7 @@ impl<F: Field> InstructionGadgetV2<F> for StoreLocStage2<F> {
             step_curr.local_write_value_invalid.expr(),
         );
         cb.require_equal(
-            "local_write_version == clk(0)",
+            "local_write_version(0) == clk(0)",
             step_curr.local_write_version.expr(),
             step_curr.clk.expr(),
         );

--- a/vm-circuit/src/chips/execution_chip_v2/executions/store_loc.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/store_loc.rs
@@ -78,11 +78,6 @@ impl<F: Field> InstructionGadgetV2<F> for StoreLocStage1<F> {
             step_curr.local_write_value_header.expr(),
             step_curr.local_read_value_header.expr(),
         );
-        cb.require_equal(
-            "local_write_version == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
         cb.require_state_transition(vec![(SP, Transition::Same)]);
         cb.last_row(|cb| {
             cb.require_state_transition(
@@ -192,11 +187,6 @@ impl<F: Field> InstructionGadgetV2<F> for StoreLocStage2<F> {
         cb.require_zero(
             "local_write_value(0) != INVALID",
             step_curr.local_write_value_invalid.expr(),
-        );
-        cb.require_equal(
-            "local_write_version(0) == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
 
         cb.not_last_row(|cb| {

--- a/vm-circuit/src/chips/execution_chip_v2/executions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/unpack.rs
@@ -238,11 +238,6 @@ impl<F: Field, const VEC_UNPACK: bool> InstructionGadgetV2<F> for UnpackStage2<F
             step_curr.stack_push_value_header.expr(),
             step_curr.stack_pop_value_header.expr(),
         );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
-        );
         cb.require_no_local_op();
 
         cb.not_last_row(|cb| {

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_len.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_len.rs
@@ -70,7 +70,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecLen<F> {
             format!("{}, local_read_value_invalid(0) == false", Self::NAME),
             step_curr.local_read_value_invalid.expr(),
         );
-        //TODO: local_read_version(0) < clk(0);
         cb.require_equal(
             format!(
                 "{}, local_write_value(0) == local_read_value(0)",

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_len.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_len.rs
@@ -94,11 +94,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecLen<F> {
             step_curr.local_write_value_invalid.expr(),
             step_curr.local_read_value_invalid.expr(),
         );
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         // push length
         cb.require_equal(
@@ -125,11 +120,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecLen<F> {
         cb.require_zero(
             format!("{}, stack_push_value_header(0) == false", Self::NAME),
             step_curr.stack_push_value_header.expr(),
-        );
-        cb.require_equal(
-            format!("{}, stack_push_version(0) == clk(0)", Self::NAME),
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
         );
         cb.require_state_transition(vec![
             (FRAME_INDEX, Transition::Same),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_pop_back.rs
@@ -148,11 +148,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecPopBackStage1<F> {
             "local_write_value_invalid(0)==false",
             step_curr.local_write_value_invalid.expr(),
         );
-        cb.require_equal(
-            "local_write_version(0) == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.not_last_row(|cb| {
                 cb.require_equal(
@@ -352,12 +347,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecPopBackStage2<F> {
             step_curr.local_read_value_header.expr(),
         );
 
-        cb.require_equal(
-            "local_write_version(0) == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
-
         // --- stack push constraints
         cb.require_equal(
             "stack_push_index(0) == sp(0)",
@@ -383,12 +372,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecPopBackStage2<F> {
             "stack_push_value_header(0)==local_read_value_header(0)",
             step_curr.stack_push_value_header.expr(),
             step_curr.local_read_value_header.expr(),
-        );
-        // TODO: do it in common?
-        cb.require_equal(
-            "stack_push_version(0)==clk(0)",
-            step_curr.stack_push_version.expr(),
-            step_curr.clk.expr(),
         );
 
         // next

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_pop_back.rs
@@ -148,9 +148,11 @@ impl<F: Field> InstructionGadgetV2<F> for VecPopBackStage1<F> {
             "local_write_value_invalid(0)==false",
             step_curr.local_write_value_invalid.expr(),
         );
-        // TODO:
-        //         local_read_version(0) < clk(0);
-        //         local_write_version(0) == clk(0);
+        cb.require_equal(
+            "local_write_version(0) == clk(0)",
+            step_curr.local_write_version.expr(),
+            step_curr.clk.expr(),
+        );
 
         cb.not_last_row(|cb| {
                 cb.require_equal(
@@ -350,9 +352,11 @@ impl<F: Field> InstructionGadgetV2<F> for VecPopBackStage2<F> {
             step_curr.local_read_value_header.expr(),
         );
 
-        // TODO:
-        //         local_read_version(0) < clk(0);
-        //         local_write_version(0) == clk(0);
+        cb.require_equal(
+            "local_write_version(0) == clk(0)",
+            step_curr.local_write_version.expr(),
+            step_curr.clk.expr(),
+        );
 
         // --- stack push constraints
         cb.require_equal(

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_push_back.rs
@@ -148,9 +148,11 @@ impl<F: Field> InstructionGadgetV2<F> for VecPushBackStage1<F> {
             "local_write_value_invalid(0)==false",
             step_curr.local_write_value_invalid.expr(),
         );
-        // TODO:
-        //         local_read_version(0) < clk(0);
-        //         local_write_version(0) == clk(0);
+        cb.require_equal(
+            "local_write_version(0) == clk(0)",
+            step_curr.local_write_version.expr(),
+            step_curr.clk.expr(),
+        );
 
         cb.not_last_row(|cb| {
                 cb.require_equal(
@@ -347,9 +349,11 @@ impl<F: Field> InstructionGadgetV2<F> for VecPushBackStage2<F> {
             step_curr.local_write_value_invalid.expr(),
         );
 
-        // TODO:
-        //         local_read_version(0) < clk(0);
-        //         local_write_version(0) == clk(0);
+        cb.require_equal(
+            "local_write_version(0) == clk(0)",
+            step_curr.local_write_version.expr(),
+            step_curr.clk.expr(),
+        );
 
         // --- stack pop constraints
         cb.require_equal(
@@ -377,12 +381,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecPushBackStage2<F> {
             step_curr.stack_pop_value_header.expr(),
             step_curr.local_write_value_header.expr(),
         );
-        // TODO: do it in common?
-        // cb.require_equal(
-        //     "stack_pop_version(0)<clk(0)",
-        //     step_curr.stack_pop_version.expr(),
-        //     step_curr.clk.expr(),
-        // );
 
         // next
         cb.require_state_transition(

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_push_back.rs
@@ -148,11 +148,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecPushBackStage1<F> {
             "local_write_value_invalid(0)==false",
             step_curr.local_write_value_invalid.expr(),
         );
-        cb.require_equal(
-            "local_write_version(0) == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
 
         cb.not_last_row(|cb| {
                 cb.require_equal(
@@ -347,12 +342,6 @@ impl<F: Field> InstructionGadgetV2<F> for VecPushBackStage2<F> {
         cb.require_zero(
             "local_write_value_invalid(0) == false",
             step_curr.local_write_value_invalid.expr(),
-        );
-
-        cb.require_equal(
-            "local_write_version(0) == clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
 
         // --- stack pop constraints

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_swap.rs
@@ -281,9 +281,6 @@ impl<F: Field, const TWO: bool> InstructionGadgetV2<F> for VecSwapStage_2_Or_3<F
             step_curr.local_read_value_header.expr(),
             step_curr.stack_push_value_header.expr(),
         );
-
-        // TODO: check the constraints
-        // step_curr.local_read_version.expr() < clk;
         cb.require_equal(
             "local_write_version(0)==clk(0)",
             step_curr.local_write_version.expr(),
@@ -466,8 +463,6 @@ impl<F: Field, const FOUR: bool> InstructionGadgetV2<F> for VecSwapStage_4_Or_5<
             "local_read_value_invalid(0) == true",
             step_curr.local_read_value_invalid.expr(),
         );
-        // TODO: check the constraints
-        // step_curr.local_read_version.expr();
         cb.require_zero(
             "local_write_value_invalid(0) == false",
             step_curr.local_write_value_invalid.expr(),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_swap.rs
@@ -281,11 +281,6 @@ impl<F: Field, const TWO: bool> InstructionGadgetV2<F> for VecSwapStage_2_Or_3<F
             step_curr.local_read_value_header.expr(),
             step_curr.stack_push_value_header.expr(),
         );
-        cb.require_equal(
-            "local_write_version(0)==clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
         cb.require_true(
             "local_write_value_invalid(0) == true",
             step_curr.local_write_value_invalid.expr(),
@@ -476,11 +471,6 @@ impl<F: Field, const FOUR: bool> InstructionGadgetV2<F> for VecSwapStage_4_Or_5<
             "local_write_value_header(0)==stack_pop_value_header(0)",
             step_curr.stack_pop_value_header.expr(),
             step_curr.local_write_value_header.expr(),
-        );
-        cb.require_equal(
-            "local_write_version(0)==clk(0)",
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
 
         if FOUR {

--- a/vm-circuit/src/chips/execution_chip_v2/executions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/write_ref.rs
@@ -115,7 +115,6 @@ impl<F: Field> InstructionGadgetV2<F> for WriteRefStage1<F> {
             cb.require_no_stack_pop();
         });
 
-        //TODO: local_read_version(0) < clk(0);
         cb.require_write_invalid_value();
         cb.require_equal(
             format!("{}, local_write_version(0) == clk(0)", Self::NAME),
@@ -265,7 +264,6 @@ impl<F: Field> InstructionGadgetV2<F> for WriteRefStage2<F> {
         );
 
         cb.require_read_invalid_value();
-        // TODO: local_read_version(0) < clk(0);
 
         cb.require_equal(
             format!("{}, local_write_value(0) == stack_pop_value(0)", Self::NAME),
@@ -435,7 +433,6 @@ impl<F: Field> InstructionGadgetV2<F> for WriteRefStage3<F> {
             header_sub_index.expr(),
             header_sub_index_ext.get_parent_sub_index(),
         );
-        //TODO: local_read_version(0) < clk(0);
         cb.require_equal(
             format!("{}, local_sub_index(0) == header_sub_index(0)", Self::NAME),
             step_curr.local_sub_index.expr(),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/write_ref.rs
@@ -116,11 +116,6 @@ impl<F: Field> InstructionGadgetV2<F> for WriteRefStage1<F> {
         });
 
         cb.require_write_invalid_value();
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
-        );
         cb.require_no_stack_push();
         cb.require_cell_transition(step_curr.local_frame_index.clone(), Transition::Same);
         cb.require_cell_transition(step_curr.local_index.clone(), Transition::Same);
@@ -277,11 +272,6 @@ impl<F: Field> InstructionGadgetV2<F> for WriteRefStage2<F> {
             ),
             step_curr.local_write_value_header.expr(),
             step_curr.stack_pop_value_header.expr(),
-        );
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
         cb.require_no_stack_push();
 
@@ -453,11 +443,6 @@ impl<F: Field> InstructionGadgetV2<F> for WriteRefStage3<F> {
             ),
             step_curr.local_write_value_header.expr(),
             step_curr.local_read_value_header.expr(),
-        );
-        cb.require_equal(
-            format!("{}, local_write_version(0) == clk(0)", Self::NAME),
-            step_curr.local_write_version.expr(),
-            step_curr.clk.expr(),
         );
         cb.require_state_transition(vec![(SP, Transition::Same)]);
 


### PR DESCRIPTION
1.change clk to start at "1", and "0" will only be used to specify empty operations
2.use version as a selector to exclude empty operations
3.fix "stack_pop_version < clk" and  "local_read_version < clk"
4.move "stack_push_version==clk" and "local_write_version==clk" to common code