### PR TITLE
optimize cell layout of mul_div_mod and shr_shl

### DIFF
--- a/aptos-move-witnesses/src/exec_state.rs
+++ b/aptos-move-witnesses/src/exec_state.rs
@@ -56,12 +56,14 @@ pub enum ExecutionState {
     EqStage2,
     NeqStage1,
     NeqStage2,
-    MulDivMod,
+    MulDivModStage1,
+    MulDivModStage2,
     Le,
     Gt,
     Lt,
     Ge,
-    Shift,
+    ShiftStage1,
+    ShiftStage2,
 }
 
 impl ExecutionState {
@@ -136,12 +138,14 @@ impl ExecutionState {
             Self::EqStage2 => &[Opcodes::EQ],
             Self::NeqStage1 => &[Opcodes::NEQ],
             Self::NeqStage2 => &[Opcodes::NEQ],
-            Self::MulDivMod => &[Opcodes::MUL, Opcodes::DIV, Opcodes::MOD],
+            Self::MulDivModStage1 => &[Opcodes::MUL, Opcodes::DIV, Opcodes::MOD],
+            Self::MulDivModStage2 => &[Opcodes::MUL, Opcodes::DIV, Opcodes::MOD],
             Self::Le => &[Opcodes::LE],
             Self::Gt => &[Opcodes::GT],
             Self::Lt => &[Opcodes::LT],
             Self::Ge => &[Opcodes::GE],
-            Self::Shift => &[Opcodes::SHL, Opcodes::SHR],
+            Self::ShiftStage1 => &[Opcodes::SHL, Opcodes::SHR],
+            Self::ShiftStage2 => &[Opcodes::SHL, Opcodes::SHR],
         }
     }
 }

--- a/aptos-move-witnesses/src/exec_state.rs
+++ b/aptos-move-witnesses/src/exec_state.rs
@@ -8,6 +8,8 @@ pub enum ExecutionState {
     BrTrue,
     BrFalse,
     Bitwise,
+    BitwiseStage1,
+    BitwiseStage2,
     Branch,
     VecSwapStage1,
     VecSwapStage2,
@@ -70,7 +72,10 @@ impl ExecutionState {
             Self::AddSub => &[Opcodes::ADD, Opcodes::SUB],
             Self::BrTrue => &[Opcodes::BR_TRUE],
             Self::BrFalse => &[Opcodes::BR_FALSE],
-            Self::Bitwise => &[Opcodes::BIT_AND, Opcodes::BIT_OR, Opcodes::XOR],
+            Self::Bitwise | Self::BitwiseStage1 | Self::BitwiseStage2 => {
+                &[Opcodes::BIT_AND, Opcodes::BIT_OR, Opcodes::XOR]
+            }
+
             Self::Branch => &[Opcodes::BRANCH],
             Self::VecSwapStage1 => &[Opcodes::VEC_SWAP],
             Self::VecSwapStage2 => &[Opcodes::VEC_SWAP],

--- a/aptos-move-witnesses/src/step_state.rs
+++ b/aptos-move-witnesses/src/step_state.rs
@@ -23,11 +23,11 @@ impl StageState {
 pub enum StageExtraAssignData {
     Ret(RetExtraAssignData),
     Start(EntryFunc),
-    BitWise(BitwiseData),
+    BinaryOp(BinaryOpData),
 }
 
 #[derive(Clone, Debug)]
-pub struct BitwiseData {
+pub struct BinaryOpData {
     pub lhs: U256,
     pub rhs: U256,
     pub out: U256,

--- a/aptos-move-witnesses/src/step_state.rs
+++ b/aptos-move-witnesses/src/step_state.rs
@@ -3,6 +3,7 @@ use crate::static_info::StaticInfo;
 use crate::types::sub_index::SubIndex;
 use crate::types::word::Word;
 use crate::Footprint;
+use move_core_types::u256::U256;
 
 pub type Version = u64;
 
@@ -22,6 +23,14 @@ impl StageState {
 pub enum StageExtraAssignData {
     Ret(RetExtraAssignData),
     Start(EntryFunc),
+    BitWise(BitwiseData),
+}
+
+#[derive(Clone, Debug)]
+pub struct BitwiseData {
+    pub lhs: U256,
+    pub rhs: U256,
+    pub out: U256,
 }
 
 #[derive(Clone, Debug)]

--- a/aptos-move-witnesses/src/witness_preprocessor.rs
+++ b/aptos-move-witnesses/src/witness_preprocessor.rs
@@ -1750,6 +1750,8 @@ impl WitnessPreProcessor {
                             MemoryOp(None, None, None),
                             MemoryOp(None, None, None),
                             MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
                             MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
                         ];
                         vec![StageState {
@@ -2064,6 +2066,8 @@ impl WitnessPreProcessor {
                 };
                 let memory_ops = vec![
                     MemoryOp(Some(stack_pop_rhs), None, None),
+                    MemoryOp(None, None, None),
+                    MemoryOp(None, None, None),
                     MemoryOp(None, None, None),
                     MemoryOp(None, None, None),
                     MemoryOp(None, None, None),

--- a/aptos-move-witnesses/src/witness_preprocessor.rs
+++ b/aptos-move-witnesses/src/witness_preprocessor.rs
@@ -1723,15 +1723,33 @@ impl WitnessPreProcessor {
                 match ty {
                     BinaryIntegerOperationType::Add
                     | BinaryIntegerOperationType::Sub
-                    | BinaryIntegerOperationType::Mul
-                    | BinaryIntegerOperationType::Div
-                    | BinaryIntegerOperationType::Mod
                     | BinaryIntegerOperationType::Lt
                     | BinaryIntegerOperationType::Gt
                     | BinaryIntegerOperationType::Le
                     | BinaryIntegerOperationType::Ge => {
                         let memory_ops = vec![
                             MemoryOp(Some(stack_pop_rhs), None, None),
+                            MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
+                        ];
+                        vec![StageState {
+                            step_states: vec![ExecStepState {
+                                step_state,
+                                memory_ops,
+                            }],
+                            extra_data: None,
+                        }]
+                    }
+                    BinaryIntegerOperationType::Mul
+                    | BinaryIntegerOperationType::Div
+                    | BinaryIntegerOperationType::Mod => {
+                        let memory_ops = vec![
+                            MemoryOp(Some(stack_pop_rhs), None, None),
+                            MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
+                            MemoryOp(None, None, None),
                             MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
                         ];
                         vec![StageState {
@@ -2046,6 +2064,12 @@ impl WitnessPreProcessor {
                 };
                 let memory_ops = vec![
                     MemoryOp(Some(stack_pop_rhs), None, None),
+                    MemoryOp(None, None, None),
+                    MemoryOp(None, None, None),
+                    MemoryOp(None, None, None),
+                    MemoryOp(None, None, None),
+                    MemoryOp(None, None, None),
+                    MemoryOp(None, None, None),
                     MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
                 ];
                 vec![StageState {

--- a/aptos-move-witnesses/src/witness_preprocessor.rs
+++ b/aptos-move-witnesses/src/witness_preprocessor.rs
@@ -4,7 +4,7 @@ use crate::exec_state::ExecutionState::{
 };
 use crate::static_info::StaticInfo;
 use crate::step_state::{
-    BitwiseData, CallerData, EntryFunc, ExecStepState, LocalReadWrite, MemoryOp,
+    BinaryOpData, CallerData, EntryFunc, ExecStepState, LocalReadWrite, MemoryOp,
     RetExtraAssignData, Slot, StackPop, StackPush, StageExtraAssignData, StageState, StepState,
     Version,
 };
@@ -1618,23 +1618,35 @@ impl WitnessPreProcessor {
                     }
                     BinaryIntegerOperationType::Mul => {
                         let output = lhs.to_u256().mul(rhs.to_u256());
-                        let step_state =
-                            StepState::new(self.clk, ExecutionState::MulDivMod, trace, static_info)
-                                .set_aux0(num_bytes as u128);
+                        let step_state = StepState::new(
+                            self.clk,
+                            ExecutionState::MulDivModStage1,
+                            trace,
+                            static_info,
+                        )
+                        .set_aux0(num_bytes as u128);
                         (SimpleValue::U256(output), step_state)
                     }
                     BinaryIntegerOperationType::Div => {
                         let output = lhs.to_u256().div(rhs.to_u256());
-                        let step_state =
-                            StepState::new(self.clk, ExecutionState::MulDivMod, trace, static_info)
-                                .set_aux0(num_bytes as u128);
+                        let step_state = StepState::new(
+                            self.clk,
+                            ExecutionState::MulDivModStage1,
+                            trace,
+                            static_info,
+                        )
+                        .set_aux0(num_bytes as u128);
                         (SimpleValue::U256(output), step_state)
                     }
                     BinaryIntegerOperationType::Mod => {
                         let output = lhs.to_u256().rem(rhs.to_u256());
-                        let step_state =
-                            StepState::new(self.clk, ExecutionState::MulDivMod, trace, static_info)
-                                .set_aux0(num_bytes as u128);
+                        let step_state = StepState::new(
+                            self.clk,
+                            ExecutionState::MulDivModStage1,
+                            trace,
+                            static_info,
+                        )
+                        .set_aux0(num_bytes as u128);
                         (SimpleValue::U256(output), step_state)
                     }
                     BinaryIntegerOperationType::Lt => {
@@ -1754,28 +1766,8 @@ impl WitnessPreProcessor {
                     }
                     BinaryIntegerOperationType::Mul
                     | BinaryIntegerOperationType::Div
-                    | BinaryIntegerOperationType::Mod => {
-                        let memory_ops = vec![
-                            MemoryOp(Some(stack_pop_rhs), None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(None, None, None),
-                            MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
-                        ];
-                        vec![StageState {
-                            step_states: vec![ExecStepState {
-                                step_state,
-                                memory_ops,
-                            }],
-                            extra_data: None,
-                        }]
-                    }
-                    BinaryIntegerOperationType::BitAnd
+                    | BinaryIntegerOperationType::Mod
+                    | BinaryIntegerOperationType::BitAnd
                     | BinaryIntegerOperationType::BitOr
                     | BinaryIntegerOperationType::Xor => {
                         let stage1 = ExecStepState {
@@ -1786,11 +1778,21 @@ impl WitnessPreProcessor {
                             ],
                         };
                         self.clk += 1;
+                        let (stage2_state, stage2_rows) = match ty {
+                            BinaryIntegerOperationType::Mul
+                            | BinaryIntegerOperationType::Div
+                            | BinaryIntegerOperationType::Mod => {
+                                (ExecutionState::MulDivModStage2, 10)
+                            }
+                            BinaryIntegerOperationType::BitAnd
+                            | BinaryIntegerOperationType::BitOr
+                            | BinaryIntegerOperationType::Xor => (ExecutionState::BitwiseStage2, 8),
+                            _ => unreachable!(),
+                        };
+
                         let stage2 = ExecStepState {
-                            step_state: step_state
-                                .change_state(ExecutionState::BitwiseStage2)
-                                .change_clk(self.clk),
-                            memory_ops: vec![MemoryOp::default(); 8],
+                            step_state: step_state.change_state(stage2_state).change_clk(self.clk),
+                            memory_ops: vec![MemoryOp::default(); stage2_rows],
                         };
                         vec![
                             StageState {
@@ -1799,7 +1801,7 @@ impl WitnessPreProcessor {
                             },
                             StageState {
                                 step_states: vec![stage2],
-                                extra_data: Some(StageExtraAssignData::BitWise(BitwiseData {
+                                extra_data: Some(StageExtraAssignData::BinaryOp(BinaryOpData {
                                     lhs: lhs.to_u256(),
                                     rhs: rhs.to_u256(),
                                     out: Integer::try_from(out.clone()).unwrap().to_u256(),
@@ -2068,7 +2070,7 @@ impl WitnessPreProcessor {
                     lhs.to_u256().checked_shr(*rhs as u32).unwrap() //never failed
                 };
                 let step_state =
-                    StepState::new(self.clk, ExecutionState::Shift, trace, static_info)
+                    StepState::new(self.clk, ExecutionState::ShiftStage1, trace, static_info)
                         .set_aux0(num_bytes as u128);
 
                 let stack_pop_rhs = StackPop {
@@ -2093,25 +2095,34 @@ impl WitnessPreProcessor {
                     value_header: false,
                     version: *self.version_stack.last().unwrap(),
                 };
-                let memory_ops = vec![
-                    MemoryOp(Some(stack_pop_rhs), None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(None, None, None),
-                    MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
-                ];
-                vec![StageState {
-                    step_states: vec![ExecStepState {
-                        step_state,
-                        memory_ops,
-                    }],
-                    extra_data: None,
-                }]
+                let stage1 = ExecStepState {
+                    step_state,
+                    memory_ops: vec![
+                        MemoryOp(Some(stack_pop_rhs), None, None),
+                        MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
+                    ],
+                };
+                self.clk += 1;
+                let stage2 = ExecStepState {
+                    step_state: step_state
+                        .change_state(ExecutionState::ShiftStage2)
+                        .change_clk(self.clk),
+                    memory_ops: vec![MemoryOp::default(); 10],
+                };
+                vec![
+                    StageState {
+                        step_states: vec![stage1],
+                        extra_data: None,
+                    },
+                    StageState {
+                        step_states: vec![stage2],
+                        extra_data: Some(StageExtraAssignData::BinaryOp(BinaryOpData {
+                            lhs: lhs.to_u256(),
+                            rhs: (*rhs).into(),
+                            out: output,
+                        })),
+                    },
+                ]
             }
             _ => todo!("{:?}", &trace.data),
         }

--- a/aptos-move-witnesses/src/witness_preprocessor.rs
+++ b/aptos-move-witnesses/src/witness_preprocessor.rs
@@ -4,8 +4,9 @@ use crate::exec_state::ExecutionState::{
 };
 use crate::static_info::StaticInfo;
 use crate::step_state::{
-    CallerData, EntryFunc, ExecStepState, LocalReadWrite, MemoryOp, RetExtraAssignData, Slot,
-    StackPop, StackPush, StageState, StepState, Version,
+    BitwiseData, CallerData, EntryFunc, ExecStepState, LocalReadWrite, MemoryOp,
+    RetExtraAssignData, Slot, StackPop, StackPush, StageExtraAssignData, StageState, StepState,
+    Version,
 };
 use crate::types::sub_index::SubIndex;
 use crate::types::value_header::ValueHeader;
@@ -1673,8 +1674,12 @@ impl WitnessPreProcessor {
                             .bit_and(IntegerValue::from(rhs.clone()))
                             .expect("should not fail")
                             .into();
-                        let step_state =
-                            StepState::new(self.clk, ExecutionState::Bitwise, trace, static_info);
+                        let step_state = StepState::new(
+                            self.clk,
+                            ExecutionState::BitwiseStage1,
+                            trace,
+                            static_info,
+                        );
                         (SimpleValue::from(output), step_state)
                     }
                     BinaryIntegerOperationType::BitOr => {
@@ -1682,8 +1687,12 @@ impl WitnessPreProcessor {
                             .bit_or(IntegerValue::from(rhs.clone()))
                             .expect("should not fail")
                             .into();
-                        let step_state =
-                            StepState::new(self.clk, ExecutionState::Bitwise, trace, static_info);
+                        let step_state = StepState::new(
+                            self.clk,
+                            ExecutionState::BitwiseStage1,
+                            trace,
+                            static_info,
+                        );
                         (SimpleValue::from(output), step_state)
                     }
                     BinaryIntegerOperationType::Xor => {
@@ -1691,8 +1700,12 @@ impl WitnessPreProcessor {
                             .bit_xor(IntegerValue::from(rhs.clone()))
                             .expect("should not fail")
                             .into();
-                        let step_state =
-                            StepState::new(self.clk, ExecutionState::Bitwise, trace, static_info);
+                        let step_state = StepState::new(
+                            self.clk,
+                            ExecutionState::BitwiseStage1,
+                            trace,
+                            static_info,
+                        );
                         (SimpleValue::from(output), step_state)
                     }
                 };
@@ -1715,7 +1728,7 @@ impl WitnessPreProcessor {
                 let stack_push = StackPush {
                     index: sp - 1,
                     sub_index: SubIndex::default(),
-                    value: out.into(),
+                    value: out.clone().into(),
                     value_header: false,
                     version: *self.version_stack.last().unwrap(),
                 };
@@ -1765,18 +1778,34 @@ impl WitnessPreProcessor {
                     BinaryIntegerOperationType::BitAnd
                     | BinaryIntegerOperationType::BitOr
                     | BinaryIntegerOperationType::Xor => {
-                        let memory_ops = vec![
-                            MemoryOp(Some(stack_pop_rhs), None, None),
-                            MemoryOp(Some(stack_pop_lhs), None, None),
-                            MemoryOp(None, Some(stack_push), None),
-                        ];
-                        vec![StageState {
-                            step_states: vec![ExecStepState {
-                                step_state,
-                                memory_ops,
-                            }],
-                            extra_data: None,
-                        }]
+                        let stage1 = ExecStepState {
+                            step_state,
+                            memory_ops: vec![
+                                MemoryOp(Some(stack_pop_rhs), None, None),
+                                MemoryOp(Some(stack_pop_lhs), Some(stack_push), None),
+                            ],
+                        };
+                        self.clk += 1;
+                        let stage2 = ExecStepState {
+                            step_state: step_state
+                                .change_state(ExecutionState::BitwiseStage2)
+                                .change_clk(self.clk),
+                            memory_ops: vec![MemoryOp::default(); 8],
+                        };
+                        vec![
+                            StageState {
+                                step_states: vec![stage1],
+                                extra_data: None,
+                            },
+                            StageState {
+                                step_states: vec![stage2],
+                                extra_data: Some(StageExtraAssignData::BitWise(BitwiseData {
+                                    lhs: lhs.to_u256(),
+                                    rhs: rhs.to_u256(),
+                                    out: Integer::try_from(out.clone()).unwrap().to_u256(),
+                                })),
+                            },
+                        ]
                     }
                 }
             }

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -46,7 +46,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
     let witness = WitnessV2::new(states, static_info, CircuitConfigV2::default());
     let circuit = VmCircuit::<Fr>::new_from_witness(&witness);
 
-    let k = 12; //TODO: auto pick best k
+    let k = 11; //TODO: auto pick best k
 
     debug!("Mock prove");
     mock_prove_circuit(&circuit, vec![], k)?;

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -15,7 +15,7 @@ use rand::SeedableRng;
 use std::path::Path;
 use vm_circuit::circuit_v2::VmCircuit;
 use vm_circuit::witness::{CircuitConfigV2, WitnessV2};
-use vm_circuit::{mock_prove_circuit, prove_vm_circuit_kzg, setup_circuit, SubCircuit};
+use vm_circuit::{mock_prove_circuit, prove_and_verify_kzg, setup_circuit, SubCircuit};
 pub const TEST_PACKAGE_NAME: &str = "cases";
 
 fn vm_test(path: &Path) -> datatest_stable::Result<()> {
@@ -57,7 +57,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
     let (_, pk) = setup_circuit(&circuit, &params)?;
 
     debug!("Generate zk proof");
-    prove_vm_circuit_kzg(circuit, &[], &params, pk.clone());
+    prove_and_verify_kzg(circuit, &[], &params, pk.clone());
 
     Ok(())
 }

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -46,7 +46,7 @@ fn vm_test(path: &Path) -> datatest_stable::Result<()> {
     let witness = WitnessV2::new(states, static_info, CircuitConfigV2::default());
     let circuit = VmCircuit::<Fr>::new_from_witness(&witness);
 
-    let k = 11; //TODO: auto pick best k
+    let k = 12; //TODO: auto pick best k
 
     debug!("Mock prove");
     mock_prove_circuit(&circuit, vec![], k)?;

--- a/movelang/src/generic_call_graph.rs
+++ b/movelang/src/generic_call_graph.rs
@@ -372,7 +372,7 @@ impl<'a, S> Visitor<'a, S> {
     }
 }
 
-impl<'a, S: ModuleResolver> Visitor<'a, S> {
+impl<S: ModuleResolver> Visitor<'_, S> {
     fn visit(&self, call_graph: &mut GenericCallGraph) {
         let (
             caller_node_idx,

--- a/movelang/src/value_ext.rs
+++ b/movelang/src/value_ext.rs
@@ -16,6 +16,7 @@ pub const LOWER_FIELD_OFFSET: usize = 1;
 pub const UPPER_FIELD_OFFSET: usize = 2;
 
 /// To efficiently represent a complex value in the circuit, we defined 'FlattenedValue'.
+///
 /// It starts with a value header carrying type information, followed by simple values
 /// flattened from the complex value.
 #[derive(Clone, Debug)]

--- a/specs/opcodes.rs
+++ b/specs/opcodes.rs
@@ -211,48 +211,6 @@ mod binary_op {
     }
 }
 
-mod binary_op_v2 {
-    pub fn constrain() {
-        if super::common::on_first_row() {
-            step_counter(0) == 10;
-            stack_pop_index(0) == sp(0);
-        }
-
-        if !super::common::on_last_row() {
-            super::common::require_no_stack_push();
-            sp(1) == sp(0); //keep sp unchanged to make assign easier
-        }
-        if super::common::on_first_row() || super::common::on_last_row() {
-            stack_pop_sub_index(0) == 0;
-            stack_pop_value_header(0) == false;
-            // stack_pop_version(0) < clk(0);
-        }
-        if !super::common::on_first_row() && !super::common::on_last_row() {
-            super::common::require_no_stack_pop();
-        }
-        super::common::require_no_local_op();
-
-        if super::common::on_last_row() {
-            stack_pop_index(0) == sp(0) - 1;
-
-            stack_push_index(0) == sp(0) - 1;
-            stack_push_sub_index(0) == 0;
-            let rhs = stack_pop_value(-9);
-            let lhs = stack_pop_value(0);
-            let out = binary_op(lhs, rhs);
-            stack_push_value(0) == out;
-            stack_push_value_header(0) == false;
-            stack_push_version(0) == clk(0);
-
-            module_index(1) == module_index(0);
-            function_index(1) == function_index(0);
-            frame_index(1) == frame_index(0);
-            pc(1) == pc(0) + 1;
-            sp(1) == sp(0) - 1;
-        }
-    }
-}
-
 mod bitwise {
     pub fn constrain() {
         if super::common::on_first_row() {

--- a/specs/opcodes.rs
+++ b/specs/opcodes.rs
@@ -211,6 +211,48 @@ mod binary_op {
     }
 }
 
+mod binary_op_v2 {
+    pub fn constrain() {
+        if super::common::on_first_row() {
+            step_counter(0) == 8;
+            stack_pop_index(0) == sp(0);
+        }
+
+        if !super::common::on_last_row() {
+            super::common::require_no_stack_push();
+            sp(1) == sp(0); //keep sp unchanged to make assign easier
+        }
+        if super::common::on_first_row() || super::common::on_last_row() {
+            stack_pop_sub_index(0) == 0;
+            stack_pop_value_header(0) == false;
+            // stack_pop_version(0) < clk(0);
+        }
+        if !super::common::on_first_row() && !super::common::on_last_row() {
+            super::common::require_no_stack_pop();
+        }
+        super::common::require_no_local_op();
+
+        if super::common::on_last_row() {
+            stack_pop_index(0) == sp(0) - 1;
+
+            stack_push_index(0) == sp(0) - 1;
+            stack_push_sub_index(0) == 0;
+            let rhs = stack_pop_value(-7);
+            let lhs = stack_pop_value(0);
+            let out = binary_op(lhs, rhs);
+            stack_push_value(0) == out;
+            stack_push_value_header(0) == false;
+            stack_push_version(0) == clk(0);
+
+            module_index(1) == module_index(0);
+            function_index(1) == function_index(0);
+            frame_index(1) == frame_index(0);
+            pc(1) == pc(0) + 1;
+            sp(1) == sp(0) - 1;
+        }
+    }
+}
+
 mod bitwise {
     pub fn constrain() {
         if super::common::on_first_row() {

--- a/specs/opcodes.rs
+++ b/specs/opcodes.rs
@@ -214,7 +214,7 @@ mod binary_op {
 mod binary_op_v2 {
     pub fn constrain() {
         if super::common::on_first_row() {
-            step_counter(0) == 8;
+            step_counter(0) == 10;
             stack_pop_index(0) == sp(0);
         }
 
@@ -237,7 +237,7 @@ mod binary_op_v2 {
 
             stack_push_index(0) == sp(0) - 1;
             stack_push_sub_index(0) == 0;
-            let rhs = stack_pop_value(-7);
+            let rhs = stack_pop_value(-9);
             let lhs = stack_pop_value(0);
             let out = binary_op(lhs, rhs);
             stack_push_value(0) == out;

--- a/vm-circuit/src/chips/execution_chip_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2.rs
@@ -2,12 +2,12 @@ use crate::chips::execution_chip_v2::executions::branch::Branch;
 use crate::chips::execution_chip_v2::executions::nop::Nop;
 use crate::chips::execution_chip_v2::executions::start::{ProcessArg, Start};
 use crate::chips::execution_chip_v2::executions::{
-    AddSub, AndOr, Bitwise, BorrowField, BorrowLoc, BrBool, CallStage1, CallStage2, CallStage3,
-    Cast, Equality, ExecutionState, LdBool, LdConst, LdSimple, Le, Lt, MoveOrCopyLoc, MulDivMod,
-    Not, Pack, Pop, ReadRef, Ret, StoreLocStage1, StoreLocStage2, UnpackStage1, UnpackStage2,
-    VecBorrow, VecLen, VecPopBackStage1, VecPopBackStage2, VecPushBackStage1, VecPushBackStage2,
-    VecSwapStage_1, VecSwapStage_2_Or_3, VecSwapStage_4_Or_5, WriteRefStage1, WriteRefStage2,
-    WriteRefStage3,
+    AddSub, AndOr, BitwiseStage1, BitwiseStage2, BorrowField, BorrowLoc, BrBool,
+    CallStage1, CallStage2, CallStage3, Cast, Equality, ExecutionState, LdBool, LdConst, LdSimple,
+    Le, Lt, MoveOrCopyLoc, MulDivMod, Not, Pack, Pop, ReadRef, Ret, StoreLocStage1, StoreLocStage2,
+    UnpackStage1, UnpackStage2, VecBorrow, VecLen, VecPopBackStage1, VecPopBackStage2,
+    VecPushBackStage1, VecPushBackStage2, VecSwapStage_1, VecSwapStage_2_Or_3, VecSwapStage_4_Or_5,
+    WriteRefStage1, WriteRefStage2, WriteRefStage3,
 };
 use crate::chips::execution_chip_v2::executions::{BaseConstraintGadget, Shift};
 use crate::chips::execution_chip_v2::lookup_table::{Lookup, LookupTableConfigV2};
@@ -58,7 +58,8 @@ pub(crate) struct ExecChipConfig<F> {
     pub process_arg: Box<ProcessArg<F>>,
     pub add_sub: Box<AddSub<F>>,
     pub and_or: Box<AndOr<F>>,
-    pub bitwise: Box<Bitwise<F>>,
+    pub bitwise_stage1: Box<BitwiseStage1<F, 8, 8>>,
+    pub bitwise_stage2: Box<BitwiseStage2<F, 8, 8>>,
     pub borrow_field: Box<BorrowField<F>>,
     pub borrow_loc: Box<BorrowLoc<F>>,
     pub br_true: Box<BrBool<F, true>>,
@@ -246,7 +247,8 @@ impl<F: Field> ExecChipConfig<F> {
             process_arg: configure_opcode_gadget!(),
             add_sub: configure_opcode_gadget!(),
             and_or: configure_opcode_gadget!(),
-            bitwise: configure_opcode_gadget!(),
+            bitwise_stage1: configure_opcode_gadget!(),
+            bitwise_stage2: configure_opcode_gadget!(),
             borrow_field: configure_opcode_gadget!(),
             borrow_loc: configure_opcode_gadget!(),
             br_true: configure_opcode_gadget!(),
@@ -684,7 +686,8 @@ impl<F: Field> ExecChipConfig<F> {
             ExecutionState::VecSwapStage5 => self.vec_swap_stage_5,
             ExecutionState::AddSub => self.add_sub,
             ExecutionState::AndOr => self.and_or,
-            ExecutionState::Bitwise => self.bitwise,
+            ExecutionState::BitwiseStage1 => self.bitwise_stage1,
+            ExecutionState::BitwiseStage2 => self.bitwise_stage2,
             ExecutionState::BorrowField => self.borrow_field,
             ExecutionState::BorrowLoc => self.borrow_loc,
             ExecutionState::BrTrue => self.br_true,

--- a/vm-circuit/src/chips/execution_chip_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2.rs
@@ -1,15 +1,15 @@
 use crate::chips::execution_chip_v2::executions::branch::Branch;
 use crate::chips::execution_chip_v2::executions::nop::Nop;
 use crate::chips::execution_chip_v2::executions::start::{ProcessArg, Start};
+use crate::chips::execution_chip_v2::executions::BaseConstraintGadget;
 use crate::chips::execution_chip_v2::executions::{
-    AddSub, AndOr, BitwiseStage1, BitwiseStage2, BorrowField, BorrowLoc, BrBool,
-    CallStage1, CallStage2, CallStage3, Cast, Equality, ExecutionState, LdBool, LdConst, LdSimple,
-    Le, Lt, MoveOrCopyLoc, MulDivMod, Not, Pack, Pop, ReadRef, Ret, StoreLocStage1, StoreLocStage2,
-    UnpackStage1, UnpackStage2, VecBorrow, VecLen, VecPopBackStage1, VecPopBackStage2,
-    VecPushBackStage1, VecPushBackStage2, VecSwapStage_1, VecSwapStage_2_Or_3, VecSwapStage_4_Or_5,
-    WriteRefStage1, WriteRefStage2, WriteRefStage3,
+    AddSub, AndOr, BitwiseStage1, BitwiseStage2, BorrowField, BorrowLoc, BrBool, CallStage1,
+    CallStage2, CallStage3, Cast, Equality, ExecutionState, LdBool, LdConst, LdSimple, Le, Lt,
+    MoveOrCopyLoc, MulDivModStage1, MulDivModStage2, Not, Pack, Pop, ReadRef, Ret, ShiftStage1,
+    ShiftStage2, StoreLocStage1, StoreLocStage2, UnpackStage1, UnpackStage2, VecBorrow, VecLen,
+    VecPopBackStage1, VecPopBackStage2, VecPushBackStage1, VecPushBackStage2, VecSwapStage_1,
+    VecSwapStage_2_Or_3, VecSwapStage_4_Or_5, WriteRefStage1, WriteRefStage2, WriteRefStage3,
 };
-use crate::chips::execution_chip_v2::executions::{BaseConstraintGadget, Shift};
 use crate::chips::execution_chip_v2::lookup_table::{Lookup, LookupTableConfigV2};
 use crate::chips::execution_chip_v2::step_v2::{Step, StepState};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::{
@@ -81,7 +81,8 @@ pub(crate) struct ExecChipConfig<F> {
     pub le: Box<Le<F, true>>,
     pub lt: Box<Lt<F, true>>,
     pub move_loc: Box<MoveOrCopyLoc<F, true>>,
-    pub mul_div_mod: Box<MulDivMod<F>>,
+    pub mul_div_mod_stage1: Box<MulDivModStage1<F>>,
+    pub mul_div_mod_stage2: Box<MulDivModStage2<F>>,
     pub neq_stage_1: Box<Equality<F, true, false>>,
     pub neq_stage_2: Box<Equality<F, false, false>>,
     pub not: Box<Not<F>>,
@@ -89,7 +90,8 @@ pub(crate) struct ExecChipConfig<F> {
     pub pop: Box<Pop<F>>,
     pub read_ref: Box<ReadRef<F>>,
     pub ret: Box<Ret<F>>,
-    pub shift: Box<Shift<F>>,
+    pub shift_stage1: Box<ShiftStage1<F>>,
+    pub shift_stage2: Box<ShiftStage2<F>>,
     pub store_loc_stage1: Box<StoreLocStage1<F>>,
     pub store_loc_stage2: Box<StoreLocStage2<F>>,
     pub unpack_stage_1: Box<UnpackStage1<F, false>>,
@@ -270,7 +272,8 @@ impl<F: Field> ExecChipConfig<F> {
             le: configure_opcode_gadget!(),
             lt: configure_opcode_gadget!(),
             move_loc: configure_opcode_gadget!(),
-            mul_div_mod: configure_opcode_gadget!(),
+            mul_div_mod_stage1: configure_opcode_gadget!(),
+            mul_div_mod_stage2: configure_opcode_gadget!(),
             neq_stage_1: configure_opcode_gadget!(),
             neq_stage_2: configure_opcode_gadget!(),
             not: configure_opcode_gadget!(),
@@ -280,7 +283,8 @@ impl<F: Field> ExecChipConfig<F> {
             ret: configure_opcode_gadget!(),
             store_loc_stage1: configure_opcode_gadget!(),
             store_loc_stage2: configure_opcode_gadget!(),
-            shift: configure_opcode_gadget!(),
+            shift_stage1: configure_opcode_gadget!(),
+            shift_stage2: configure_opcode_gadget!(),
             unpack_stage_1: configure_opcode_gadget!(),
             unpack_stage_2: configure_opcode_gadget!(),
             vec_borrow: configure_opcode_gadget!(),
@@ -711,7 +715,8 @@ impl<F: Field> ExecChipConfig<F> {
             ExecutionState::Lt => self.lt,
             ExecutionState::MoveLoc => self.move_loc,
             ExecutionState::CopyLoc => self.copy_loc,
-            ExecutionState::MulDivMod => self.mul_div_mod,
+            ExecutionState::MulDivModStage1 => self.mul_div_mod_stage1,
+            ExecutionState::MulDivModStage2=> self.mul_div_mod_stage2,
             ExecutionState::Not => self.not,
             ExecutionState::Pack => self.pack,
             ExecutionState::Pop => self.pop,
@@ -726,7 +731,8 @@ impl<F: Field> ExecChipConfig<F> {
             ExecutionState::Nop => self.nop,
             ExecutionState::Start => self.start,
             ExecutionState::ProcessArg => self.process_arg,
-            ExecutionState::Shift => self.shift,
+            ExecutionState::ShiftStage1 => self.shift_stage1,
+            ExecutionState::ShiftStage2 => self.shift_stage2,
         });
         debug_assert_eq!(assigned_rows, stage_state.rows());
         Ok(assigned_rows)

--- a/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/add_sub.rs
@@ -2,9 +2,7 @@ use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::math_gadgets::add::AddGadget;
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
 use crate::chips::execution_chip_v2::math_gadgets::range_check::IntegerRangeCheck;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/and_or.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/and_or.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/base.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/base.rs
@@ -80,6 +80,7 @@ impl<F: Field> BaseConstraintGadget<F> {
             cb.condition(
                 not::expr(cb.curr.execution_state_selector([
                     ExecutionState::Start,
+                    ExecutionState::ProcessArg,
                     ExecutionState::CallStage1,
                     ExecutionState::CallStage3,
                     ExecutionState::Ret,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
@@ -13,15 +13,271 @@ use crate::chips::utils::Expr;
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
 use aptos_move_witnesses::static_info::StaticInfo;
-use aptos_move_witnesses::step_state::StageState;
+use aptos_move_witnesses::step_state::{StageExtraAssignData, StageState};
+use aptos_move_witnesses::utils::to_u256::ToU256;
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
 };
-use itertools::izip;
+use itertools::{izip, Itertools};
 use std::marker::PhantomData;
 use types::Field;
+#[derive(Clone, Debug)]
+pub struct BitwiseStage1<F, const R: usize, const C: usize> {
+    lhs_nibbles: [Cell<F>; C],
+    rhs_nibbles: [Cell<F>; C],
+    out_nibbles: [Cell<F>; C],
+}
+impl<F: Field, const R: usize, const C: usize> InstructionGadgetV2<F> for BitwiseStage1<F, R, C> {
+    const NAME: &'static str = "BitwiseStage1";
+    const EXECUTION_STATE: ExecutionState = ExecutionState::BitwiseStage1;
 
+    fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        debug_assert_eq!(R * C, NUM_OF_NIBBLE_U256);
+        let step_curr = cb.curr.state.clone();
+        let step_prev = cb.step_state_at_offset(-1);
+        let lhs_nibbles = cb.query_cells::<C>();
+        let rhs_nibbles = cb.query_cells::<C>();
+        let out_nibbles = cb.query_cells::<C>();
+
+        cb.first_row(|cb| {
+            cb.require_in_set(
+                "opcode in OPCODES",
+                step_curr.opcode.expr(),
+                Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
+            );
+            cb.require_equal(
+                "step_counter(0) == 2",
+                step_curr.step_counter.expr(),
+                2u64.expr(),
+            );
+        });
+
+        // stack pop
+        cb.require_equal(
+            format!(
+                "{}, stack_pop_index(0) == sp(0) + step_counter(0) - 2",
+                Self::NAME
+            ),
+            step_curr.stack_pop_index.expr(),
+            step_curr.sp.expr() + step_curr.step_counter.expr() - 2u64.expr(),
+        );
+        cb.require_zero(
+            format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
+            step_curr.stack_pop_sub_index.expr(),
+        );
+        cb.require_zero(
+            format!("{}, stack_pop_value_header(0) == false", Self::NAME),
+            step_curr.stack_pop_value_header.expr(),
+        );
+
+        cb.first_row(|cb| {
+            cb.require_no_stack_push();
+            cb.require_state_transition(vec![(SP, Transition::Same)]);
+        });
+
+        cb.require_no_local_op();
+
+        cb.last_row(|cb| {
+            cb.require_equal(
+                format!("{}, stack_push_index(0) == stack_pop_index", Self::NAME),
+                step_curr.stack_push_index.expr(),
+                step_curr.stack_pop_index.expr(),
+            );
+            cb.require_zero(
+                format!("{}, stack_push_sub_index(0) == 0", Self::NAME),
+                step_curr.stack_push_sub_index.expr(),
+            );
+            cb.require_zero(
+                format!("{}, stack_push_value_header(0) == false", Self::NAME),
+                step_curr.stack_push_value_header.expr(),
+            );
+            cb.require_equal(
+                "stack_push_version(0) == clk(0)",
+                step_curr.stack_push_version.expr(),
+                step_curr.clk.expr(),
+            );
+        });
+
+        cb.last_row(|cb| {
+            // constrain lhs
+            let lhs = step_curr.stack_pop_value.as_integer();
+            let nibbles_lhs = (1..(R as i32))
+                .flat_map(|i| cb.cells_at_offset(lhs_nibbles.clone(), i))
+                .collect::<Vec<_>>();
+            cb.require_equal(
+                "lhs.lo = from_limbs(nibbles_lhs[0..32])",
+                lhs.lo(),
+                from_limbs::expr::<_, _, 4>(&nibbles_lhs[..NUM_OF_BYTES_U256]),
+            );
+            cb.require_equal(
+                "lhs.hi = from_limbs(nibbles_lhs[32..])",
+                lhs.hi(),
+                from_limbs::expr::<_, _, 4>(&nibbles_lhs[NUM_OF_BYTES_U256..]),
+            );
+
+            // constrain rhs
+            let rhs = step_prev.stack_pop_value.as_integer();
+            let nibbles_rhs = (1..(R as i32))
+                .flat_map(|i| cb.cells_at_offset(rhs_nibbles.clone(), i))
+                .collect::<Vec<_>>();
+            cb.require_equal(
+                "rhs.lo = from_limbs(nibbles_rhs[0..32])",
+                rhs.lo(),
+                from_limbs::expr::<_, _, 4>(&nibbles_rhs[..NUM_OF_BYTES_U256]),
+            );
+            cb.require_equal(
+                "rhs.hi = from_limbs(nibbles_rhs[32..])",
+                rhs.hi(),
+                from_limbs::expr::<_, _, 4>(&nibbles_rhs[NUM_OF_BYTES_U256..]),
+            );
+
+            // constrain output
+            let out = step_curr.stack_push_value.as_integer();
+            let nibbles_out = (1..(R as i32))
+                .flat_map(|i| cb.cells_at_offset(out_nibbles.clone(), i))
+                .collect::<Vec<_>>();
+
+            cb.require_equal(
+                "out.lo = from_limbs(nibbles[0..32])",
+                out.lo(),
+                from_limbs::expr::<_, _, 4>(&nibbles_out[..NUM_OF_BYTES_U256]),
+            );
+            cb.require_equal(
+                "out.hi = from_limbs(nibbles[32..])",
+                out.hi(),
+                from_limbs::expr::<_, _, 4>(&nibbles_out[NUM_OF_BYTES_U256..]),
+            );
+        });
+        cb.last_row(|cb| {
+            cb.require_next_state(ExecutionState::BitwiseStage2);
+            // only need to make sure pc, sp are the same
+            cb.require_state_transition(
+                [PC, SP]
+                    .into_iter()
+                    .map(|state_name| (state_name, Transition::Same))
+                    .collect(),
+            );
+        });
+        BitwiseStage1 {
+            lhs_nibbles,
+            rhs_nibbles,
+            out_nibbles,
+        }
+    }
+
+    fn assign(
+        &self,
+        _step: StepState<F>,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        stage_state: &StageState,
+        static_info: &StaticInfo,
+    ) -> Result<usize, Error> {
+        // debug_assert!(!stage_state.step_states.is_empty());
+        let step_state = stage_state.step_states.first().unwrap();
+        Ok(step_state.memory_ops.len())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BitwiseStage2<F, const R: usize, const C: usize> {
+    lhs_nibbles: [Cell<F>; C],
+    rhs_nibbles: [Cell<F>; C],
+    out_nibbles: [Cell<F>; C],
+}
+impl<F: Field, const R: usize, const C: usize> InstructionGadgetV2<F> for BitwiseStage2<F, R, C> {
+    const NAME: &'static str = "BitwiseStage2";
+    const EXECUTION_STATE: ExecutionState = ExecutionState::BitwiseStage2;
+
+    fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        debug_assert_eq!(R * C, NUM_OF_NIBBLE_U256);
+        let step_curr = cb.curr.state.clone();
+        let lhs_nibbles = cb.query_cells::<C>();
+        let rhs_nibbles = cb.query_cells::<C>();
+        let out_nibbles = cb.query_cells::<C>();
+
+        cb.first_row(|cb| {
+            cb.require_prev_state(ExecutionState::BitwiseStage1);
+
+            // NOTICE: not necessary needed.
+            // cb.require_in_set(
+            //     "opcode in OPCODES",
+            //     step_curr.opcode.expr(),
+            //     Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
+            // );
+
+            cb.require_equal(
+                "step_counter(0) == R",
+                step_curr.step_counter.expr(),
+                R.expr(),
+            );
+        });
+
+        cb.require_no_stack_pop();
+        cb.require_no_stack_push();
+        cb.require_no_local_op();
+
+        let op = BitwiseOperation {
+            opcode: step_curr.opcode.expr(),
+            nibbles_lhs: lhs_nibbles.clone(),
+            nibbles_rhs: rhs_nibbles.clone(),
+            nibbles_out: out_nibbles.clone(),
+        };
+        LookupBitwise::lookup(cb, op);
+
+        cb.last_row(|cb| {
+            cb.require_state_transition(vec![
+                (SP, Transition::Delta((-1).expr())),
+                (PC, Transition::Delta(1.expr())),
+            ]);
+        });
+
+        BitwiseStage2 {
+            lhs_nibbles,
+            rhs_nibbles,
+            out_nibbles,
+        }
+    }
+
+    fn assign(
+        &self,
+        _step: StepState<F>,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        stage_state: &StageState,
+        static_info: &StaticInfo,
+    ) -> Result<usize, Error> {
+        // debug_assert!(!stage_state.step_states.is_empty());
+        let step_state = stage_state.step_states.first().unwrap();
+
+        debug_assert_eq!(step_state.memory_ops.len(), R);
+        let (lhs, rhs, out) = match &stage_state.extra_data {
+            Some(StageExtraAssignData::BitWise(d)) => (d.lhs, d.rhs, d.out),
+            _ => unreachable!(),
+        };
+        for (cells, value) in [
+            (&self.rhs_nibbles, rhs),
+            (&self.lhs_nibbles, lhs),
+            (&self.out_nibbles, out),
+        ] {
+            for (i, chunk) in value
+                .to_nibbles()
+                .as_chunks::<C>()
+                .0
+                .iter()
+                .cloned()
+                .enumerate()
+            {
+                for (cell, nibble) in cells.iter().zip_eq(chunk) {
+                    cell.assign(region, offset + i, Value::known(F::from(nibble as u64)))?;
+                }
+            }
+        }
+
+        Ok(step_state.memory_ops.len())
+    }
+}
 #[derive(Clone, Debug)]
 pub struct Bitwise<F> {
     nibbles: [Cell<F>; NUM_OF_BYTES_U256 * 2],
@@ -184,18 +440,18 @@ impl<F: Field> InstructionGadgetV2<F> for Bitwise<F> {
     }
 }
 
-struct BitwiseOperation<F: Field> {
+struct BitwiseOperation<F: Field, const C: usize> {
     opcode: Expression<F>,
-    nibbles_lhs: [Cell<F>; NUM_OF_BYTES_U256 * 2],
-    nibbles_rhs: [Cell<F>; NUM_OF_BYTES_U256 * 2],
-    nibbles_out: [Cell<F>; NUM_OF_BYTES_U256 * 2],
+    nibbles_lhs: [Cell<F>; C],
+    nibbles_rhs: [Cell<F>; C],
+    nibbles_out: [Cell<F>; C],
 }
 
 struct LookupBitwise<F> {
     phantom_data: PhantomData<F>,
 }
 impl<F: Field> LookupBitwise<F> {
-    fn lookup(cb: &mut ConstraintBuilderV2<F>, op: BitwiseOperation<F>) {
+    fn lookup<const C: usize>(cb: &mut ConstraintBuilderV2<F>, op: BitwiseOperation<F, C>) {
         for (operand_1, operand_2, result) in izip!(op.nibbles_lhs, op.nibbles_rhs, op.nibbles_out)
         {
             cb.add_lookup_directly(

--- a/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
@@ -253,7 +253,7 @@ impl<F: Field, const R: usize, const C: usize> InstructionGadgetV2<F> for Bitwis
 
         debug_assert_eq!(step_state.memory_ops.len(), R);
         let (lhs, rhs, out) = match &stage_state.extra_data {
-            Some(StageExtraAssignData::BitWise(d)) => (d.lhs, d.rhs, d.out),
+            Some(StageExtraAssignData::BinaryOp(d)) => (d.lhs, d.rhs, d.out),
             _ => unreachable!(),
         };
         for (cells, value) in [

--- a/vm-circuit/src/chips/execution_chip_v2/executions/borrow_field.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/borrow_field.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::executions::ExtendedSubIndex;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/br_bool.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/br_bool.rs
@@ -1,7 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/call.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/call.rs
@@ -62,22 +62,23 @@ impl<F: Field> InstructionGadgetV2<F> for CallStage1<F> {
             version: step_curr.clk.expr(),
         };
 
-        cb.add_lookup(
-            "function lookup",
-            Lookup::Function {
-                module_index: step_curr.module_index.expr(),
-                function_handle_index: step_curr.aux0.expr(),
-                def_module_index: step_next.module_index.expr(),
-                function_index: step_next.function_index.expr(),
-                num_arg: num_arg.expr(),
-                entry: 0u64.expr(),
-            },
-        );
-        cb.require_state_transition(vec![
-            (PC, Transition::To(0u64.expr())),
-            (FRAME_INDEX, Transition::Delta(1.expr())),
-        ]);
-
+        cb.condition(is_zero_num_arg.expr(), |cb| {
+            cb.add_lookup(
+                "function lookup",
+                Lookup::Function {
+                    module_index: step_curr.module_index.expr(),
+                    function_handle_index: step_curr.aux0.expr(),
+                    def_module_index: step_next.module_index.expr(),
+                    function_index: step_next.function_index.expr(),
+                    num_arg: num_arg.expr(),
+                    entry: 0u64.expr(),
+                },
+            );
+            cb.require_state_transition(vec![
+                (PC, Transition::To(0u64.expr())),
+                (FRAME_INDEX, Transition::Delta(1.expr())),
+            ]);
+        });
         cb.condition(not::expr(is_zero_num_arg.expr()), |cb| {
             cb.require_next_state(ExecutionState::CallStage2);
             cb.require_cell_transition(num_arg.clone(), Transition::Same);

--- a/vm-circuit/src/chips/execution_chip_v2/executions/cast.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/cast.rs
@@ -1,9 +1,7 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
 use crate::chips::execution_chip_v2::math_gadgets::range_check::IntegerRangeCheck;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/equality.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/equality.rs
@@ -2,9 +2,7 @@ use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::executions::SubIndexReverse;
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
 use crate::chips::execution_chip_v2::math_gadgets::lt::LtGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/ld.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/ld.rs
@@ -1,7 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/ld_bool.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/ld_bool.rs
@@ -1,7 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/ld_const.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/ld_const.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::lookup_table::Lookup;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/le_gt.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/le_gt.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::math_gadgets::comparison::ComparisonGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/lt_ge.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/lt_ge.rs
@@ -1,9 +1,7 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::math_gadgets::comparison::ComparisonGadget;
 use crate::chips::execution_chip_v2::math_gadgets::lt::LtGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
@@ -21,7 +21,7 @@ use crate::chips::utils::Expr;
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
 use aptos_move_witnesses::static_info::StaticInfo;
-use aptos_move_witnesses::step_state::StageState;
+use aptos_move_witnesses::step_state::{StageExtraAssignData, StageState};
 use gadgets::util::{or, select};
 use halo2_proofs::{
     circuit::Value,
@@ -31,54 +31,19 @@ use itertools::izip;
 use move_binary_format::file_format_common::Opcodes;
 use move_core_types::u256::U256;
 use movelang::utility::{pair_u128_to_u256, split_u256_to_u128};
+use std::marker::PhantomData;
 use types::Field;
 
 #[derive(Clone, Debug)]
-struct MulDivModCells<F> {
-    a_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    a_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    b_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    b_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    c_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    c_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    d_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    d_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    comp_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
-    lt_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
+pub struct MulDivModStage1<F> {
+    phantom_data: PhantomData<F>,
 }
-
-#[derive(Clone, Debug)]
-pub struct MulDivMod<F> {
-    bytes: [Cell<F>; NUM_OF_BYTES_U128],
-    is_first_row: IsZeroGadget<F>,
-    is_last_row: IsZeroGadget<F>,
-    is_mul: IsZeroGadget<F>,
-    is_div: IsZeroGadget<F>,
-    is_mod: IsZeroGadget<F>,
-    mul_div_mod: MulDivModGadget<F>,
-    divisor_lo_is_zero: IsZeroGadget<F>,
-    divisor_hi_is_zero: IsZeroGadget<F>,
-}
-impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
-    const NAME: &'static str = "Mul_Div_Mod";
-    const EXECUTION_STATE: ExecutionState = ExecutionState::MulDivMod;
+impl<F: Field> InstructionGadgetV2<F> for MulDivModStage1<F> {
+    const NAME: &'static str = "Mul_Div_Mod_Stage1";
+    const EXECUTION_STATE: ExecutionState = ExecutionState::MulDivModStage1;
 
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
-        let bytes = cb.query_bytes();
-        let is_first_row =
-            IsZeroGadget::construct(cb, 10u64.expr() - step_curr.step_counter.expr());
-        let is_last_row = IsZeroGadget::construct(cb, 1u64.expr() - step_curr.step_counter.expr());
-        let is_mul =
-            IsZeroGadget::construct(cb, (Opcodes::MUL as u64).expr() - step_curr.opcode.expr());
-        let is_div =
-            IsZeroGadget::construct(cb, (Opcodes::DIV as u64).expr() - step_curr.opcode.expr());
-        let is_mod =
-            IsZeroGadget::construct(cb, (Opcodes::MOD as u64).expr() - step_curr.opcode.expr());
-        let mut mul_div_mod = None;
-        let mut divisor_lo_is_zero = None;
-        let mut divisor_hi_is_zero = None;
-
         cb.first_row(|cb| {
             cb.require_in_set(
                 "opcode in OPCODES",
@@ -86,10 +51,11 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
             );
             cb.require_equal(
-                "step_counter(0) == 10",
+                "step_counter(0) == 2",
                 step_curr.step_counter.expr(),
-                10u64.expr(),
+                2u64.expr(),
             );
+            cb.require_no_stack_push();
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
                 step_curr.stack_pop_index.expr(),
@@ -97,29 +63,17 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
             );
         });
 
-        cb.not_last_row(|cb| {
-            cb.require_no_stack_push();
-            //keep sp unchanged to make assign easier
-            cb.require_state_transition(vec![(SP, Transition::Same)]);
-        });
-
-        cb.condition(or::expr([is_first_row.expr(), is_last_row.expr()]), |cb| {
-            cb.require_zero(
-                format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
-                step_curr.stack_pop_sub_index.expr(),
-            );
-            cb.require_zero(
-                format!("{}, stack_pop_value_header(0) == false", Self::NAME),
-                step_curr.stack_pop_value_header.expr(),
-            );
-        });
-
-        let middle_row = (1u64.expr() - is_first_row.expr()) * (1u64.expr() - is_last_row.expr());
-        cb.condition(middle_row, |cb| {
-            cb.require_no_stack_pop();
-        });
-
+        cb.require_zero(
+            format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
+            step_curr.stack_pop_sub_index.expr(),
+        );
+        cb.require_zero(
+            format!("{}, stack_pop_value_header(0) == false", Self::NAME),
+            step_curr.stack_pop_value_header.expr(),
+        );
         cb.require_no_local_op();
+        //keep sp unchanged to make assign easier
+        cb.require_state_transition(vec![(SP, Transition::Same)]);
 
         cb.last_row(|cb| {
             cb.require_equal(
@@ -145,11 +99,90 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 step_curr.stack_push_version.expr(),
                 step_curr.clk.expr(),
             );
+        });
 
-            let lhs = step_curr.stack_pop_value.as_integer();
-            let step_first = cb.step_state_at_offset(-9);
-            let rhs = step_first.stack_pop_value.as_integer();
-            let out = step_curr.stack_push_value.as_integer();
+        cb.last_row(|cb| {
+            cb.require_next_state(ExecutionState::MulDivModStage2);
+            cb.require_state_transition(vec![(PC, Transition::Same)]);
+        });
+
+        MulDivModStage1 {
+            phantom_data: PhantomData,
+        }
+    }
+
+    fn assign(
+        &self,
+        _step: StepState<F>,
+        _region: &mut CachedRegion<'_, '_, F>,
+        _offset: usize,
+        stage_state: &StageState,
+        _static_info: &StaticInfo,
+    ) -> Result<usize, Error> {
+        // no need to assign anything else
+        Ok(stage_state.rows())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MulDivModCells<F> {
+    a_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    a_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    b_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    b_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    c_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    c_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    d_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    d_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    bytes_1: [Cell<F>; NUM_OF_BYTES_U128], // used for remainder_lt_divisor
+    bytes_2: [Cell<F>; NUM_OF_BYTES_U128], // used for remainder_lt_divisor
+}
+
+#[derive(Clone, Debug)]
+pub struct MulDivModStage2<F> {
+    bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    is_mul: IsZeroGadget<F>,
+    is_div: IsZeroGadget<F>,
+    is_mod: IsZeroGadget<F>,
+    mul_div_mod: MulDivModGadget<F>,
+    divisor_lo_is_zero: IsZeroGadget<F>,
+    divisor_hi_is_zero: IsZeroGadget<F>,
+}
+impl<F: Field> InstructionGadgetV2<F> for MulDivModStage2<F> {
+    const NAME: &'static str = "Mul_Div_Mod_Stage2";
+    const EXECUTION_STATE: ExecutionState = ExecutionState::MulDivModStage2;
+
+    fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        let bytes = cb.query_bytes();
+
+        let mut is_mul = None;
+        let mut is_div = None;
+        let mut is_mod = None;
+        let mut mul_div_mod = None;
+        let mut divisor_lo_is_zero = None;
+        let mut divisor_hi_is_zero = None;
+        let step_curr = cb.curr.state.clone();
+
+        cb.first_row(|cb| {
+            cb.require_prev_state(ExecutionState::MulDivModStage1);
+            cb.require_equal(
+                "step_counter(0) == 10",
+                step_curr.step_counter.expr(),
+                10u64.expr(),
+            );
+        });
+
+        cb.require_no_stack_pop();
+        cb.require_no_stack_push();
+        cb.require_no_local_op();
+
+        cb.last_row(|cb| {
+            let step_first_of_stage1 = cb.step_state_at_offset(-11);
+            let step_last_of_stage1 = cb.step_state_at_offset(-10);
+
+            let lhs = step_last_of_stage1.stack_pop_value.as_integer();
+            let rhs = step_first_of_stage1.stack_pop_value.as_integer();
+            let out = step_last_of_stage1.stack_push_value.as_integer();
             let cells = MulDivModCells {
                 a_lo: cb.cells_at_offset(bytes.clone(), -9),
                 a_hi: cb.cells_at_offset(bytes.clone(), -8),
@@ -159,10 +192,16 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 c_hi: cb.cells_at_offset(bytes.clone(), -4),
                 d_lo: cb.cells_at_offset(bytes.clone(), -3),
                 d_hi: cb.cells_at_offset(bytes.clone(), -2),
-                comp_gadget_bytes: cb.cells_at_offset(bytes.clone(), -1),
-                lt_gadget_bytes: bytes.clone(),
+                bytes_1: cb.cells_at_offset(bytes.clone(), -1),
+                bytes_2: bytes.clone(),
             };
 
+            let is_mul_ =
+                IsZeroGadget::construct(cb, (Opcodes::MUL as u64).expr() - step_curr.opcode.expr());
+            let is_div_ =
+                IsZeroGadget::construct(cb, (Opcodes::DIV as u64).expr() - step_curr.opcode.expr());
+            let is_mod_ =
+                IsZeroGadget::construct(cb, (Opcodes::MOD as u64).expr() - step_curr.opcode.expr());
             let divisor_lo_is_zero_ = IsZeroGadget::construct(cb, rhs.lo());
             let divisor_hi_is_zero_ = IsZeroGadget::construct(cb, rhs.hi());
             let divisor_is_zero = divisor_lo_is_zero_.expr() * divisor_hi_is_zero_.expr();
@@ -172,15 +211,15 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 lhs,
                 rhs,
                 out,
-                is_mul.expr(),
-                is_div.expr(),
-                is_mod.expr(),
+                is_mul_.expr(),
+                is_div_.expr(),
+                is_mod_.expr(),
                 step_curr.aux0.expr(), //n_bytes
                 divisor_is_zero.clone(),
             );
 
             // for Div&Mod, go to Error state if divisor == 0
-            let divide_by_zero = (1u64.expr() - is_mul.expr()) * divisor_is_zero;
+            let divide_by_zero = (1u64.expr() - is_mul_.expr()) * divisor_is_zero;
             let overflow = mul_div_mod_.overflow();
             let error = or::expr([divide_by_zero, overflow]);
             cb.condition(error.clone(), |cb| {
@@ -193,18 +232,19 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                     (PC, Transition::Delta(1.expr())),
                 ]);
             });
+            is_mul = Some(is_mul_);
+            is_div = Some(is_div_);
+            is_mod = Some(is_mod_);
             divisor_lo_is_zero = Some(divisor_lo_is_zero_);
             divisor_hi_is_zero = Some(divisor_hi_is_zero_);
             mul_div_mod = Some(mul_div_mod_);
         });
 
-        MulDivMod {
+        MulDivModStage2 {
             bytes,
-            is_first_row,
-            is_last_row,
-            is_mul,
-            is_div,
-            is_mod,
+            is_mul: is_mul.unwrap(),
+            is_div: is_div.unwrap(),
+            is_mod: is_mod.unwrap(),
             mul_div_mod: mul_div_mod.unwrap(),
             divisor_lo_is_zero: divisor_lo_is_zero.unwrap(),
             divisor_hi_is_zero: divisor_hi_is_zero.unwrap(),
@@ -230,44 +270,31 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         let is_mul = opcode == Opcodes::MUL as u8;
         let is_div = opcode == Opcodes::DIV as u8;
         let is_mod = opcode == Opcodes::MOD as u8;
-
         let num_bytes = step_state.step_state.aux0 as usize;
-        let rhs = step_state.memory_ops[0].0.clone().unwrap().value;
-        let lhs = step_state.memory_ops[9].0.clone().unwrap().value;
-        let out = step_state.memory_ops[9].1.clone().unwrap().value;
-        let rhs_lo = rhs.lo();
-        let rhs_hi = rhs.hi();
-        let lhs_lo = lhs.lo();
-        let lhs_hi = lhs.hi();
-        let out_lo = out.lo();
-        let out_hi = out.hi();
+        let (lhs, rhs, out) = match &stage_state.extra_data {
+            Some(StageExtraAssignData::BinaryOp(d)) => (d.lhs, d.rhs, d.out),
+            _ => unreachable!(),
+        };
+        let (rhs_lo, rhs_hi) = split_u256_to_u128(rhs);
+        let (lhs_lo, lhs_hi) = split_u256_to_u128(lhs);
+        let (out_lo, out_hi) = split_u256_to_u128(out);
 
         debug_assert_eq!(step_state.memory_ops.len(), 10);
-        for i in 0..step_state.memory_ops.len() {
-            self.is_first_row.assign(
-                region,
-                offset + i,
-                F::from(10u64) - F::from(10 - i as u64),
-            )?;
-            self.is_last_row
-                .assign(region, offset + i, F::from(1u64) - F::from(10 - i as u64))?;
-            self.is_mul.assign(
-                region,
-                offset + i,
-                F::from(Opcodes::MUL as u64) - F::from(step_state.step_state.opcode as u64),
-            )?;
-            self.is_div.assign(
-                region,
-                offset + i,
-                F::from(Opcodes::DIV as u64) - F::from(step_state.step_state.opcode as u64),
-            )?;
-            self.is_mod.assign(
-                region,
-                offset + i,
-                F::from(Opcodes::MOD as u64) - F::from(step_state.step_state.opcode as u64),
-            )?;
-        }
-
+        self.is_mul.assign(
+            region,
+            offset + 9,
+            F::from(Opcodes::MUL as u64) - F::from(step_state.step_state.opcode as u64),
+        )?;
+        self.is_div.assign(
+            region,
+            offset + 9,
+            F::from(Opcodes::DIV as u64) - F::from(step_state.step_state.opcode as u64),
+        )?;
+        self.is_mod.assign(
+            region,
+            offset + 9,
+            F::from(Opcodes::MOD as u64) - F::from(step_state.step_state.opcode as u64),
+        )?;
         self.mul_div_mod.assign(
             region,
             offset + 9,
@@ -388,14 +415,14 @@ impl<F: Field> MulDivModGadget<F> {
         // for Div&Mod, remainder(c) < divisor(b) when divisor != 0
         // for Div&Mod, overflow == 0
         cb.require_zero("c == 0 for Mul", c.clone() * is_mul.clone());
-        let remainder_lt_divisor = LtInteger::construct_from_bytes(
+        let remainder_lt_divisor = LtInteger::construct_from_given_bytes(
             cb,
             c_lo,
             c_hi,
             b_lo,
             b_hi,
-            cells.comp_gadget_bytes.clone(),
-            cells.lt_gadget_bytes.clone(),
+            cells.bytes_1.clone(),
+            cells.bytes_2.clone(),
         );
         cb.require_zero(
             "remainder < divisor when divisor != 0",

--- a/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
@@ -43,6 +43,8 @@ struct MulDivModCells<F> {
     c_hi: [Cell<F>; NUM_OF_BYTES_U128],
     d_lo: [Cell<F>; NUM_OF_BYTES_U128],
     d_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    comp_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    lt_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
 }
 
 #[derive(Clone, Debug)]
@@ -64,7 +66,8 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
         let bytes = cb.query_bytes();
-        let is_first_row = IsZeroGadget::construct(cb, 8u64.expr() - step_curr.step_counter.expr());
+        let is_first_row =
+            IsZeroGadget::construct(cb, 10u64.expr() - step_curr.step_counter.expr());
         let is_last_row = IsZeroGadget::construct(cb, 1u64.expr() - step_curr.step_counter.expr());
         let is_mul =
             IsZeroGadget::construct(cb, (Opcodes::MUL as u64).expr() - step_curr.opcode.expr());
@@ -83,9 +86,9 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
             );
             cb.require_equal(
-                "step_counter(0) == 8",
+                "step_counter(0) == 10",
                 step_curr.step_counter.expr(),
-                8u64.expr(),
+                10u64.expr(),
             );
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
@@ -144,18 +147,20 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
             );
 
             let lhs = step_curr.stack_pop_value.as_integer();
-            let step_first = cb.step_state_at_offset(-7);
+            let step_first = cb.step_state_at_offset(-9);
             let rhs = step_first.stack_pop_value.as_integer();
             let out = step_curr.stack_push_value.as_integer();
             let cells = MulDivModCells {
-                a_lo: cb.cells_at_offset(bytes.clone(), -7),
-                a_hi: cb.cells_at_offset(bytes.clone(), -6),
-                b_lo: cb.cells_at_offset(bytes.clone(), -5),
-                b_hi: cb.cells_at_offset(bytes.clone(), -4),
-                c_lo: cb.cells_at_offset(bytes.clone(), -3),
-                c_hi: cb.cells_at_offset(bytes.clone(), -2),
-                d_lo: cb.cells_at_offset(bytes.clone(), -1),
-                d_hi: bytes.clone(),
+                a_lo: cb.cells_at_offset(bytes.clone(), -9),
+                a_hi: cb.cells_at_offset(bytes.clone(), -8),
+                b_lo: cb.cells_at_offset(bytes.clone(), -7),
+                b_hi: cb.cells_at_offset(bytes.clone(), -6),
+                c_lo: cb.cells_at_offset(bytes.clone(), -5),
+                c_hi: cb.cells_at_offset(bytes.clone(), -4),
+                d_lo: cb.cells_at_offset(bytes.clone(), -3),
+                d_hi: cb.cells_at_offset(bytes.clone(), -2),
+                comp_gadget_bytes: cb.cells_at_offset(bytes.clone(), -1),
+                lt_gadget_bytes: bytes.clone(),
             };
 
             let divisor_lo_is_zero_ = IsZeroGadget::construct(cb, rhs.lo());
@@ -228,8 +233,8 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
 
         let num_bytes = step_state.step_state.aux0 as usize;
         let rhs = step_state.memory_ops[0].0.clone().unwrap().value;
-        let lhs = step_state.memory_ops[7].0.clone().unwrap().value;
-        let out = step_state.memory_ops[7].1.clone().unwrap().value;
+        let lhs = step_state.memory_ops[9].0.clone().unwrap().value;
+        let out = step_state.memory_ops[9].1.clone().unwrap().value;
         let rhs_lo = rhs.lo();
         let rhs_hi = rhs.hi();
         let lhs_lo = lhs.lo();
@@ -237,12 +242,15 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         let out_lo = out.lo();
         let out_hi = out.hi();
 
-        debug_assert_eq!(step_state.memory_ops.len(), 8);
+        debug_assert_eq!(step_state.memory_ops.len(), 10);
         for i in 0..step_state.memory_ops.len() {
-            self.is_first_row
-                .assign(region, offset + i, F::from(8u64) - F::from(8 - i as u64))?;
+            self.is_first_row.assign(
+                region,
+                offset + i,
+                F::from(10u64) - F::from(10 - i as u64),
+            )?;
             self.is_last_row
-                .assign(region, offset + i, F::from(1u64) - F::from(8 - i as u64))?;
+                .assign(region, offset + i, F::from(1u64) - F::from(10 - i as u64))?;
             self.is_mul.assign(
                 region,
                 offset + i,
@@ -262,7 +270,7 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
 
         self.mul_div_mod.assign(
             region,
-            offset + 7,
+            offset + 9,
             is_mul,
             is_div,
             is_mod,
@@ -276,9 +284,9 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         )?;
 
         self.divisor_lo_is_zero
-            .assign(region, offset + 7, F::from_u128(rhs_lo))?;
+            .assign(region, offset + 9, F::from_u128(rhs_lo))?;
         self.divisor_hi_is_zero
-            .assign(region, offset + 7, F::from_u128(rhs_hi))?;
+            .assign(region, offset + 9, F::from_u128(rhs_hi))?;
         Ok(step_state.memory_ops.len())
     }
 }
@@ -380,7 +388,15 @@ impl<F: Field> MulDivModGadget<F> {
         // for Div&Mod, remainder(c) < divisor(b) when divisor != 0
         // for Div&Mod, overflow == 0
         cb.require_zero("c == 0 for Mul", c.clone() * is_mul.clone());
-        let remainder_lt_divisor = LtInteger::construct(cb, c_lo, c_hi, b_lo, b_hi);
+        let remainder_lt_divisor = LtInteger::construct_from_bytes(
+            cb,
+            c_lo,
+            c_hi,
+            b_lo,
+            b_hi,
+            cells.comp_gadget_bytes.clone(),
+            cells.lt_gadget_bytes.clone(),
+        );
         cb.require_zero(
             "remainder < divisor when divisor != 0",
             (1u64.expr() - remainder_lt_divisor.expr())

--- a/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/mul_div_mod.rs
@@ -5,9 +5,7 @@ use crate::chips::execution_chip_v2::math_gadgets::lt::LtInteger;
 use crate::chips::execution_chip_v2::math_gadgets::mul_add::MulAddExprs;
 use crate::chips::execution_chip_v2::math_gadgets::mul_add::MulAddGadget;
 use crate::chips::execution_chip_v2::math_gadgets::range_check::IntegerRangeCheck;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,
@@ -49,10 +47,9 @@ struct MulDivModCells<F> {
 
 #[derive(Clone, Debug)]
 pub struct MulDivMod<F> {
-    bytes_1_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    bytes_1_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    bytes_2_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    bytes_2_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    is_first_row: IsZeroGadget<F>,
+    is_last_row: IsZeroGadget<F>,
     is_mul: IsZeroGadget<F>,
     is_div: IsZeroGadget<F>,
     is_mod: IsZeroGadget<F>,
@@ -66,11 +63,9 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
 
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
-        let step_prev = cb.step_state_at_offset(-1);
-        let bytes_1_lo = cb.query_bytes();
-        let bytes_1_hi = cb.query_bytes();
-        let bytes_2_lo = cb.query_bytes();
-        let bytes_2_hi = cb.query_bytes();
+        let bytes = cb.query_bytes();
+        let is_first_row = IsZeroGadget::construct(cb, 8u64.expr() - step_curr.step_counter.expr());
+        let is_last_row = IsZeroGadget::construct(cb, 1u64.expr() - step_curr.step_counter.expr());
         let is_mul =
             IsZeroGadget::construct(cb, (Opcodes::MUL as u64).expr() - step_curr.opcode.expr());
         let is_div =
@@ -88,28 +83,39 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
                 Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
             );
             cb.require_equal(
-                "step_counter(0) == 2",
+                "step_counter(0) == 8",
                 step_curr.step_counter.expr(),
-                2u64.expr(),
+                8u64.expr(),
             );
-            cb.require_no_stack_push();
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
                 step_curr.stack_pop_index.expr(),
                 step_curr.sp.expr(),
             );
+        });
+
+        cb.not_last_row(|cb| {
+            cb.require_no_stack_push();
             //keep sp unchanged to make assign easier
             cb.require_state_transition(vec![(SP, Transition::Same)]);
         });
 
-        cb.require_zero(
-            format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
-            step_curr.stack_pop_sub_index.expr(),
-        );
-        cb.require_zero(
-            format!("{}, stack_pop_value_header(0) == false", Self::NAME),
-            step_curr.stack_pop_value_header.expr(),
-        );
+        cb.condition(or::expr([is_first_row.expr(), is_last_row.expr()]), |cb| {
+            cb.require_zero(
+                format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
+                step_curr.stack_pop_sub_index.expr(),
+            );
+            cb.require_zero(
+                format!("{}, stack_pop_value_header(0) == false", Self::NAME),
+                step_curr.stack_pop_value_header.expr(),
+            );
+        });
+
+        let middle_row = (1u64.expr() - is_first_row.expr()) * (1u64.expr() - is_last_row.expr());
+        cb.condition(middle_row, |cb| {
+            cb.require_no_stack_pop();
+        });
+
         cb.require_no_local_op();
 
         cb.last_row(|cb| {
@@ -138,17 +144,18 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
             );
 
             let lhs = step_curr.stack_pop_value.as_integer();
-            let rhs = step_prev.stack_pop_value.as_integer();
+            let step_first = cb.step_state_at_offset(-7);
+            let rhs = step_first.stack_pop_value.as_integer();
             let out = step_curr.stack_push_value.as_integer();
             let cells = MulDivModCells {
-                a_lo: cb.cells_at_offset(bytes_1_lo.clone(), -1),
-                a_hi: cb.cells_at_offset(bytes_1_hi.clone(), -1),
-                b_lo: cb.cells_at_offset(bytes_2_lo.clone(), -1),
-                b_hi: cb.cells_at_offset(bytes_2_hi.clone(), -1),
-                c_lo: bytes_1_lo.clone(),
-                c_hi: bytes_1_hi.clone(),
-                d_lo: bytes_2_lo.clone(),
-                d_hi: bytes_2_hi.clone(),
+                a_lo: cb.cells_at_offset(bytes.clone(), -7),
+                a_hi: cb.cells_at_offset(bytes.clone(), -6),
+                b_lo: cb.cells_at_offset(bytes.clone(), -5),
+                b_hi: cb.cells_at_offset(bytes.clone(), -4),
+                c_lo: cb.cells_at_offset(bytes.clone(), -3),
+                c_hi: cb.cells_at_offset(bytes.clone(), -2),
+                d_lo: cb.cells_at_offset(bytes.clone(), -1),
+                d_hi: bytes.clone(),
             };
 
             let divisor_lo_is_zero_ = IsZeroGadget::construct(cb, rhs.lo());
@@ -187,10 +194,9 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         });
 
         MulDivMod {
-            bytes_1_lo,
-            bytes_1_hi,
-            bytes_2_lo,
-            bytes_2_hi,
+            bytes,
+            is_first_row,
+            is_last_row,
             is_mul,
             is_div,
             is_mod,
@@ -206,7 +212,7 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         stage_state: &StageState,
-        static_info: &StaticInfo,
+        _static_info: &StaticInfo,
     ) -> Result<usize, Error> {
         debug_assert!(!stage_state.step_states.is_empty());
         let step_state = stage_state.step_states.first().unwrap();
@@ -222,8 +228,8 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
 
         let num_bytes = step_state.step_state.aux0 as usize;
         let rhs = step_state.memory_ops[0].0.clone().unwrap().value;
-        let lhs = step_state.memory_ops[1].0.clone().unwrap().value;
-        let out = step_state.memory_ops[1].1.clone().unwrap().value;
+        let lhs = step_state.memory_ops[7].0.clone().unwrap().value;
+        let out = step_state.memory_ops[7].1.clone().unwrap().value;
         let rhs_lo = rhs.lo();
         let rhs_hi = rhs.hi();
         let lhs_lo = lhs.lo();
@@ -231,8 +237,12 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         let out_lo = out.lo();
         let out_hi = out.hi();
 
-        debug_assert_eq!(step_state.memory_ops.len(), 2);
+        debug_assert_eq!(step_state.memory_ops.len(), 8);
         for i in 0..step_state.memory_ops.len() {
+            self.is_first_row
+                .assign(region, offset + i, F::from(8u64) - F::from(8 - i as u64))?;
+            self.is_last_row
+                .assign(region, offset + i, F::from(1u64) - F::from(8 - i as u64))?;
             self.is_mul.assign(
                 region,
                 offset + i,
@@ -252,7 +262,7 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
 
         self.mul_div_mod.assign(
             region,
-            offset + 1,
+            offset + 7,
             is_mul,
             is_div,
             is_mod,
@@ -266,9 +276,9 @@ impl<F: Field> InstructionGadgetV2<F> for MulDivMod<F> {
         )?;
 
         self.divisor_lo_is_zero
-            .assign(region, offset + 1, F::from_u128(rhs_lo))?;
+            .assign(region, offset + 7, F::from_u128(rhs_lo))?;
         self.divisor_hi_is_zero
-            .assign(region, offset + 1, F::from_u128(rhs_hi))?;
+            .assign(region, offset + 7, F::from_u128(rhs_hi))?;
         Ok(step_state.memory_ops.len())
     }
 }

--- a/vm-circuit/src/chips/execution_chip_v2/executions/not.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/not.rs
@@ -1,7 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/pack.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/pack.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::{ExecutionState, DEPTH_POW_OF_ONE_LEVEL};
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/pop.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/pop.rs
@@ -1,7 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/read_ref.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/read_ref.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::executions::ExtendedSubIndex;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/shl_shr.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/shl_shr.rs
@@ -5,9 +5,7 @@ use crate::chips::execution_chip_v2::math_gadgets::lt::{LtGadget, LtInteger};
 use crate::chips::execution_chip_v2::math_gadgets::mul_add::MulAddExprs;
 use crate::chips::execution_chip_v2::math_gadgets::mul_add::MulAddGadget;
 use crate::chips::execution_chip_v2::opcode::Opcode;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,
@@ -24,7 +22,7 @@ use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
 use aptos_move_witnesses::static_info::StaticInfo;
 use aptos_move_witnesses::step_state::StageState;
-use gadgets::util::select;
+use gadgets::util::{or, select};
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
@@ -48,10 +46,9 @@ struct ShiftCells<F> {
 
 #[derive(Clone, Debug)]
 pub struct Shift<F> {
-    bytes_1_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    bytes_1_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    bytes_2_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    bytes_2_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    is_first_row: IsZeroGadget<F>,
+    is_last_row: IsZeroGadget<F>,
     is_shl: IsZeroGadget<F>,
     shift_gadget: ShiftGadget<F>,
     rhs_lt256: LtGadget<F, NUM_OF_BYTES_U8>,
@@ -73,11 +70,9 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
 
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
-        let step_prev = cb.step_state_at_offset(-1);
-        let bytes_1_lo = cb.query_bytes();
-        let bytes_1_hi = cb.query_bytes();
-        let bytes_2_lo = cb.query_bytes();
-        let bytes_2_hi = cb.query_bytes();
+        let bytes = cb.query_bytes();
+        let is_first_row = IsZeroGadget::construct(cb, 8u64.expr() - step_curr.step_counter.expr());
+        let is_last_row = IsZeroGadget::construct(cb, 1u64.expr() - step_curr.step_counter.expr());
         let is_shl =
             IsZeroGadget::construct(cb, (Opcode::Shl as u64).expr() - step_curr.opcode.expr());
         let mut shift_gadget = None;
@@ -107,28 +102,39 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
                 Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
             );
             cb.require_equal(
-                "step_counter(0) == 2",
+                "step_counter(0) == 8",
                 step_curr.step_counter.expr(),
-                2u64.expr(),
+                8u64.expr(),
             );
-            cb.require_no_stack_push();
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
                 step_curr.stack_pop_index.expr(),
                 step_curr.sp.expr(),
             );
+        });
+
+        cb.not_last_row(|cb| {
+            cb.require_no_stack_push();
             //keep sp unchanged to make assign easier
             cb.require_state_transition(vec![(SP, Transition::Same)]);
         });
 
-        cb.require_zero(
-            format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
-            step_curr.stack_pop_sub_index.expr(),
-        );
-        cb.require_zero(
-            format!("{}, stack_pop_value_header(0) == false", Self::NAME),
-            step_curr.stack_pop_value_header.expr(),
-        );
+        cb.condition(or::expr([is_first_row.expr(), is_last_row.expr()]), |cb| {
+            cb.require_zero(
+                format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
+                step_curr.stack_pop_sub_index.expr(),
+            );
+            cb.require_zero(
+                format!("{}, stack_pop_value_header(0) == false", Self::NAME),
+                step_curr.stack_pop_value_header.expr(),
+            );
+        });
+
+        let middle_row = (1u64.expr() - is_first_row.expr()) * (1u64.expr() - is_last_row.expr());
+        cb.condition(middle_row, |cb| {
+            cb.require_no_stack_pop();
+        });
+
         cb.require_no_local_op();
 
         cb.last_row(|cb| {
@@ -157,7 +163,8 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             );
 
             let lhs = step_curr.stack_pop_value.as_integer();
-            let rhs = step_prev.stack_pop_value.as_integer();
+            let step_first = cb.step_state_at_offset(-7);
+            let rhs = step_first.stack_pop_value.as_integer();
             let out = step_curr.stack_push_value.as_integer();
 
             let rhs_lt_256 = LtGadget::construct(cb, rhs.expr(), 256u64.expr());
@@ -185,14 +192,14 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             });
 
             let cells = ShiftCells {
-                a_lo: cb.cells_at_offset(bytes_1_lo.clone(), -1),
-                a_hi: cb.cells_at_offset(bytes_1_hi.clone(), -1),
-                b_lo: cb.cells_at_offset(bytes_2_lo.clone(), -1),
-                b_hi: cb.cells_at_offset(bytes_2_hi.clone(), -1),
-                c_lo: bytes_1_lo.clone(),
-                c_hi: bytes_1_hi.clone(),
-                d_lo: bytes_2_lo.clone(),
-                d_hi: bytes_2_hi.clone(),
+                a_lo: cb.cells_at_offset(bytes.clone(), -7),
+                a_hi: cb.cells_at_offset(bytes.clone(), -6),
+                b_lo: cb.cells_at_offset(bytes.clone(), -5),
+                b_hi: cb.cells_at_offset(bytes.clone(), -4),
+                c_lo: cb.cells_at_offset(bytes.clone(), -3),
+                c_hi: cb.cells_at_offset(bytes.clone(), -2),
+                d_lo: cb.cells_at_offset(bytes.clone(), -1),
+                d_hi: bytes.clone(),
             };
 
             let shift = ShiftGadget::construct(
@@ -225,10 +232,9 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
         });
 
         Shift {
-            bytes_1_lo,
-            bytes_1_hi,
-            bytes_2_lo,
-            bytes_2_hi,
+            bytes,
+            is_first_row,
+            is_last_row,
             is_shl,
             shift_gadget: shift_gadget.unwrap(),
             rhs_lt256: rhs_lt256.unwrap(),
@@ -262,15 +268,19 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
         let num_bytes = step_state.step_state.aux0 as usize;
         let pop0 = step_state.memory_ops[0].0.clone().unwrap().value;
         let rhs = pop0.to_u8_unchecked();
-        let lhs = step_state.memory_ops[1].0.clone().unwrap().value;
-        let out = step_state.memory_ops[1].1.clone().unwrap().value;
+        let lhs = step_state.memory_ops[7].0.clone().unwrap().value;
+        let out = step_state.memory_ops[7].1.clone().unwrap().value;
         let lhs_lo = lhs.lo();
         let lhs_hi = lhs.hi();
         let out_lo = out.lo();
         let out_hi = out.hi();
 
-        debug_assert_eq!(step_state.memory_ops.len(), 2);
+        debug_assert_eq!(step_state.memory_ops.len(), 8);
         for i in 0..step_state.memory_ops.len() {
+            self.is_first_row
+                .assign(region, offset + i, F::from(8u64) - F::from(8 - i as u64))?;
+            self.is_last_row
+                .assign(region, offset + i, F::from(1u64) - F::from(8 - i as u64))?;
             self.is_shl.assign(
                 region,
                 offset + i,
@@ -311,7 +321,7 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
         //for below gadget, we only assign the last row
         self.shift_gadget.assign(
             region,
-            offset + 1,
+            offset + 7,
             is_shl,
             rhs,
             lhs_lo,
@@ -320,17 +330,17 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             out_hi,
         )?;
         self.rhs_lt256
-            .assign(region, offset + 1, F::from(rhs as u64), F::from(256u64))?;
+            .assign(region, offset + 7, F::from(rhs as u64), F::from(256u64))?;
         self.rhs_lt128
-            .assign(region, offset + 1, F::from(rhs as u64), F::from(128u64))?;
+            .assign(region, offset + 7, F::from(rhs as u64), F::from(128u64))?;
         self.rhs_lt64
-            .assign(region, offset + 1, F::from(rhs as u64), F::from(64u64))?;
+            .assign(region, offset + 7, F::from(rhs as u64), F::from(64u64))?;
         self.rhs_lt32
-            .assign(region, offset + 1, F::from(rhs as u64), F::from(32u64))?;
+            .assign(region, offset + 7, F::from(rhs as u64), F::from(32u64))?;
         self.rhs_lt16
-            .assign(region, offset + 1, F::from(rhs as u64), F::from(16u64))?;
+            .assign(region, offset + 7, F::from(rhs as u64), F::from(16u64))?;
         self.rhs_lt8
-            .assign(region, offset + 1, F::from(rhs as u64), F::from(8u64))?;
+            .assign(region, offset + 7, F::from(rhs as u64), F::from(8u64))?;
 
         Ok(step_state.memory_ops.len())
     }

--- a/vm-circuit/src/chips/execution_chip_v2/executions/shl_shr.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/shl_shr.rs
@@ -1,4 +1,4 @@
-use crate::chips::execution_chip_v2::executions::ExecutionState;
+use crate::chips::execution_chip_v2::executions::{ExecutionState, MulDivModStage2};
 use crate::chips::execution_chip_v2::lookup_table::Lookup;
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
 use crate::chips::execution_chip_v2::math_gadgets::lt::{LtGadget, LtInteger};
@@ -21,8 +21,8 @@ use crate::chips::utils::Expr;
 use crate::utils::cached_region::CachedRegion;
 use crate::utils::cell_manager::Cell;
 use aptos_move_witnesses::static_info::StaticInfo;
-use aptos_move_witnesses::step_state::StageState;
-use gadgets::util::{or, select};
+use aptos_move_witnesses::step_state::{StageExtraAssignData, StageState};
+use gadgets::util::select;
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
@@ -30,74 +30,19 @@ use halo2_proofs::{
 use itertools::izip;
 use move_core_types::u256::U256;
 use movelang::utility::{pair_u128_to_u256, split_u256_to_u128};
+use std::marker::PhantomData;
 use types::Field;
 
 #[derive(Clone, Debug)]
-struct ShiftCells<F> {
-    a_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    a_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    b_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    b_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    c_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    c_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    d_lo: [Cell<F>; NUM_OF_BYTES_U128],
-    d_hi: [Cell<F>; NUM_OF_BYTES_U128],
-    comp_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
-    lt_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
+pub struct ShiftStage1<F> {
+    phantom_data: PhantomData<F>,
 }
-
-#[derive(Clone, Debug)]
-pub struct Shift<F> {
-    bytes: [Cell<F>; NUM_OF_BYTES_U128],
-    is_first_row: IsZeroGadget<F>,
-    is_last_row: IsZeroGadget<F>,
-    is_shl: IsZeroGadget<F>,
-    shift_gadget: ShiftGadget<F>,
-    rhs_lt256: LtGadget<F, NUM_OF_BYTES_U8>,
-    rhs_lt128: LtGadget<F, NUM_OF_BYTES_U8>,
-    rhs_lt64: LtGadget<F, NUM_OF_BYTES_U8>,
-    rhs_lt32: LtGadget<F, NUM_OF_BYTES_U8>,
-    rhs_lt16: LtGadget<F, NUM_OF_BYTES_U8>,
-    rhs_lt8: LtGadget<F, NUM_OF_BYTES_U8>,
-    is_u8: IsZeroGadget<F>,
-    is_u16: IsZeroGadget<F>,
-    is_u32: IsZeroGadget<F>,
-    is_u64: IsZeroGadget<F>,
-    is_u128: IsZeroGadget<F>,
-    is_u256: IsZeroGadget<F>,
-}
-impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
-    const NAME: &'static str = "Shift";
-    const EXECUTION_STATE: ExecutionState = ExecutionState::Shift;
+impl<F: Field> InstructionGadgetV2<F> for ShiftStage1<F> {
+    const NAME: &'static str = "ShiftStage1";
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ShiftStage1;
 
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
-        let bytes = cb.query_bytes();
-        let is_first_row =
-            IsZeroGadget::construct(cb, 10u64.expr() - step_curr.step_counter.expr());
-        let is_last_row = IsZeroGadget::construct(cb, 1u64.expr() - step_curr.step_counter.expr());
-        let is_shl =
-            IsZeroGadget::construct(cb, (Opcode::Shl as u64).expr() - step_curr.opcode.expr());
-        let mut shift_gadget = None;
-        let mut rhs_lt256 = None;
-        let mut rhs_lt128 = None;
-        let mut rhs_lt64 = None;
-        let mut rhs_lt32 = None;
-        let mut rhs_lt16 = None;
-        let mut rhs_lt8 = None;
-
-        let n_bytes = step_curr.aux0.expr();
-        let is_u8 = IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U8 as u64).expr());
-        let is_u16 =
-            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U16 as u64).expr());
-        let is_u32 =
-            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U32 as u64).expr());
-        let is_u64 =
-            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U64 as u64).expr());
-        let is_u128 =
-            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U128 as u64).expr());
-        let is_u256 =
-            IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U256 as u64).expr());
         cb.first_row(|cb| {
             cb.require_in_set(
                 "opcode in OPCODES",
@@ -105,10 +50,11 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
                 Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
             );
             cb.require_equal(
-                "step_counter(0) == 10",
+                "step_counter(0) == 2",
                 step_curr.step_counter.expr(),
-                10u64.expr(),
+                2u64.expr(),
             );
+            cb.require_no_stack_push();
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
                 step_curr.stack_pop_index.expr(),
@@ -116,29 +62,17 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             );
         });
 
-        cb.not_last_row(|cb| {
-            cb.require_no_stack_push();
-            //keep sp unchanged to make assign easier
-            cb.require_state_transition(vec![(SP, Transition::Same)]);
-        });
-
-        cb.condition(or::expr([is_first_row.expr(), is_last_row.expr()]), |cb| {
-            cb.require_zero(
-                format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
-                step_curr.stack_pop_sub_index.expr(),
-            );
-            cb.require_zero(
-                format!("{}, stack_pop_value_header(0) == false", Self::NAME),
-                step_curr.stack_pop_value_header.expr(),
-            );
-        });
-
-        let middle_row = (1u64.expr() - is_first_row.expr()) * (1u64.expr() - is_last_row.expr());
-        cb.condition(middle_row, |cb| {
-            cb.require_no_stack_pop();
-        });
-
+        cb.require_zero(
+            format!("{}, stack_pop_sub_index(0) == 0", Self::NAME),
+            step_curr.stack_pop_sub_index.expr(),
+        );
+        cb.require_zero(
+            format!("{}, stack_pop_value_header(0) == false", Self::NAME),
+            step_curr.stack_pop_value_header.expr(),
+        );
         cb.require_no_local_op();
+        //keep sp unchanged to make assign easier
+        cb.require_state_transition(vec![(SP, Transition::Same)]);
 
         cb.last_row(|cb| {
             cb.require_equal(
@@ -164,36 +98,106 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
                 step_curr.stack_push_version.expr(),
                 step_curr.clk.expr(),
             );
+        });
 
-            let lhs = step_curr.stack_pop_value.as_integer();
-            let step_first = cb.step_state_at_offset(-9);
-            let rhs = step_first.stack_pop_value.as_integer();
-            let out = step_curr.stack_push_value.as_integer();
+        cb.last_row(|cb| {
+            cb.require_next_state(ExecutionState::ShiftStage2);
+            cb.require_state_transition(vec![(PC, Transition::Same)]);
+        });
 
-            let rhs_lt_256 = LtGadget::construct(cb, rhs.expr(), 256u64.expr());
-            let rhs_lt_128 = LtGadget::construct(cb, rhs.expr(), 128u64.expr());
-            let rhs_lt_64 = LtGadget::construct(cb, rhs.expr(), 64u64.expr());
-            let rhs_lt_32 = LtGadget::construct(cb, rhs.expr(), 32u64.expr());
-            let rhs_lt_16 = LtGadget::construct(cb, rhs.expr(), 16u64.expr());
-            let rhs_lt_8 = LtGadget::construct(cb, rhs.expr(), 8u64.expr());
+        ShiftStage1 {
+            phantom_data: PhantomData,
+        }
+    }
 
-            // Opcode Shl and Shr shifts the "lhs" integer "rhs" bits and pushes the "out" on the stack.
-            // lhs and out can be U8, U16, U32, U64, U128 or U256
-            // rhs can only be U8
-            cb.require_true(format!("{}, rhs < 256", Self::NAME), rhs_lt_256.expr());
+    fn assign(
+        &self,
+        _step: StepState<F>,
+        _region: &mut CachedRegion<'_, '_, F>,
+        _offset: usize,
+        stage_state: &StageState,
+        _static_info: &StaticInfo,
+    ) -> Result<usize, Error> {
+        // no need to assign anything else
+        Ok(stage_state.rows())
+    }
+}
 
-            // According to VM implementation, if lhs has integer type UX, rhs must be less then N_BITS_UX,
-            // otherwise goto Error
-            let error = is_u8.expr() * (1u64.expr() - rhs_lt_8.expr())
-                + is_u16.expr() * (1u64.expr() - rhs_lt_16.expr())
-                + is_u32.expr() * (1u64.expr() - rhs_lt_32.expr())
-                + is_u64.expr() * (1u64.expr() - rhs_lt_64.expr())
-                + is_u128.expr() * (1u64.expr() - rhs_lt_128.expr());
-            cb.condition(error, |_cb| {
-                // cb.require_next_state(ExecutionState::ErrorState);
-                // ErrorCode == StatusCode::ArithmeticError
-            });
+#[derive(Clone, Debug)]
+struct ShiftCells<F> {
+    a_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    a_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    b_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    b_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    c_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    c_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    d_lo: [Cell<F>; NUM_OF_BYTES_U128],
+    d_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    bytes_1: [Cell<F>; NUM_OF_BYTES_U128], // used for remainder_lt_divisor
+    bytes_2: [Cell<F>; NUM_OF_BYTES_U128], // used for remainder_lt_divisor
+}
 
+#[derive(Clone, Debug)]
+pub struct ShiftStage2<F> {
+    bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    is_shl: IsZeroGadget<F>,
+    shift_gadget: ShiftGadget<F>,
+    rhs_lt256: LtGadget<F, NUM_OF_BYTES_U8>,
+    rhs_lt128: LtGadget<F, NUM_OF_BYTES_U8>,
+    rhs_lt64: LtGadget<F, NUM_OF_BYTES_U8>,
+    rhs_lt32: LtGadget<F, NUM_OF_BYTES_U8>,
+    rhs_lt16: LtGadget<F, NUM_OF_BYTES_U8>,
+    rhs_lt8: LtGadget<F, NUM_OF_BYTES_U8>,
+    is_u8: IsZeroGadget<F>,
+    is_u16: IsZeroGadget<F>,
+    is_u32: IsZeroGadget<F>,
+    is_u64: IsZeroGadget<F>,
+    is_u128: IsZeroGadget<F>,
+    is_u256: IsZeroGadget<F>,
+}
+impl<F: Field> InstructionGadgetV2<F> for ShiftStage2<F> {
+    const NAME: &'static str = "ShiftStage2";
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ShiftStage2;
+
+    fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
+        let bytes = cb.query_bytes();
+
+        let mut is_shl = None;
+        let mut shift_gadget = None;
+        let mut rhs_lt256 = None;
+        let mut rhs_lt128 = None;
+        let mut rhs_lt64 = None;
+        let mut rhs_lt32 = None;
+        let mut rhs_lt16 = None;
+        let mut rhs_lt8 = None;
+        let mut is_u8 = None;
+        let mut is_u16 = None;
+        let mut is_u32 = None;
+        let mut is_u64 = None;
+        let mut is_u128 = None;
+        let mut is_u256 = None;
+        let step_curr = cb.curr.state.clone();
+
+        cb.first_row(|cb| {
+            cb.require_prev_state(ExecutionState::ShiftStage1);
+            cb.require_equal(
+                "step_counter(0) == 10",
+                step_curr.step_counter.expr(),
+                10u64.expr(),
+            );
+        });
+
+        cb.require_no_stack_pop();
+        cb.require_no_stack_push();
+        cb.require_no_local_op();
+
+        cb.last_row(|cb| {
+            let step_first_of_stage1 = cb.step_state_at_offset(-11);
+            let step_last_of_stage1 = cb.step_state_at_offset(-10);
+
+            let lhs = step_last_of_stage1.stack_pop_value.as_integer();
+            let rhs = step_first_of_stage1.stack_pop_value.as_integer();
+            let out = step_last_of_stage1.stack_push_value.as_integer();
             let cells = ShiftCells {
                 a_lo: cb.cells_at_offset(bytes.clone(), -9),
                 a_hi: cb.cells_at_offset(bytes.clone(), -8),
@@ -203,9 +207,50 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
                 c_hi: cb.cells_at_offset(bytes.clone(), -4),
                 d_lo: cb.cells_at_offset(bytes.clone(), -3),
                 d_hi: cb.cells_at_offset(bytes.clone(), -2),
-                comp_gadget_bytes: cb.cells_at_offset(bytes.clone(), -1),
-                lt_gadget_bytes: bytes.clone(),
+                bytes_1: cb.cells_at_offset(bytes.clone(), -1),
+                bytes_2: bytes.clone(),
             };
+
+            let n_bytes = step_curr.aux0.expr();
+            let is_shl_ =
+                IsZeroGadget::construct(cb, (Opcode::Shl as u64).expr() - step_curr.opcode.expr());
+
+            let is_u8_ =
+                IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U8 as u64).expr());
+            let is_u16_ =
+                IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U16 as u64).expr());
+            let is_u32_ =
+                IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U32 as u64).expr());
+            let is_u64_ =
+                IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U64 as u64).expr());
+            let is_u128_ =
+                IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U128 as u64).expr());
+            let is_u256_ =
+                IsZeroGadget::construct(cb, n_bytes.clone() - (NUM_OF_BYTES_U256 as u64).expr());
+
+            let rhs_lt_256_ = LtGadget::construct(cb, rhs.expr(), 256u64.expr());
+            let rhs_lt_128_ = LtGadget::construct(cb, rhs.expr(), 128u64.expr());
+            let rhs_lt_64_ = LtGadget::construct(cb, rhs.expr(), 64u64.expr());
+            let rhs_lt_32_ = LtGadget::construct(cb, rhs.expr(), 32u64.expr());
+            let rhs_lt_16_ = LtGadget::construct(cb, rhs.expr(), 16u64.expr());
+            let rhs_lt_8_ = LtGadget::construct(cb, rhs.expr(), 8u64.expr());
+
+            // Opcode Shl and Shr shifts the "lhs" integer "rhs" bits and pushes the "out" on the stack.
+            // lhs and out can be U8, U16, U32, U64, U128 or U256
+            // rhs can only be U8
+            cb.require_true(format!("{}, rhs < 256", Self::NAME), rhs_lt_256_.expr());
+
+            // According to VM implementation, if lhs has integer type UX, rhs must be less then N_BITS_UX,
+            // otherwise goto Error
+            let error = is_u8_.expr() * (1u64.expr() - rhs_lt_8_.expr())
+                + is_u16_.expr() * (1u64.expr() - rhs_lt_16_.expr())
+                + is_u32_.expr() * (1u64.expr() - rhs_lt_32_.expr())
+                + is_u64_.expr() * (1u64.expr() - rhs_lt_64_.expr())
+                + is_u128_.expr() * (1u64.expr() - rhs_lt_128_.expr());
+            cb.condition(error, |_cb| {
+                // cb.require_next_state(ExecutionState::ErrorState);
+                // ErrorCode == StatusCode::ArithmeticError
+            });
 
             let shift = ShiftGadget::construct(
                 cb,
@@ -213,22 +258,29 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
                 lhs,
                 rhs,
                 out,
-                is_shl.expr(),
-                is_u8.expr(),
-                is_u16.expr(),
-                is_u32.expr(),
-                is_u64.expr(),
-                is_u128.expr(),
-                is_u256.expr(),
+                is_shl_.expr(),
+                is_u8_.expr(),
+                is_u16_.expr(),
+                is_u32_.expr(),
+                is_u64_.expr(),
+                is_u128_.expr(),
+                is_u256_.expr(),
             );
 
-            rhs_lt256 = Some(rhs_lt_256);
-            rhs_lt128 = Some(rhs_lt_128);
-            rhs_lt64 = Some(rhs_lt_64);
-            rhs_lt32 = Some(rhs_lt_32);
-            rhs_lt16 = Some(rhs_lt_16);
-            rhs_lt8 = Some(rhs_lt_8);
+            is_shl = Some(is_shl_);
             shift_gadget = Some(shift);
+            rhs_lt256 = Some(rhs_lt_256_);
+            rhs_lt128 = Some(rhs_lt_128_);
+            rhs_lt64 = Some(rhs_lt_64_);
+            rhs_lt32 = Some(rhs_lt_32_);
+            rhs_lt16 = Some(rhs_lt_16_);
+            rhs_lt8 = Some(rhs_lt_8_);
+            is_u8 = Some(is_u8_);
+            is_u16 = Some(is_u16_);
+            is_u32 = Some(is_u32_);
+            is_u64 = Some(is_u64_);
+            is_u128 = Some(is_u128_);
+            is_u256 = Some(is_u256_);
 
             cb.require_state_transition(vec![
                 (SP, Transition::Delta((-1).expr())),
@@ -236,11 +288,9 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             ]);
         });
 
-        Shift {
+        ShiftStage2 {
             bytes,
-            is_first_row,
-            is_last_row,
-            is_shl,
+            is_shl: is_shl.unwrap(),
             shift_gadget: shift_gadget.unwrap(),
             rhs_lt256: rhs_lt256.unwrap(),
             rhs_lt128: rhs_lt128.unwrap(),
@@ -248,12 +298,12 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             rhs_lt32: rhs_lt32.unwrap(),
             rhs_lt16: rhs_lt16.unwrap(),
             rhs_lt8: rhs_lt8.unwrap(),
-            is_u8,
-            is_u16,
-            is_u32,
-            is_u64,
-            is_u128,
-            is_u256,
+            is_u8: is_u8.unwrap(),
+            is_u16: is_u16.unwrap(),
+            is_u32: is_u32.unwrap(),
+            is_u64: is_u64.unwrap(),
+            is_u128: is_u128.unwrap(),
+            is_u256: is_u256.unwrap(),
         }
     }
 
@@ -271,60 +321,50 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
         debug_assert!(opcode == Opcode::Shl as u8 || opcode == Opcode::Shr as u8);
         let is_shl = opcode == Opcode::Shl as u8;
         let num_bytes = step_state.step_state.aux0 as usize;
-        let pop0 = step_state.memory_ops[0].0.clone().unwrap().value;
-        let rhs = pop0.to_u8_unchecked();
-        let lhs = step_state.memory_ops[9].0.clone().unwrap().value;
-        let out = step_state.memory_ops[9].1.clone().unwrap().value;
-        let lhs_lo = lhs.lo();
-        let lhs_hi = lhs.hi();
-        let out_lo = out.lo();
-        let out_hi = out.hi();
+        let (lhs, rhs, out) = match &stage_state.extra_data {
+            Some(StageExtraAssignData::BinaryOp(d)) => (d.lhs, d.rhs, d.out),
+            _ => unreachable!(),
+        };
+        let rhs = rhs.unchecked_as_u8();
+        let (lhs_lo, lhs_hi) = split_u256_to_u128(lhs);
+        let (out_lo, out_hi) = split_u256_to_u128(out);
 
         debug_assert_eq!(step_state.memory_ops.len(), 10);
-        for i in 0..step_state.memory_ops.len() {
-            self.is_first_row.assign(
-                region,
-                offset + i,
-                F::from(10u64) - F::from(10 - i as u64),
-            )?;
-            self.is_last_row
-                .assign(region, offset + i, F::from(1u64) - F::from(10 - i as u64))?;
-            self.is_shl.assign(
-                region,
-                offset + i,
-                F::from(Opcode::Shl as u64) - F::from(step_state.step_state.opcode as u64),
-            )?;
-            self.is_u8.assign(
-                region,
-                offset + i,
-                F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U8 as u64),
-            )?;
-            self.is_u16.assign(
-                region,
-                offset + i,
-                F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U16 as u64),
-            )?;
-            self.is_u32.assign(
-                region,
-                offset + i,
-                F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U32 as u64),
-            )?;
-            self.is_u64.assign(
-                region,
-                offset + i,
-                F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U64 as u64),
-            )?;
-            self.is_u128.assign(
-                region,
-                offset + i,
-                F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U128 as u64),
-            )?;
-            self.is_u256.assign(
-                region,
-                offset + i,
-                F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U256 as u64),
-            )?;
-        }
+        self.is_shl.assign(
+            region,
+            offset + 9,
+            F::from(Opcode::Shl as u64) - F::from(step_state.step_state.opcode as u64),
+        )?;
+        self.is_u8.assign(
+            region,
+            offset + 9,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U8 as u64),
+        )?;
+        self.is_u16.assign(
+            region,
+            offset + 9,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U16 as u64),
+        )?;
+        self.is_u32.assign(
+            region,
+            offset + 9,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U32 as u64),
+        )?;
+        self.is_u64.assign(
+            region,
+            offset + 9,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U64 as u64),
+        )?;
+        self.is_u128.assign(
+            region,
+            offset + 9,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U128 as u64),
+        )?;
+        self.is_u256.assign(
+            region,
+            offset + 9,
+            F::from(num_bytes as u64) - F::from(NUM_OF_BYTES_U256 as u64),
+        )?;
 
         //for below gadget, we only assign the last row
         self.shift_gadget.assign(
@@ -443,14 +483,14 @@ impl<F: Field> ShiftGadget<F> {
         // for shr, c < b (remainder < divisor, shl also applicable), mul_add never overflow
         //
         cb.require_zero("c == 0 for shl", c.clone() * is_shl.clone());
-        let remainder_lt_divisor = LtInteger::construct_from_bytes(
+        let remainder_lt_divisor = LtInteger::construct_from_given_bytes(
             cb,
             c_lo.clone(),
             c_hi.clone(),
             b_lo,
             b_hi,
-            cells.comp_gadget_bytes.clone(),
-            cells.lt_gadget_bytes.clone(),
+            cells.bytes_1.clone(),
+            cells.bytes_2.clone(),
         );
         cb.require_true("remainder < divisor", remainder_lt_divisor.expr());
         let mul_add_exprs = MulAddExprs {

--- a/vm-circuit/src/chips/execution_chip_v2/executions/shl_shr.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/shl_shr.rs
@@ -42,6 +42,8 @@ struct ShiftCells<F> {
     c_hi: [Cell<F>; NUM_OF_BYTES_U128],
     d_lo: [Cell<F>; NUM_OF_BYTES_U128],
     d_hi: [Cell<F>; NUM_OF_BYTES_U128],
+    comp_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    lt_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
 }
 
 #[derive(Clone, Debug)]
@@ -71,7 +73,8 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
     fn configure(cb: &mut ConstraintBuilderV2<F>) -> Self {
         let step_curr = cb.curr.state.clone();
         let bytes = cb.query_bytes();
-        let is_first_row = IsZeroGadget::construct(cb, 8u64.expr() - step_curr.step_counter.expr());
+        let is_first_row =
+            IsZeroGadget::construct(cb, 10u64.expr() - step_curr.step_counter.expr());
         let is_last_row = IsZeroGadget::construct(cb, 1u64.expr() - step_curr.step_counter.expr());
         let is_shl =
             IsZeroGadget::construct(cb, (Opcode::Shl as u64).expr() - step_curr.opcode.expr());
@@ -102,9 +105,9 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
                 Self::OPCODES.iter().map(|v| (*v as u64).expr()).collect(),
             );
             cb.require_equal(
-                "step_counter(0) == 8",
+                "step_counter(0) == 10",
                 step_curr.step_counter.expr(),
-                8u64.expr(),
+                10u64.expr(),
             );
             cb.require_equal(
                 format!("{}, stack_pop_index(0) == sp(0)", Self::NAME),
@@ -163,7 +166,7 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             );
 
             let lhs = step_curr.stack_pop_value.as_integer();
-            let step_first = cb.step_state_at_offset(-7);
+            let step_first = cb.step_state_at_offset(-9);
             let rhs = step_first.stack_pop_value.as_integer();
             let out = step_curr.stack_push_value.as_integer();
 
@@ -192,14 +195,16 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             });
 
             let cells = ShiftCells {
-                a_lo: cb.cells_at_offset(bytes.clone(), -7),
-                a_hi: cb.cells_at_offset(bytes.clone(), -6),
-                b_lo: cb.cells_at_offset(bytes.clone(), -5),
-                b_hi: cb.cells_at_offset(bytes.clone(), -4),
-                c_lo: cb.cells_at_offset(bytes.clone(), -3),
-                c_hi: cb.cells_at_offset(bytes.clone(), -2),
-                d_lo: cb.cells_at_offset(bytes.clone(), -1),
-                d_hi: bytes.clone(),
+                a_lo: cb.cells_at_offset(bytes.clone(), -9),
+                a_hi: cb.cells_at_offset(bytes.clone(), -8),
+                b_lo: cb.cells_at_offset(bytes.clone(), -7),
+                b_hi: cb.cells_at_offset(bytes.clone(), -6),
+                c_lo: cb.cells_at_offset(bytes.clone(), -5),
+                c_hi: cb.cells_at_offset(bytes.clone(), -4),
+                d_lo: cb.cells_at_offset(bytes.clone(), -3),
+                d_hi: cb.cells_at_offset(bytes.clone(), -2),
+                comp_gadget_bytes: cb.cells_at_offset(bytes.clone(), -1),
+                lt_gadget_bytes: bytes.clone(),
             };
 
             let shift = ShiftGadget::construct(
@@ -268,19 +273,22 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
         let num_bytes = step_state.step_state.aux0 as usize;
         let pop0 = step_state.memory_ops[0].0.clone().unwrap().value;
         let rhs = pop0.to_u8_unchecked();
-        let lhs = step_state.memory_ops[7].0.clone().unwrap().value;
-        let out = step_state.memory_ops[7].1.clone().unwrap().value;
+        let lhs = step_state.memory_ops[9].0.clone().unwrap().value;
+        let out = step_state.memory_ops[9].1.clone().unwrap().value;
         let lhs_lo = lhs.lo();
         let lhs_hi = lhs.hi();
         let out_lo = out.lo();
         let out_hi = out.hi();
 
-        debug_assert_eq!(step_state.memory_ops.len(), 8);
+        debug_assert_eq!(step_state.memory_ops.len(), 10);
         for i in 0..step_state.memory_ops.len() {
-            self.is_first_row
-                .assign(region, offset + i, F::from(8u64) - F::from(8 - i as u64))?;
+            self.is_first_row.assign(
+                region,
+                offset + i,
+                F::from(10u64) - F::from(10 - i as u64),
+            )?;
             self.is_last_row
-                .assign(region, offset + i, F::from(1u64) - F::from(8 - i as u64))?;
+                .assign(region, offset + i, F::from(1u64) - F::from(10 - i as u64))?;
             self.is_shl.assign(
                 region,
                 offset + i,
@@ -321,7 +329,7 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
         //for below gadget, we only assign the last row
         self.shift_gadget.assign(
             region,
-            offset + 7,
+            offset + 9,
             is_shl,
             rhs,
             lhs_lo,
@@ -330,17 +338,17 @@ impl<F: Field> InstructionGadgetV2<F> for Shift<F> {
             out_hi,
         )?;
         self.rhs_lt256
-            .assign(region, offset + 7, F::from(rhs as u64), F::from(256u64))?;
+            .assign(region, offset + 9, F::from(rhs as u64), F::from(256u64))?;
         self.rhs_lt128
-            .assign(region, offset + 7, F::from(rhs as u64), F::from(128u64))?;
+            .assign(region, offset + 9, F::from(rhs as u64), F::from(128u64))?;
         self.rhs_lt64
-            .assign(region, offset + 7, F::from(rhs as u64), F::from(64u64))?;
+            .assign(region, offset + 9, F::from(rhs as u64), F::from(64u64))?;
         self.rhs_lt32
-            .assign(region, offset + 7, F::from(rhs as u64), F::from(32u64))?;
+            .assign(region, offset + 9, F::from(rhs as u64), F::from(32u64))?;
         self.rhs_lt16
-            .assign(region, offset + 7, F::from(rhs as u64), F::from(16u64))?;
+            .assign(region, offset + 9, F::from(rhs as u64), F::from(16u64))?;
         self.rhs_lt8
-            .assign(region, offset + 7, F::from(rhs as u64), F::from(8u64))?;
+            .assign(region, offset + 9, F::from(rhs as u64), F::from(8u64))?;
 
         Ok(step_state.memory_ops.len())
     }
@@ -435,7 +443,15 @@ impl<F: Field> ShiftGadget<F> {
         // for shr, c < b (remainder < divisor, shl also applicable), mul_add never overflow
         //
         cb.require_zero("c == 0 for shl", c.clone() * is_shl.clone());
-        let remainder_lt_divisor = LtInteger::construct(cb, c_lo.clone(), c_hi.clone(), b_lo, b_hi);
+        let remainder_lt_divisor = LtInteger::construct_from_bytes(
+            cb,
+            c_lo.clone(),
+            c_hi.clone(),
+            b_lo,
+            b_hi,
+            cells.comp_gadget_bytes.clone(),
+            cells.lt_gadget_bytes.clone(),
+        );
         cb.require_true("remainder < divisor", remainder_lt_divisor.expr());
         let mul_add_exprs = MulAddExprs {
             a_limbs,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/store_loc.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/store_loc.rs
@@ -1,7 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::step_v2::{
-    AUX0, AUX1, OPCODE, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{AUX0, AUX1, OPCODE, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/unpack.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/unpack.rs
@@ -2,9 +2,7 @@ use crate::chips::execution_chip_v2::executions::{
     ExecutionState, Membership, DEPTH_POW_OF_ONE_LEVEL,
 };
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_borrow.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_borrow.rs
@@ -1,8 +1,6 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::executions::ExtendedSubIndex;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_pop_back.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_pop_back.rs
@@ -2,9 +2,7 @@ use crate::chips::execution_chip_v2::executions::{
     ExecutionState, ExtendedSubIndex, DEPTH_POW_OF_ONE_LEVEL,
 };
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, AUX0, AUX1, OPCODE, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, AUX0, AUX1, OPCODE, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_push_back.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_push_back.rs
@@ -2,9 +2,7 @@ use crate::chips::execution_chip_v2::executions::{
     ExecutionState, ExtendedSubIndex, DEPTH_POW_OF_ONE_LEVEL,
 };
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, AUX0, AUX1, OPCODE, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, AUX0, AUX1, OPCODE, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/vec_swap.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/vec_swap.rs
@@ -1,9 +1,7 @@
 use crate::chips::execution_chip_v2::executions::{
     ExecutionState, ExtendedSubIndex, DEPTH_POW_OF_ONE_LEVEL,
 };
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, AUX0, AUX1, OPCODE, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, AUX0, AUX1, OPCODE, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/executions/write_ref.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/write_ref.rs
@@ -2,9 +2,7 @@ use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::executions::ExtendedSubIndex;
 use crate::chips::execution_chip_v2::executions::Membership;
 use crate::chips::execution_chip_v2::math_gadgets::is_zero::IsZeroGadget;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/comparison.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/comparison.rs
@@ -3,6 +3,7 @@ use crate::chips::execution_chip_v2::math_gadgets::lt::LtGadget;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::ConstraintBuilderV2;
 use crate::chips::utils::sum;
 use crate::utils::cached_region::CachedRegion;
+use crate::utils::cell_manager::Cell;
 use halo2_proofs::plonk::{Error, Expression};
 use types::Field;
 
@@ -24,6 +25,18 @@ impl<F: Field, const N_BYTES: usize> ComparisonGadget<F, N_BYTES> {
         rhs: Expression<F>,
     ) -> Self {
         let lt = LtGadget::<F, N_BYTES>::construct(cb, lhs, rhs);
+        let eq = IsZeroGadget::<F>::construct(cb, sum::expr(lt.diff_bytes()));
+
+        Self { lt, eq }
+    }
+
+    pub(crate) fn construct_from_bytes(
+        cb: &mut ConstraintBuilderV2<F>,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+        bytes: [Cell<F>; N_BYTES],
+    ) -> Self {
+        let lt = LtGadget::<F, N_BYTES>::construct_from_bytes(cb, lhs, rhs, bytes);
         let eq = IsZeroGadget::<F>::construct(cb, sum::expr(lt.diff_bytes()));
 
         Self { lt, eq }

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/comparison.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/comparison.rs
@@ -30,13 +30,13 @@ impl<F: Field, const N_BYTES: usize> ComparisonGadget<F, N_BYTES> {
         Self { lt, eq }
     }
 
-    pub(crate) fn construct_from_bytes(
+    pub(crate) fn construct_from_given_bytes(
         cb: &mut ConstraintBuilderV2<F>,
         lhs: Expression<F>,
         rhs: Expression<F>,
         bytes: [Cell<F>; N_BYTES],
     ) -> Self {
-        let lt = LtGadget::<F, N_BYTES>::construct_from_bytes(cb, lhs, rhs, bytes);
+        let lt = LtGadget::<F, N_BYTES>::construct_from_given_bytes(cb, lhs, rhs, bytes);
         let eq = IsZeroGadget::<F>::construct(cb, sum::expr(lt.diff_bytes()));
 
         Self { lt, eq }

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/lt.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/lt.rs
@@ -51,6 +51,29 @@ impl<F: Field, const N_BYTES: usize> LtGadget<F, N_BYTES> {
         Self { lt, diff, range }
     }
 
+    pub(crate) fn construct_from_bytes(
+        cb: &mut ConstraintBuilderV2<F>,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+        diff_bytes: [Cell<F>; N_BYTES],
+    ) -> Self {
+        let lt = cb.query_bool();
+        let range = pow_of_two(N_BYTES * 8);
+
+        // The equation we require to hold: `lhs - rhs == diff - (lt * range)`.
+        cb.require_equal(
+            "lhs - rhs == diff - (lt ⋅ range)",
+            lhs - rhs,
+            from_limbs::expr::<_, _, 8>(&diff_bytes) - (lt.expr() * range),
+        );
+
+        Self {
+            lt,
+            diff: diff_bytes,
+            range,
+        }
+    }
+
     pub(crate) fn expr(&self) -> Expression<F> {
         self.lt.expr()
     }
@@ -120,6 +143,24 @@ impl<F: Field> LtInteger<F> {
     ) -> Self {
         let comparison_hi = ComparisonGadget::construct(cb, lhs_hi, rhs_hi);
         let lt_lo = LtGadget::construct(cb, lhs_lo, rhs_lo);
+        Self {
+            comparison_hi,
+            lt_lo,
+        }
+    }
+
+    pub(crate) fn construct_from_bytes(
+        cb: &mut ConstraintBuilderV2<F>,
+        lhs_lo: Expression<F>,
+        lhs_hi: Expression<F>,
+        rhs_lo: Expression<F>,
+        rhs_hi: Expression<F>,
+        comp_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
+        lt_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
+    ) -> Self {
+        let comparison_hi =
+            ComparisonGadget::construct_from_bytes(cb, lhs_hi, rhs_hi, comp_gadget_bytes);
+        let lt_lo = LtGadget::construct_from_bytes(cb, lhs_lo, rhs_lo, lt_gadget_bytes);
         Self {
             comparison_hi,
             lt_lo,

--- a/vm-circuit/src/chips/execution_chip_v2/math_gadgets/lt.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/math_gadgets/lt.rs
@@ -51,7 +51,7 @@ impl<F: Field, const N_BYTES: usize> LtGadget<F, N_BYTES> {
         Self { lt, diff, range }
     }
 
-    pub(crate) fn construct_from_bytes(
+    pub(crate) fn construct_from_given_bytes(
         cb: &mut ConstraintBuilderV2<F>,
         lhs: Expression<F>,
         rhs: Expression<F>,
@@ -149,7 +149,7 @@ impl<F: Field> LtInteger<F> {
         }
     }
 
-    pub(crate) fn construct_from_bytes(
+    pub(crate) fn construct_from_given_bytes(
         cb: &mut ConstraintBuilderV2<F>,
         lhs_lo: Expression<F>,
         lhs_hi: Expression<F>,
@@ -159,8 +159,8 @@ impl<F: Field> LtInteger<F> {
         lt_gadget_bytes: [Cell<F>; NUM_OF_BYTES_U128],
     ) -> Self {
         let comparison_hi =
-            ComparisonGadget::construct_from_bytes(cb, lhs_hi, rhs_hi, comp_gadget_bytes);
-        let lt_lo = LtGadget::construct_from_bytes(cb, lhs_lo, rhs_lo, lt_gadget_bytes);
+            ComparisonGadget::construct_from_given_bytes(cb, lhs_hi, rhs_hi, comp_gadget_bytes);
+        let lt_lo = LtGadget::construct_from_given_bytes(cb, lhs_lo, rhs_lo, lt_gadget_bytes);
         Self {
             comparison_hi,
             lt_lo,

--- a/vm-circuit/src/chips/execution_chip_v2/utils/constraint_builder_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/utils/constraint_builder_v2.rs
@@ -74,7 +74,7 @@ pub(crate) struct ConstraintBuilderV2<'a, F: Field> {
     in_next_step: bool,
 }
 
-impl<'a, F: Field> ConstrainBuilderCommon<F> for ConstraintBuilderV2<'a, F> {
+impl<F: Field> ConstrainBuilderCommon<F> for ConstraintBuilderV2<'_, F> {
     fn add_constraint(&mut self, name: String, constraint: Expression<F>) {
         let constraint = constraint * self.condition_expr();
         // let constraint = self.split_expression(

--- a/vm-circuit/src/lib.rs
+++ b/vm-circuit/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) zkMove Authors
 #![feature(lint_reasons)]
 #![feature(associated_type_defaults)]
+#![feature(slice_as_chunks)]
 
 extern crate aptos_move_witnesses;
 extern crate move_core_types;

--- a/vm-circuit/src/lib.rs
+++ b/vm-circuit/src/lib.rs
@@ -15,6 +15,6 @@ mod utils;
 pub mod witness;
 
 pub use utils::{
-    mock_prove_circuit, print_circuit_layout, prove_and_verify_circuit_ipa, prove_circuit_kzg,
+    mock_prove_circuit, print_circuit_layout, prove_and_verify_circuit_ipa, prove_and_verify_kzg,
     setup_circuit, verify_circuit_kzg, SubCircuit, SubCircuitConfig, MAX_K, MIN_K,
 };

--- a/vm-circuit/src/utils.rs
+++ b/vm-circuit/src/utils.rs
@@ -259,9 +259,10 @@ where
     <Scheme as CommitmentScheme>::ParamsVerifier: 'params,
     <Scheme as CommitmentScheme>::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
 {
-    let proof = prove_circuit(circuit, instance, params, pk.clone())
+    let proof = prove_circuit::<Scheme, P, ConcreteCircuit>(circuit, instance, params, pk.clone())
         .expect("proof generation should not fail");
-    verify_circuit(instance, params, pk, proof.clone()).expect("verify proof should be ok");
+    verify_circuit::<Scheme, V, Strategy>(instance, params, pk, proof.clone())
+        .expect("verify proof should be ok");
     proof
 }
 // TODO: rework on these functions.


### PR DESCRIPTION
original layout: 2 rows, 16*4 bytes in one row

```
bytes_1_lo: [Cell<F>; NUM_OF_BYTES_U128],
bytes_1_hi: [Cell<F>; NUM_OF_BYTES_U128],
bytes_2_lo: [Cell<F>; NUM_OF_BYTES_U128],
bytes_2_hi: [Cell<F>; NUM_OF_BYTES_U128],

a_lo: cb.cells_at_offset(bytes_1_lo.clone(), -1),
a_hi: cb.cells_at_offset(bytes_1_hi.clone(), -1),
b_lo: cb.cells_at_offset(bytes_2_lo.clone(), -1),
b_hi: cb.cells_at_offset(bytes_2_hi.clone(), -1),
c_lo: bytes_1_lo.clone(),
c_hi: bytes_1_hi.clone(),
d_lo: bytes_2_lo.clone(),
d_hi: bytes_2_hi.clone(),
```

new layout: 10 rows, 16 bytes in one row

```
bytes: [Cell<F>; NUM_OF_BYTES_U128],

a_lo: cb.cells_at_offset(bytes.clone(), -9),
a_hi: cb.cells_at_offset(bytes.clone(), -8),
b_lo: cb.cells_at_offset(bytes.clone(), -7),
b_hi: cb.cells_at_offset(bytes.clone(), -6),
c_lo: cb.cells_at_offset(bytes.clone(), -5),
c_hi: cb.cells_at_offset(bytes.clone(), -4),
d_lo: cb.cells_at_offset(bytes.clone(), -3),
d_hi: cb.cells_at_offset(bytes.clone(), -2),
comp_gadget_bytes: cb.cells_at_offset(bytes.clone(), -1),
lt_gadget_bytes: bytes.clone(),
```