### PR TITLE
optimization: try reduce the columns used in bitwise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,9 @@ panic = 'unwind'
 incremental = true
 lto = "thin"
 codegen-units = 16
-[profile.test]
-inherits = "release"
+
+#[profile.test]
+#inherits = "release"
 
 
 [profile.release]

--- a/aptos-move-witnesses/src/exec_state.rs
+++ b/aptos-move-witnesses/src/exec_state.rs
@@ -1,6 +1,6 @@
 use move_binary_format::file_format_common::Opcodes;
 use strum_macros::EnumIter;
-#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq, EnumIter)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq, Ord, PartialOrd, EnumIter)]
 pub enum ExecutionState {
     Start = 0,
     ProcessArg,

--- a/vm-circuit/src/chips/execution_chip_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2.rs
@@ -10,7 +10,7 @@ use crate::chips::execution_chip_v2::executions::{
     WriteRefStage3,
 };
 use crate::chips::execution_chip_v2::executions::{BaseConstraintGadget, Shift};
-use crate::chips::execution_chip_v2::lookup_table::{LookupTableConfigV2, Table};
+use crate::chips::execution_chip_v2::lookup_table::{Lookup, LookupTableConfigV2};
 use crate::chips::execution_chip_v2::step_v2::{Step, StepState};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::{
     BaseConstraintBuilder, ConstrainBuilderCommon,
@@ -33,7 +33,7 @@ use gadgets::util::{and, not, or};
 use halo2_proofs::circuit::{Layouter, Value};
 use halo2_proofs::plonk::{ConstraintSystem, Error, Expression, Selector, VirtualCells};
 use move_binary_format::file_format_common::Opcodes;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::iter;
 use types::Field;
 
@@ -113,6 +113,7 @@ pub(crate) struct ExecChipConfig<F> {
     pub nop: Box<Nop<F>>,
     pub step: Step<F>,
     pub stored_expressions_map: HashMap<ExecutionState, Vec<StoredExpression<F>>>,
+    pub dynamic_cell_stat_map: BTreeMap<ExecutionState, BTreeMap<CellType, usize>>,
 }
 
 impl<F: Field> ExecChipConfig<F> {
@@ -195,7 +196,9 @@ impl<F: Field> ExecChipConfig<F> {
             cb.gate(s_usable)
         });
 
+        let mut lookup_map = BTreeMap::new();
         let mut stored_expressions_map = HashMap::new();
+        let mut additional_cell_stat_map = BTreeMap::new();
         // base configuration for every opcode gadgets
         let (step_curr, base_constraint) = {
             let mut cb =
@@ -211,6 +214,8 @@ impl<F: Field> ExecChipConfig<F> {
                 None,
                 cb,
                 &mut stored_expressions_map,
+                &mut lookup_map,
+                lookup_table_configs,
             );
             (step_curr, base_constraint)
         };
@@ -225,6 +230,9 @@ impl<F: Field> ExecChipConfig<F> {
                     s_step_last,
                     &step_curr,
                     &mut stored_expressions_map,
+                    &mut lookup_map,
+                    &mut additional_cell_stat_map,
+                    lookup_table_configs,
                 ))
             };
         }
@@ -294,6 +302,7 @@ impl<F: Field> ExecChipConfig<F> {
             columns: cell_columns,
             step: step_curr,
             stored_expressions_map,
+            dynamic_cell_stat_map: additional_cell_stat_map,
         };
 
         Self::configure_lookup(
@@ -320,6 +329,12 @@ impl<F: Field> ExecChipConfig<F> {
         //s_step: Column<Advice>,
         step_curr: &Step<F>,
         stored_expressions_map: &mut HashMap<ExecutionState, Vec<StoredExpression<F>>>,
+        lookup_map: &mut BTreeMap<
+            Option<ExecutionState>,
+            Vec<(Option<ConstraintLocation>, String, Lookup<F>)>,
+        >,
+        cell_stat_map: &mut BTreeMap<ExecutionState, BTreeMap<CellType, usize>>, // TODO: replace with Instrument
+        lookup_table_config: &LookupTableConfigV2<F>,
     ) -> G {
         // Now actually configure the gadget with the correct minimal height
         let mut cb = ConstraintBuilderV2::new(
@@ -330,6 +345,11 @@ impl<F: Field> ExecChipConfig<F> {
             Some(G::EXECUTION_STATE),
         );
         let gadget = G::configure(&mut cb);
+        let mut stat = cb.curr.cell_manager.get_stats(cb.columns);
+        debug_assert_eq!(stat.len(), 1);
+
+        cell_stat_map.insert(G::EXECUTION_STATE, stat.pop().unwrap());
+
         Self::configure_opcode_gadget_impl(
             s_usable,
             s_step_first,
@@ -338,6 +358,8 @@ impl<F: Field> ExecChipConfig<F> {
             Some(G::EXECUTION_STATE),
             cb,
             stored_expressions_map,
+            lookup_map,
+            lookup_table_config,
         );
         gadget
     }
@@ -350,10 +372,15 @@ impl<F: Field> ExecChipConfig<F> {
         execution_state: Option<ExecutionState>,
         mut cb: ConstraintBuilderV2<F>,
         stored_expressions_map: &mut HashMap<ExecutionState, Vec<StoredExpression<F>>>,
+        lookup_map: &mut BTreeMap<
+            Option<ExecutionState>,
+            Vec<(Option<ConstraintLocation>, String, Lookup<F>)>,
+        >,
+        lookup_table_config: &LookupTableConfigV2<F>,
     ) {
         let step_prev = cb.step_state_at_offset(-1);
         let step_next = cb.step_state_at_offset(1);
-        let (step_curr, constraints, stored_expressions, meta) = cb.build();
+        let (step_curr, constraints, lookups, stored_expressions, meta, columns) = cb.build();
 
         if let Some(execution_state) = execution_state {
             debug_assert!(
@@ -362,6 +389,7 @@ impl<F: Field> ExecChipConfig<F> {
             );
             stored_expressions_map.insert(execution_state, stored_expressions);
         }
+        //lookup_map.insert(execution_state, lookups);
 
         // Enforce the logic for this opcode
         let first_row: &dyn Fn(&mut VirtualCells<F>) -> Expression<F> = &|meta| {
@@ -397,13 +425,13 @@ impl<F: Field> ExecChipConfig<F> {
                 ),
             ])
         };
-
+        let any_row: &dyn Fn(&mut VirtualCells<F>) -> Expression<F> = &|_| 1.expr();
         for (selector, constraints) in [
             (first_row, constraints.first_row),
             (last_row, constraints.last_row),
             (not_first_row, constraints.not_first_row),
             (not_last_row, constraints.not_last_row),
-            (&|_| 1.expr(), constraints.any_row),
+            (any_row, constraints.any_row),
         ] {
             if !constraints.is_empty() {
                 meta.create_gate(name, |meta| {
@@ -414,6 +442,35 @@ impl<F: Field> ExecChipConfig<F> {
                     })
                 });
             }
+        }
+
+        for (constraint_location, name, lookup) in lookups {
+            let location_selector = match constraint_location {
+                None => any_row,
+                Some(ConstraintLocation::FirstRow) => first_row,
+                Some(ConstraintLocation::LastRow) => last_row,
+                Some(ConstraintLocation::NotFirstRow) => not_first_row,
+                Some(ConstraintLocation::NotLastRow) => not_last_row,
+            };
+
+            meta.lookup_any(name.as_str(), |meta| {
+                let s_usable = meta.query_selector(s_usable);
+                let location_selector = location_selector(meta);
+                let state_selector = match execution_state {
+                    Some(s) => step_curr.execution_state_selector([s]),
+                    None => 1.expr(),
+                };
+
+                let table_expressions = lookup_table_config.table_exprs(lookup.table(), meta);
+                lookup
+                    .input_exprs()
+                    .into_iter()
+                    .map(|e| {
+                        s_usable.clone() * location_selector.clone() * state_selector.clone() * e
+                    })
+                    .zip(table_expressions)
+                    .collect()
+            });
         }
     }
 
@@ -448,19 +505,7 @@ impl<F: Field> ExecChipConfig<F> {
                 let column_expr = column.expr(meta);
                 meta.lookup_any(name.as_str(), |meta| {
                     let s_usable = meta.query_selector(s_usable);
-                    let table_expressions = match table {
-                        Table::Nibble => lookup_table_config.nibble_table.table_exprs(meta),
-                        Table::U8 => lookup_table_config.u8_table.table_exprs(meta),
-                        Table::U10 => lookup_table_config.u10_table.table_exprs(meta),
-                        #[cfg(feature = "table-u16")]
-                        Table::U16 => lookup_table_config.u16_table.table_exprs(meta),
-                        Table::Function => lookup_table_config.function_table.table_exprs(meta),
-                        Table::Bitwise => lookup_table_config.bitwise_table.table_exprs(meta),
-                        Table::Bytecode => lookup_table_config.bytecode_table.table_exprs(meta),
-                        Table::Constant => lookup_table_config.constant_table.table_exprs(meta),
-                        Table::Pow2 => lookup_table_config.pow2_table.table_exprs(meta),
-                        _ => unimplemented!(),
-                    };
+                    let table_expressions = lookup_table_config.table_exprs(table, meta);
                     vec![(
                         s_usable * column_expr,
                         rlc::expr(&table_expressions, challenges.lookup_input()),
@@ -713,11 +758,12 @@ impl<F: Field> ExecChipConfig<F> {
                         None => true,
                     };
 
-                    if row_match {
-                        expression.assign(region, offset_begin + i)?;
-                    } else {
-                        expression.assign_empty(region, offset_begin + i)?;
-                    }
+                    // if row_match {
+                    //     expression.assign(region, offset_begin + i)?;
+                    // } else {
+                    //     expression.assign_empty(region, offset_begin + i)?;
+                    // }
+                    expression.assign(region, offset_begin + i)?;
                 }
             }
         }

--- a/vm-circuit/src/chips/execution_chip_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2.rs
@@ -758,12 +758,11 @@ impl<F: Field> ExecChipConfig<F> {
                         None => true,
                     };
 
-                    // if row_match {
-                    //     expression.assign(region, offset_begin + i)?;
-                    // } else {
-                    //     expression.assign_empty(region, offset_begin + i)?;
-                    // }
-                    expression.assign(region, offset_begin + i)?;
+                    if row_match {
+                        expression.assign(region, offset_begin + i)?;
+                    } else {
+                        expression.assign_empty(region, offset_begin + i)?;
+                    }
                 }
             }
         }

--- a/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
@@ -1,9 +1,7 @@
 use crate::chips::execution_chip_v2::executions::bitwise::to_nibbles::ToNibbles;
 use crate::chips::execution_chip_v2::executions::ExecutionState;
 use crate::chips::execution_chip_v2::lookup_table::Lookup;
-use crate::chips::execution_chip_v2::step_v2::{
-    StepState, PC, SP,
-};
+use crate::chips::execution_chip_v2::step_v2::{StepState, PC, SP};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,
@@ -37,10 +35,14 @@ impl<F: Field> InstructionGadgetV2<F> for Bitwise<F> {
         let step_prev = cb.step_state_at_offset(-1);
         let step_prev_2 = cb.step_state_at_offset(-2);
         let nibbles: [Cell<F>; NUM_OF_BYTES_U256 * 2] = (0..NUM_OF_BYTES_U256 * 2)
-            .map(|_| cb.query_nibble())
+            .map(|_| cb.query_cell())
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();
+
+        for (i, nibble) in nibbles.iter().enumerate() {
+            cb.range_lookup(format!("nibble[{}]", i), nibble.expr(), 16);
+        }
 
         cb.first_row(|cb| {
             cb.require_in_set(
@@ -139,7 +141,6 @@ impl<F: Field> InstructionGadgetV2<F> for Bitwise<F> {
                 nibbles_out: nibbles.clone(),
             };
             LookupBitwise::lookup(cb, op);
-
             cb.require_zero(
                 format!("{}, stack_push_value_header(0) == false", Self::NAME),
                 step_curr.stack_push_value_header.expr(),
@@ -204,8 +205,8 @@ impl<F: Field> LookupBitwise<F> {
     fn lookup(cb: &mut ConstraintBuilderV2<F>, op: BitwiseOperation<F>) {
         for (operand_1, operand_2, result) in izip!(op.nibbles_lhs, op.nibbles_rhs, op.nibbles_out)
         {
-            cb.add_lookup(
-                "bitwise lookup",
+            cb.add_lookup_directly(
+                "bitwise lookup".to_string(),
                 Lookup::Bitwise {
                     opcode: op.opcode.clone(),
                     value_1: operand_1.expr(),

--- a/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
@@ -40,10 +40,6 @@ impl<F: Field> InstructionGadgetV2<F> for Bitwise<F> {
             .try_into()
             .unwrap();
 
-        for (i, nibble) in nibbles.iter().enumerate() {
-            cb.range_lookup(format!("nibble[{}]", i), nibble.expr(), 16);
-        }
-
         cb.first_row(|cb| {
             cb.require_in_set(
                 "opcode in OPCODES",

--- a/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/executions/bitwise.rs
@@ -7,7 +7,7 @@ use crate::chips::execution_chip_v2::utils::constraint_builder_v2::{
     ConstraintBuilderV2, Transition,
 };
 use crate::chips::execution_chip_v2::utils::from_limbs;
-use crate::chips::execution_chip_v2::value::NUM_OF_BYTES_U256;
+use crate::chips::execution_chip_v2::value::{NUM_OF_BYTES_U256, NUM_OF_NIBBLE_U256};
 use crate::chips::execution_chip_v2::InstructionGadgetV2;
 use crate::chips::utils::Expr;
 use crate::utils::cached_region::CachedRegion;
@@ -34,11 +34,8 @@ impl<F: Field> InstructionGadgetV2<F> for Bitwise<F> {
         let step_curr = cb.curr.state.clone();
         let step_prev = cb.step_state_at_offset(-1);
         let step_prev_2 = cb.step_state_at_offset(-2);
-        let nibbles: [Cell<F>; NUM_OF_BYTES_U256 * 2] = (0..NUM_OF_BYTES_U256 * 2)
-            .map(|_| cb.query_cell())
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        // although we use byte to represent nibble, no need to do range check as these cells will be bitwise-lookuped.
+        let nibbles: [Cell<F>; NUM_OF_NIBBLE_U256] = cb.query_bytes::<NUM_OF_NIBBLE_U256>();
 
         cb.first_row(|cb| {
             cb.require_in_set(

--- a/vm-circuit/src/chips/execution_chip_v2/lookup_table.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/lookup_table.rs
@@ -1,14 +1,16 @@
 use crate::chips::execution_chip_v2::lookup_table::bitwise_table::BitwiseLookupTable;
 use crate::chips::execution_chip_v2::lookup_table::byecode_table::BytecodeLookupTable;
 use crate::chips::execution_chip_v2::lookup_table::constant_table::ConstantLookupTable;
+use crate::chips::execution_chip_v2::lookup_table::fix_table::FixedTable;
 use crate::chips::execution_chip_v2::lookup_table::function_table::FunctionLookupTable;
 use crate::chips::execution_chip_v2::lookup_table::pow2::Pow2LookupTable;
 use crate::chips::execution_chip_v2::lookup_table::ux_table::UXTable;
 use crate::chips::execution_chip_v2::step_v2::NUM_OF_VALUE_LIMBS;
+use crate::table::LookupTable;
 use aptos_move_witnesses::static_info::StaticInfo;
 use gadgets::impl_expr;
 use halo2_proofs::circuit::Layouter;
-use halo2_proofs::plonk::{ConstraintSystem, Error, Expression};
+use halo2_proofs::plonk::{ConstraintSystem, Error, Expression, VirtualCells};
 use std::marker::PhantomData;
 use strum_macros::EnumIter;
 use types::Field;
@@ -16,6 +18,7 @@ use types::Field;
 pub(crate) mod bitwise_table;
 pub(crate) mod byecode_table;
 pub(crate) mod constant_table;
+pub(crate) mod fix_table;
 pub(crate) mod function_table;
 pub(crate) mod pow2;
 pub(crate) mod utils;
@@ -197,9 +200,68 @@ pub enum FixedTableTag {
     Pow2,
 }
 impl_expr!(FixedTableTag);
+impl FixedTableTag {
+    /// build up the fixed table row values
+    pub(crate) fn build<F: Field>(&self) -> Box<dyn Iterator<Item = [F; 4]>> {
+        let tag = F::from(*self as u64);
+        match self {
+            Self::Zero => Box::new((0..1).map(move |_| [tag, F::ZERO, F::ZERO, F::ZERO])),
+            Self::Range5 => {
+                Box::new((0..5).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range16 => {
+                Box::new((0..16).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range32 => {
+                Box::new((0..32).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range64 => {
+                Box::new((0..64).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range128 => {
+                Box::new((0..128).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range256 => {
+                Box::new((0..256).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range512 => {
+                Box::new((0..512).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::Range1024 => {
+                Box::new((0..1024).map(move |value| [tag, F::from(value), F::ZERO, F::ZERO]))
+            }
+            Self::SignByte => Box::new((0..256).map(move |value| {
+                [
+                    tag,
+                    F::from(value),
+                    F::from((value >> 7) * 0xFFu64),
+                    F::ZERO,
+                ]
+            })),
+            Self::BitwiseAnd => Box::new((0..16).flat_map(move |lhs| {
+                (0..16).map(move |rhs| [tag, F::from(lhs), F::from(rhs), F::from(lhs & rhs)])
+            })),
+            Self::BitwiseOr => Box::new((0..16).flat_map(move |lhs| {
+                (0..16).map(move |rhs| [tag, F::from(lhs), F::from(rhs), F::from(lhs | rhs)])
+            })),
+            Self::BitwiseXor => Box::new((0..16).flat_map(move |lhs| {
+                (0..16).map(move |rhs| [tag, F::from(lhs), F::from(rhs), F::from(lhs ^ rhs)])
+            })),
+            Self::Pow2 => Box::new((0..256).map(move |value| {
+                let (pow_lo, pow_hi) = if value < 128 {
+                    (F::from_u128(1_u128 << value), F::from(0))
+                } else {
+                    (F::from(0), F::from_u128(1 << (value - 128)))
+                };
+                [tag, F::from(value), pow_lo, pow_hi]
+            })),
+        }
+    }
+}
 
 #[derive(Copy, Clone, Debug)]
 pub struct LookupTableConfigV2<F> {
+    pub(crate) fixed_table: FixedTable,
     pub(crate) nibble_table: UXTable<4>,
     pub(crate) u8_table: UXTable<8>,
     pub(crate) u10_table: UXTable<10>,
@@ -215,6 +277,7 @@ pub struct LookupTableConfigV2<F> {
 
 impl<F: Field> LookupTableConfigV2<F> {
     pub fn new(meta: &mut ConstraintSystem<F>) -> Self {
+        let fixed_table = FixedTable::construct(meta);
         let nibble_table = UXTable::construct(meta);
         let u8_table = UXTable::construct(meta);
         let u10_table = UXTable::construct(meta);
@@ -226,6 +289,7 @@ impl<F: Field> LookupTableConfigV2<F> {
         let bitwise_table = BitwiseLookupTable::construct(meta);
         let pow2_table = Pow2LookupTable::construct(meta);
         Self {
+            fixed_table,
             nibble_table,
             u8_table,
             u10_table,
@@ -243,8 +307,10 @@ impl<F: Field> LookupTableConfigV2<F> {
     pub fn load(
         &self,
         layouter: &mut impl Layouter<F>,
+        fixed_table_tags: Vec<FixedTableTag>,
         static_info: &StaticInfo,
     ) -> Result<(), Error> {
+        self.fixed_table.load(layouter, fixed_table_tags)?;
         self.nibble_table.load(layouter)?;
         self.u8_table.load(layouter)?;
         self.u10_table.load(layouter)?;
@@ -256,5 +322,21 @@ impl<F: Field> LookupTableConfigV2<F> {
         self.bitwise_table.load(layouter)?;
         self.pow2_table.load(layouter)?;
         Ok(())
+    }
+
+    pub fn table_exprs(&self, table: Table, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
+        match table {
+            Table::Fixed => self.fixed_table.table_exprs(meta),
+            Table::Nibble => self.nibble_table.table_exprs(meta),
+            Table::U8 => self.u8_table.table_exprs(meta),
+            Table::U10 => self.u10_table.table_exprs(meta),
+            #[cfg(feature = "table-u16")]
+            Table::U16 => self.u16_table.table_exprs(meta),
+            Table::Function => self.function_table.table_exprs(meta),
+            Table::Bitwise => self.bitwise_table.table_exprs(meta),
+            Table::Bytecode => self.bytecode_table.table_exprs(meta),
+            Table::Constant => self.constant_table.table_exprs(meta),
+            Table::Pow2 => self.pow2_table.table_exprs(meta),
+        }
     }
 }

--- a/vm-circuit/src/chips/execution_chip_v2/lookup_table/fix_table.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/lookup_table/fix_table.rs
@@ -1,0 +1,54 @@
+use crate::chips::execution_chip_v2::lookup_table::FixedTableTag;
+use crate::table::LookupTable;
+use halo2_proofs::circuit::{Layouter, Value};
+use halo2_proofs::plonk::{Any, Column, ConstraintSystem, Error, Fixed};
+use itertools::Itertools;
+use types::Field;
+
+#[derive(Clone, Copy, Debug)]
+pub struct FixedTable {
+    cols: [Column<Fixed>; 4],
+}
+
+impl FixedTable {
+    pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
+        let fixed_table = [(); 4].map(|_| meta.fixed_column());
+        Self { cols: fixed_table }
+    }
+
+    /// Load fixed table
+    pub fn load<F: Field>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        fixed_table_tags: Vec<FixedTableTag>,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "fixed table",
+            |mut region| {
+                for (offset, row) in std::iter::once([F::ZERO; 4])
+                    .chain(fixed_table_tags.iter().flat_map(|tag| tag.build()))
+                    .enumerate()
+                {
+                    for (column, value) in self.cols.iter().zip_eq(row) {
+                        region.assign_fixed(|| "", *column, offset, || Value::known(value))?;
+                    }
+                }
+
+                Ok(())
+            },
+        )
+    }
+}
+
+impl<F: Field> LookupTable<F> for FixedTable {
+    fn columns(&self) -> Vec<Column<Any>> {
+        self.cols.into_iter().map(|c| c.into()).collect()
+    }
+
+    fn annotations(&self) -> Vec<String> {
+        vec!["tag", "fix(0)", "fix(1)", "fix(2)"]
+            .into_iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+}

--- a/vm-circuit/src/chips/execution_chip_v2/utils/constraint_builder_v2.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/utils/constraint_builder_v2.rs
@@ -1,5 +1,5 @@
 use crate::chips::execution_chip_v2::executions::ExecutionState;
-use crate::chips::execution_chip_v2::lookup_table::{Lookup, Table};
+use crate::chips::execution_chip_v2::lookup_table::{FixedTableTag, Lookup, Table};
 use crate::chips::execution_chip_v2::step_v2::{Step, StepState};
 use crate::chips::execution_chip_v2::utils::base_constraint_builder::ConstrainBuilderCommon;
 use crate::chips::execution_chip_v2::utils::StoredExpression;
@@ -58,7 +58,7 @@ pub(crate) struct Constraints<F> {
 
 pub(crate) struct ConstraintBuilderV2<'a, F: Field> {
     meta: &'a mut ConstraintSystem<F>,
-    columns: &'a mut CellManagerColumns,
+    pub(crate) columns: &'a mut CellManagerColumns,
     challenges: &'a Challenges<Expression<F>>,
 
     execution_state: Option<ExecutionState>,
@@ -67,6 +67,8 @@ pub(crate) struct ConstraintBuilderV2<'a, F: Field> {
     constraints: Constraints<F>,
     constraints_location: Option<ConstraintLocation>,
     conditions: Vec<Expression<F>>,
+
+    lookups: Vec<(Option<ConstraintLocation>, String, Lookup<F>)>,
 
     stored_expressions: Vec<StoredExpression<F>>,
     in_next_step: bool,
@@ -77,11 +79,11 @@ impl<'a, F: Field> ConstrainBuilderCommon<F> for ConstraintBuilderV2<'a, F> {
         let constraint = constraint * self.condition_expr();
         // let constraint = self.split_expression(
         //     name.as_str(),
-        //     constraint * self.condition_expr(),
+        //     constraint,
         //     MAX_DEGREE - IMPLICIT_DEGREE, // FIXME: check on the degree
         // );
 
-        //self.validate_degree(constraint.degree(), name.as_str());
+        // self.validate_degree(constraint.degree(), name.as_str());
 
         self.push_constraint(name, constraint);
     }
@@ -106,6 +108,7 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
             stored_expressions: Vec::new(),
             in_next_step: false,
             conditions: Vec::new(),
+            lookups: Vec::new(),
         }
     }
 
@@ -115,8 +118,10 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
     ) -> (
         Step<F>,
         Constraints<F>,
+        Vec<(Option<ConstraintLocation>, String, Lookup<F>)>,
         Vec<StoredExpression<F>>,
         &'a mut ConstraintSystem<F>,
+        &'a mut CellManagerColumns,
     ) {
         debug_assert_eq!(self.conditions.len(), 0);
         let op_sel = match self.execution_state {
@@ -137,8 +142,10 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
                 not_last_row: mul_exec_state_sel(self.constraints.not_last_row),
                 any_row: mul_exec_state_sel(self.constraints.any_row),
             },
+            self.lookups,
             self.stored_expressions,
             self.meta,
+            self.columns,
         )
     }
 
@@ -165,9 +172,9 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
     pub(crate) fn query_u16(&mut self) -> Cell<F> {
         self.query_cell_with_type(CellType::Lookup(Table::U16))
     }
-    pub(crate) fn query_nibble(&mut self) -> Cell<F> {
-        self.query_cell_with_type(CellType::Lookup(Table::Nibble))
-    }
+    // pub(crate) fn query_nibble(&mut self) -> Cell<F> {
+    //     self.query_cell_with_type(CellType::Lookup(Table::Nibble))
+    // }
     pub(crate) fn query_bytes<const N: usize>(&mut self) -> [Cell<F>; N] {
         self.query_u8_dyn(N).try_into().unwrap()
     }
@@ -375,6 +382,33 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
         self.challenges.column_keccak_input()
     }
     // Lookups
+    pub(crate) fn range_lookup(&mut self, lookup_name: String, value: Expression<F>, range: u64) {
+        let (name, tag) = match range {
+            5 => ("Range5", FixedTableTag::Range5),
+            16 => ("Range16", FixedTableTag::Range16),
+            32 => ("Range32", FixedTableTag::Range32),
+            64 => ("Range64", FixedTableTag::Range64),
+            128 => ("Range128", FixedTableTag::Range128),
+            256 => ("Range256", FixedTableTag::Range256),
+            512 => ("Range512", FixedTableTag::Range512),
+            1024 => ("Range1024", FixedTableTag::Range1024),
+            _ => unimplemented!(),
+        };
+        self.add_lookup_directly(
+            format!("{}-{}", name, lookup_name),
+            Lookup::Fixed {
+                tag: tag.expr(),
+                values: [value, 0.expr(), 0.expr()],
+            },
+        );
+    }
+    pub(crate) fn add_lookup_directly(&mut self, name: String, lookup: Lookup<F>) {
+        let lookup = match self.condition_expr_opt() {
+            Some(condition) => lookup.conditional(condition),
+            None => lookup,
+        };
+        self.lookups.push((self.constraints_location, name, lookup))
+    }
 
     pub(crate) fn add_lookup(&mut self, name: &str, lookup: Lookup<F>) {
         // debug_assert!(
@@ -403,7 +437,8 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
         cell_type: CellType,
     ) -> Expression<F> {
         // Check if we already stored the expression somewhere
-        let stored_expression = self.find_stored_expression(&expr, cell_type);
+        let stored_expression =
+            self.find_stored_expression(&expr, cell_type, self.constraints_location);
 
         match stored_expression {
             Some(stored_expression) => {
@@ -442,11 +477,14 @@ impl<'a, F: Field> ConstraintBuilderV2<'a, F> {
         &self,
         expr: &Expression<F>,
         cell_type: CellType,
+        constraint_location: Option<ConstraintLocation>,
     ) -> Option<&StoredExpression<F>> {
         let expr_id = expr.identifier();
-        self.stored_expressions
-            .iter()
-            .find(|&e| e.cell_type == cell_type && e.expr_id == expr_id)
+        self.stored_expressions.iter().find(|&e| {
+            e.cell_type == cell_type
+                && e.expr_id == expr_id
+                && e.required_location == constraint_location
+        })
     }
 
     fn split_expression(

--- a/vm-circuit/src/chips/execution_chip_v2/value.rs
+++ b/vm-circuit/src/chips/execution_chip_v2/value.rs
@@ -17,6 +17,7 @@ pub const NUM_OF_BYTES_U32: usize = 4;
 pub const NUM_OF_BYTES_U64: usize = 8;
 pub const NUM_OF_BYTES_U128: usize = 16;
 pub const NUM_OF_BYTES_U256: usize = 32;
+pub const NUM_OF_NIBBLE_U256: usize = NUM_OF_BYTES_U256 * 2;
 
 pub const INTEGER_NUM_OF_BYTES_SET: [usize; 6] = [
     NUM_OF_BYTES_U8,

--- a/vm-circuit/src/circuit_v2.rs
+++ b/vm-circuit/src/circuit_v2.rs
@@ -1,6 +1,6 @@
 // Copyright (c) zkMove Authors
 
-use crate::chips::execution_chip_v2::lookup_table::LookupTableConfigV2;
+use crate::chips::execution_chip_v2::lookup_table::{FixedTableTag, LookupTableConfigV2};
 use crate::chips::execution_chip_v2::ExecChipConfig;
 use crate::utils::challenges::Challenges;
 use crate::utils::{SubCircuit, SubCircuitConfig};
@@ -11,16 +11,19 @@ use halo2_proofs::{
 };
 use movelang::value::Value;
 use std::marker::PhantomData;
+use strum::IntoEnumIterator;
 use types::Field;
 
 #[derive(Clone)]
 pub struct VmCircuitConfig<F: Field> {
     lookup_table_config: LookupTableConfigV2<F>,
     exec_chip_config: ExecChipConfig<F>,
+    fixed_table_tags: Vec<FixedTableTag>,
 }
 
 pub struct VmCircuitConfigArgs {
     challenges: Challenges,
+    fixed_table_tags: Vec<FixedTableTag>,
 }
 
 impl<F: Field> SubCircuitConfig<F> for VmCircuitConfig<F> {
@@ -31,7 +34,29 @@ impl<F: Field> SubCircuitConfig<F> for VmCircuitConfig<F> {
         let challenges_expr = args.challenges.exprs(meta);
         let exec_chip_config =
             ExecChipConfig::configure(meta, challenges_expr.clone(), &lookup_table_config);
+        // TODO: delete me
+        #[cfg(test)]
+        {
+            use crate::utils::cell_manager::CellType;
+            let mut headers = CellType::all()
+                .iter()
+                .map(|t| format!("{:?}", t))
+                .collect::<Vec<_>>();
+            headers.insert(0, "state".to_string());
+            println!("{}", headers.join(","));
+
+            for (state, stat) in &exec_chip_config.dynamic_cell_stat_map {
+                let mut stat = CellType::all()
+                    .iter()
+                    .map(|t| stat.get(t).cloned().unwrap_or_default().to_string())
+                    .collect::<Vec<_>>();
+                stat.insert(0, format!("{:?}", state));
+                println!("{}", stat.join(","));
+            }
+        }
+
         Self {
+            fixed_table_tags: args.fixed_table_tags,
             exec_chip_config,
             lookup_table_config,
         }
@@ -55,8 +80,15 @@ impl<F: Field> Circuit<F> for VmCircuit<F> {
 
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let challenges = Challenges::construct(meta);
+        let fixed_table_tags = FixedTableTag::iter().collect();
         (
-            VmCircuitConfig::new(meta, VmCircuitConfigArgs { challenges }),
+            VmCircuitConfig::new(
+                meta,
+                VmCircuitConfigArgs {
+                    challenges,
+                    fixed_table_tags,
+                },
+            ),
             challenges,
         )
     }
@@ -87,12 +119,17 @@ impl<F: Field> SubCircuit<F> for VmCircuit<F> {
         VmCircuitConfig {
             exec_chip_config,
             lookup_table_config,
+            fixed_table_tags,
         }: &Self::Config,
         challenges: &Challenges<halo2_proofs::circuit::Value<F>>,
         layouter: &mut impl Layouter<F>,
     ) -> Result<(), Error> {
         //dbg!(&self.witness.static_info.function_info);
-        lookup_table_config.load(layouter, &self.witness.static_info)?;
+        lookup_table_config.load(
+            layouter,
+            fixed_table_tags.clone(),
+            &self.witness.static_info,
+        )?;
         exec_chip_config.assign(layouter, &self.witness, challenges)?;
         Ok(())
     }

--- a/vm-circuit/src/utils.rs
+++ b/vm-circuit/src/utils.rs
@@ -75,6 +75,8 @@ pub fn mock_prove_circuit<F: Field, ConcreteCircuit: Circuit<F>>(
         .map(|g| g.polynomials().len())
         .sum::<usize>());
     dbg!(prover.cs().advice_queries().len());
+    dbg!(prover.cs().lookups().len());
+
     // uncomment this to output assignments
     {
         let mut f = std::fs::File::options()

--- a/vm-circuit/src/utils/cell_manager.rs
+++ b/vm-circuit/src/utils/cell_manager.rs
@@ -10,6 +10,7 @@ use halo2_proofs::{
 };
 
 use crate::chips::execution_chip_v2::lookup_table::Table;
+use strum::IntoEnumIterator;
 use types::Field;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -22,13 +23,31 @@ pub(crate) enum CellType {
 }
 
 impl CellType {
+    pub(crate) fn all() -> Vec<CellType> {
+        [
+            Self::StoragePhase1,
+            Self::StoragePhase2,
+            Self::StoragePermutation,
+        ]
+        .into_iter()
+        .chain(Table::iter().map(CellType::Lookup))
+        .collect()
+    }
+}
+
+impl CellType {
     // TODO: find a better way to do this.
     pub fn phase(&self) -> u8 {
         match self {
             CellType::StoragePhase1 => 0, // TODO: check the phase
             CellType::StoragePhase2 => 1,
             CellType::StoragePermutation => 1, // FIXME: check the type
-            CellType::Lookup(_) => 2,
+            CellType::Lookup(t) => match t {
+                Table::Nibble | Table::U8 | Table::U10 => 0,
+                #[cfg(feature = "table-u16")]
+                Table::U16 => 0,
+                _ => 2,
+            },
         }
     }
 }
@@ -57,6 +76,9 @@ impl CellType {
 
     /// Return the storage cell of the expression.
     pub(crate) fn storage_for_expr<F: Field>(expr: &Expression<F>) -> CellType {
+        if Self::expr_phase::<F>(expr) > 1 {
+            dbg!(expr);
+        }
         Self::storage_for_phase(Self::expr_phase::<F>(expr))
     }
 }

--- a/vm-circuit/src/utils/cell_placement_strategy.rs
+++ b/vm-circuit/src/utils/cell_placement_strategy.rs
@@ -1,6 +1,6 @@
 use super::cell_manager::{CellManagerColumns, CellPlacement, CellPlacementStrategy, CellType};
 use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, FirstPhase, SecondPhase, ThirdPhase};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use types::Field;
 
@@ -203,7 +203,7 @@ impl CellPlacementStrategy for CMFixedWidthStrategy {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CMFixedHeightStrategy {
-    row_width: Vec<HashMap<CellType, usize>>,
+    row_width: Vec<BTreeMap<CellType, usize>>,
     height_offset: isize,
     num_unused_cells: usize,
 }
@@ -211,7 +211,7 @@ pub(crate) struct CMFixedHeightStrategy {
 impl CMFixedHeightStrategy {
     pub(crate) fn new(height: usize, height_offset: isize) -> CMFixedHeightStrategy {
         CMFixedHeightStrategy {
-            row_width: vec![HashMap::default(); height],
+            row_width: vec![BTreeMap::default(); height],
             height_offset,
             num_unused_cells: Default::default(),
         }
@@ -244,10 +244,10 @@ impl CellPlacementStrategy for CMFixedHeightStrategy {
         self.row_width.len()
     }
 
-    type Stats = ();
+    type Stats = Vec<BTreeMap<CellType, usize>>;
 
     fn get_stats(&self, _columns: &CellManagerColumns) -> Self::Stats {
-        // This CM strategy has not statistics.
+        self.row_width.clone()
     }
 
     fn place_cell_with_affinity<F: Field>(


### PR DESCRIPTION
use plain cell instead of CellType::Nibble , so that bitwise can reuse cell in StoragePhase1.

before: 

```
[vm-circuit/src/utils.rs:67:5] prover.cs().num_advice_columns() = 357
[vm-circuit/src/utils.rs:68:5] prover.cs().num_instance_columns() = 0
[vm-circuit/src/utils.rs:69:5] prover.cs().num_fixed_columns() = 31
[vm-circuit/src/utils.rs:70:5] prover.cs().num_selectors() = 3
[vm-circuit/src/utils.rs:71:5] prover.cs().gates().iter().map(|g| g.polynomials().len()).sum::<usize>() = 22818
[vm-circuit/src/utils.rs:77:5] prover.cs().advice_queries().len() = 749
```