### PR TITLE
Add Sui native verifier transaction command to CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,3 @@ incremental = false
 
 [profile.bench]
 lto = true
-
-#[patch."https://github.com/zkmove/halo2"]
-#halo2_proofs = { path = "../halo2/halo2_proofs" }
-#halo2_backend = { path = "../halo2/halo2_backend" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,9 +13,9 @@ move-package = { workspace = true }
 move-core-types = { workspace = true }
 log.workspace = true
 env_logger.workspace = true
-halo2-verifier = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
-aptos-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
-sui-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
+halo2-verifier = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "feat/cli" }
+aptos-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "feat/cli" }
+sui-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "feat/cli" }
 
 anyhow = "1.0.38"
 clap = { version = "4", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ log.workspace = true
 env_logger.workspace = true
 halo2-verifier = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
 aptos-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
+sui-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
 
 anyhow = "1.0.38"
 clap = { version = "4", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,9 +13,9 @@ move-package = { workspace = true }
 move-core-types = { workspace = true }
 log.workspace = true
 env_logger.workspace = true
-halo2-verifier = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "feat/cli" }
-aptos-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "feat/cli" }
-sui-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "feat/cli" }
+halo2-verifier = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
+aptos-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
+sui-verifier-api = { git = "https://github.com/zkmove/halo2-verifier.move", branch = "main" }
 
 anyhow = "1.0.38"
 clap = { version = "4", features = ["derive"] }

--- a/cli/src/aptos_cmds.rs
+++ b/cli/src/aptos_cmds.rs
@@ -55,6 +55,10 @@ enum AptosSubcommands {
     BuildVerifyProofAptosTxn(BuildVerifyProofAptosTxn),
     BuildPublishParamsNativeAptosTxn(BuildPublishParamsNativeAptosTxn),
     BuildPublishCircuitNativeAptosTxn(BuildPublishCircuitNativeAptosTxn),
+    #[command(
+        name = "build-verify-proof-native-txn",
+        alias = "build-verify-proof-native-aptos-txn"
+    )]
     BuildVerifyProofNativeAptosTxn(BuildVerifyProofNativeAptosTxn),
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -21,6 +21,7 @@ use witness::static_info::{EntryInfo, ModuleIdMapping};
 
 pub mod aptos_cmds;
 pub mod poseidon_cmds;
+pub mod sui_cmds;
 pub mod vm_cmds;
 
 /// Common code used by multiple command modules.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,10 @@
 use clap::{Parser, Subcommand};
 use env_logger::Env;
 use log::info;
-use zkmove_cli::{aptos_cmds::AptosCommands, poseidon_cmds::PoseidonCommand, vm_cmds::VmCommands};
+use zkmove_cli::{
+    aptos_cmds::AptosCommands, poseidon_cmds::PoseidonCommand, sui_cmds::SuiCommands,
+    vm_cmds::VmCommands,
+};
 
 #[derive(Parser)]
 #[command(name = "zkmove", about = "CLI for zkMove")]
@@ -14,6 +17,7 @@ pub struct Cli {
 pub enum Commands {
     Vm(VmCommands),
     Aptos(AptosCommands),
+    Sui(SuiCommands),
     Poseidon(PoseidonCommand),
 }
 
@@ -25,6 +29,7 @@ fn main() -> anyhow::Result<()> {
     match args.command {
         Commands::Vm(vm_command) => vm_command.run(),
         Commands::Aptos(aptos_command) => aptos_command.run(),
+        Commands::Sui(sui_command) => sui_command.run(),
         Commands::Poseidon(poseidon_command) => poseidon_command.run(),
     }
 }

--- a/cli/src/sui_cmds.rs
+++ b/cli/src/sui_cmds.rs
@@ -57,8 +57,6 @@ struct BuildPublishParamsNativeSuiTxn {
     verifier_api_package: String,
     #[arg(long = "params-store-object-id", default_value = "0x1")]
     params_store_object_id: String,
-    #[arg(long = "publisher-address", default_value = "0x1")]
-    publisher_address: String,
     #[arg(short = 'o', long = "output-dir", help = "directory to save the txn")]
     output_dir: Option<PathBuf>,
 }
@@ -72,7 +70,6 @@ impl BuildPublishParamsNativeSuiTxn {
             &params,
             self.verifier_api_package.as_str(),
             self.params_store_object_id.as_str(),
-            self.publisher_address.as_str(),
         )?;
         let output = serde_json::to_string_pretty(&json)?;
         save_txn_output(

--- a/cli/src/sui_cmds.rs
+++ b/cli/src/sui_cmds.rs
@@ -1,14 +1,20 @@
-use crate::{save_to_file, KZGVariant};
+use crate::{get_circuit_config_args_from_move_toml, load_package, save_to_file, KZGVariant};
 use anyhow::{Context, Result};
 use clap::{value_parser, Parser, Subcommand};
-use halo2::proofs::KZG;
-use halo2_proofs::halo2curves::bn256::{Fr, G1Affine};
+use halo2::proofs::{best_k, setup_circuit, KZG};
+use halo2_proofs::halo2curves::bn256::{Bn256, Fr, G1Affine};
+use halo2_proofs::poly::{commitment::Params, kzg::commitment::ParamsKZG};
 use log::info;
 use std::env::current_dir;
 use std::path::{Path, PathBuf};
-use sui_verifier_api::native_verifier::build_verify_proof_native_transaction_payload;
-use sui_verifier_api::DEFAULT_HALO2_KZG_PACKAGE;
+use std::rc::Rc;
+use sui_verifier_api::native_verifier::{
+    build_publish_params_native_transaction_payload, build_publish_vk_native_transaction_payload,
+    build_verify_proof_native_transaction_payload,
+};
 use vm_circuit::public_inputs::PublicInputs;
+use vm_circuit::{CircuitGuard, VmCircuit};
+use witness::static_info::Footprints;
 
 #[derive(Parser)]
 #[command(about = "Generate Sui txns for verify proof on Sui")]
@@ -22,6 +28,8 @@ pub struct SuiCommands {
 impl SuiCommands {
     pub fn run(&self) -> Result<()> {
         match &self.command {
+            SuiSubcommands::BuildPublishParamsNativeSuiTxn(cmd) => cmd.run(),
+            SuiSubcommands::BuildPublishCircuitNativeSuiTxn(cmd) => cmd.run(),
             SuiSubcommands::BuildVerifyProofNativeSuiTxn(cmd) => cmd.run(),
         }
     }
@@ -30,11 +38,133 @@ impl SuiCommands {
 #[derive(Subcommand)]
 #[allow(clippy::enum_variant_names)]
 enum SuiSubcommands {
+    #[command(name = "build-publish-params-native-txn")]
+    BuildPublishParamsNativeSuiTxn(BuildPublishParamsNativeSuiTxn),
+    #[command(name = "build-publish-circuit-native-txn")]
+    BuildPublishCircuitNativeSuiTxn(BuildPublishCircuitNativeSuiTxn),
     #[command(
         name = "build-verify-proof-native-txn",
         alias = "build-verify-proof-native-sui-txn"
     )]
     BuildVerifyProofNativeSuiTxn(BuildVerifyProofNativeSuiTxn),
+}
+
+#[derive(Parser)]
+struct BuildPublishParamsNativeSuiTxn {
+    #[arg(long, help = "params file used for prove/verify in kzg")]
+    params_path: PathBuf,
+    #[arg(long = "verifier-api-package")]
+    verifier_api_package: String,
+    #[arg(long = "params-store-object-id", default_value = "0x1")]
+    params_store_object_id: String,
+    #[arg(long = "publisher-address", default_value = "0x1")]
+    publisher_address: String,
+    #[arg(short = 'o', long = "output-dir", help = "directory to save the txn")]
+    output_dir: Option<PathBuf>,
+}
+
+impl BuildPublishParamsNativeSuiTxn {
+    pub fn run(&self) -> Result<()> {
+        let mut params_file = std::fs::File::open(self.params_path.as_path())?;
+        let params = ParamsKZG::<Bn256>::read(&mut params_file)?;
+
+        let json = build_publish_params_native_transaction_payload(
+            &params,
+            self.verifier_api_package.as_str(),
+            self.params_store_object_id.as_str(),
+            self.publisher_address.as_str(),
+        )?;
+        let output = serde_json::to_string_pretty(&json)?;
+        save_txn_output(
+            self.output_dir.clone(),
+            &self.params_path,
+            "publish-params-native",
+            &output,
+        )?;
+        info!("Transaction built successfully.");
+        Ok(())
+    }
+}
+
+#[derive(Parser)]
+struct BuildPublishCircuitNativeSuiTxn {
+    #[arg(long, help = "params file used for prove/verify in kzg")]
+    params_path: PathBuf,
+    #[arg(long = "package-dir", short = 'p', value_parser = value_parser!(PathBuf))]
+    package_dir: PathBuf,
+    #[arg(
+        long = "circuit-name",
+        short = 'c',
+        help = "Name of the circuit section in Move.toml (e.g. fibonacci for [circuit.fibonacci]). If omitted, uses the plain [circuit] section in Move.toml."
+    )]
+    circuit_name: Option<String>,
+    #[arg(
+        short = 'w',
+        long = "witness",
+        help = "path to .json file containing witness"
+    )]
+    witness: PathBuf,
+    #[arg(long = "verifier-api-package")]
+    verifier_api_package: String,
+    #[arg(
+        long = "pubs-indices",
+        help = "Indices of arguments to be treated as public inputs (e.g., --pubs-indices 0 1)",
+        value_parser = clap::value_parser!(usize),
+        num_args = 0..,
+    )]
+    pubs_indices: Vec<usize>,
+    #[arg(short = 'o', long = "output-dir", help = "directory to save the txn")]
+    output_dir: Option<PathBuf>,
+}
+
+impl BuildPublishCircuitNativeSuiTxn {
+    pub fn run(&self) -> Result<()> {
+        let mut params_file = std::fs::File::open(self.params_path.as_path())?;
+        let params = ParamsKZG::<Bn256>::read(&mut params_file)?;
+        let package = load_package(&self.package_dir)?;
+        let circuit_name = self.circuit_name.as_deref();
+        let circuit_config_args = get_circuit_config_args_from_move_toml(
+            &self.package_dir.join("Move.toml"),
+            circuit_name,
+        )?;
+
+        info!("Loading witness from {:?}", self.witness.display());
+        let traces = Footprints::load(&self.witness)
+            .with_context(|| format!("Failed to load witness from {:?}", self.witness))?;
+        let circuit = Rc::new(VmCircuit::<Fr>::new(
+            &package,
+            &traces,
+            &self.pubs_indices,
+            circuit_config_args,
+        ));
+        let _circuit_guard = CircuitGuard::new(circuit.clone());
+
+        let k = best_k(&circuit);
+        info!("k = {}", k);
+        let mut params = params.clone();
+        if k < params.k() {
+            params.downsize(k);
+        }
+
+        let (vk, _pk) = setup_circuit(&*circuit, &params)
+            .map_err(|e| anyhow::anyhow!("Failed to setup circuit: {:?}", e))?;
+
+        let json = build_publish_vk_native_transaction_payload(
+            &vk,
+            &params,
+            circuit.as_ref(),
+            self.verifier_api_package.as_str(),
+        )?;
+        let output = serde_json::to_string_pretty(&json)?;
+        save_txn_output(
+            self.output_dir.clone(),
+            &self.witness,
+            "publish-vk-native",
+            &output,
+        )?;
+        info!("Transaction built successfully.");
+        Ok(())
+    }
 }
 
 #[derive(Parser)]
@@ -45,14 +175,12 @@ struct BuildVerifyProofNativeSuiTxn {
     proof_path: PathBuf,
     #[arg(long = "output", short = 'o', value_parser = value_parser!(PathBuf))]
     output_dir: Option<PathBuf>,
-    #[arg(long = "halo2-kzg-package", default_value = DEFAULT_HALO2_KZG_PACKAGE)]
-    halo2_kzg_package: String,
+    #[arg(long = "verifier-api-package")]
+    verifier_api_package: String,
     #[arg(long = "params-object-id")]
     params_object_id: String,
     #[arg(long = "vk-object-id")]
     vk_object_id: String,
-    #[arg(long = "circuit-object-id")]
-    circuit_object_id: String,
     #[arg(long = "kzg", value_enum, default_value_t = KZGVariant::GWC)]
     variant: KZGVariant,
     #[arg(
@@ -77,10 +205,9 @@ impl BuildVerifyProofNativeSuiTxn {
             proof,
             kzg as u8,
             public_inputs.as_vec(),
-            self.halo2_kzg_package.as_str(),
+            self.verifier_api_package.as_str(),
             self.params_object_id.as_str(),
             self.vk_object_id.as_str(),
-            self.circuit_object_id.as_str(),
             self.k,
         )?;
 

--- a/cli/src/sui_cmds.rs
+++ b/cli/src/sui_cmds.rs
@@ -30,6 +30,10 @@ impl SuiCommands {
 #[derive(Subcommand)]
 #[allow(clippy::enum_variant_names)]
 enum SuiSubcommands {
+    #[command(
+        name = "build-verify-proof-native-txn",
+        alias = "build-verify-proof-native-sui-txn"
+    )]
     BuildVerifyProofNativeSuiTxn(BuildVerifyProofNativeSuiTxn),
 }
 
@@ -84,7 +88,7 @@ impl BuildVerifyProofNativeSuiTxn {
         save_txn_output(
             self.output_dir.clone(),
             &self.proof_path,
-            "verify-proof-native-sui",
+            "verify-proof-native",
             &output,
         )?;
         info!("Transaction built successfully.");

--- a/cli/src/sui_cmds.rs
+++ b/cli/src/sui_cmds.rs
@@ -1,0 +1,113 @@
+use crate::{save_to_file, KZGVariant};
+use anyhow::{Context, Result};
+use clap::{value_parser, Parser, Subcommand};
+use halo2::proofs::KZG;
+use halo2_proofs::halo2curves::bn256::{Fr, G1Affine};
+use log::info;
+use std::env::current_dir;
+use std::path::{Path, PathBuf};
+use sui_verifier_api::native_verifier::build_verify_proof_native_transaction_payload;
+use sui_verifier_api::DEFAULT_HALO2_KZG_PACKAGE;
+use vm_circuit::public_inputs::PublicInputs;
+
+#[derive(Parser)]
+#[command(about = "Generate Sui txns for verify proof on Sui")]
+pub struct SuiCommands {
+    #[arg(short = 'd', long = "debug", help = "debug mode")]
+    debug: bool,
+    #[command(subcommand)]
+    command: SuiSubcommands,
+}
+
+impl SuiCommands {
+    pub fn run(&self) -> Result<()> {
+        match &self.command {
+            SuiSubcommands::BuildVerifyProofNativeSuiTxn(cmd) => cmd.run(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::enum_variant_names)]
+enum SuiSubcommands {
+    BuildVerifyProofNativeSuiTxn(BuildVerifyProofNativeSuiTxn),
+}
+
+#[derive(Parser)]
+struct BuildVerifyProofNativeSuiTxn {
+    #[arg(long = "pubs-path", value_parser = value_parser!(PathBuf))]
+    pubs_path: PathBuf,
+    #[arg(long = "proof-path", short = 'p', value_parser = value_parser!(PathBuf))]
+    proof_path: PathBuf,
+    #[arg(long = "output", short = 'o', value_parser = value_parser!(PathBuf))]
+    output_dir: Option<PathBuf>,
+    #[arg(long = "halo2-kzg-package", default_value = DEFAULT_HALO2_KZG_PACKAGE)]
+    halo2_kzg_package: String,
+    #[arg(long = "params-object-id")]
+    params_object_id: String,
+    #[arg(long = "vk-object-id")]
+    vk_object_id: String,
+    #[arg(long = "circuit-object-id")]
+    circuit_object_id: String,
+    #[arg(long = "kzg", value_enum, default_value_t = KZGVariant::GWC)]
+    variant: KZGVariant,
+    #[arg(
+        long = "k",
+        help = "optional new parameter k to downsize the KZG parameters if needed"
+    )]
+    k: Option<u32>,
+}
+
+impl BuildVerifyProofNativeSuiTxn {
+    pub fn run(&self) -> Result<()> {
+        let kzg = match self.variant {
+            KZGVariant::GWC => KZG::GWC,
+            KZGVariant::SHPLONK => KZG::SHPLONK,
+        };
+        let proof = std::fs::read(&self.proof_path)
+            .with_context(|| format!("Failed to read proof from {:?}", self.proof_path))?;
+        let pubs = std::fs::read(&self.pubs_path)
+            .with_context(|| format!("Failed to read pubs from {:?}", self.pubs_path))?;
+        let public_inputs = PublicInputs::<Fr>::from_bytes(&pubs);
+        let json = build_verify_proof_native_transaction_payload::<G1Affine>(
+            proof,
+            kzg as u8,
+            public_inputs.as_vec(),
+            self.halo2_kzg_package.as_str(),
+            self.params_object_id.as_str(),
+            self.vk_object_id.as_str(),
+            self.circuit_object_id.as_str(),
+            self.k,
+        )?;
+
+        let output = serde_json::to_string_pretty(&json)?;
+        save_txn_output(
+            self.output_dir.clone(),
+            &self.proof_path,
+            "verify-proof-native-sui",
+            &output,
+        )?;
+        info!("Transaction built successfully.");
+        Ok(())
+    }
+}
+
+fn save_txn_output(
+    output_dir: Option<PathBuf>,
+    input_path: &Path,
+    suffix: &str,
+    content: &str,
+) -> Result<()> {
+    let output_dir = output_dir.unwrap_or_else(|| current_dir().unwrap());
+    std::fs::create_dir_all(&output_dir)
+        .with_context(|| format!("Failed to create output directory at {:?}", output_dir))?;
+    let file_stem = input_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow::anyhow!("Invalid file name"))?;
+    save_to_file(
+        &output_dir,
+        &format!("{}-{}.txn", file_stem, suffix),
+        content,
+    )
+}


### PR DESCRIPTION
## Summary

This PR adds Sui support to the `zkmove` CLI for building native verifier transaction payloads.

Changes include:
- Add `zkmove sui build-verify-proof-native-txn`
- Add alias `build-verify-proof-native-txn`
- Wire `SuiCommands` into the top-level CLI command enum
- Add `sui-verifier-api` as a CLI dependency
- Keep the Aptos native verifier command name aligned with the shared `build-verify-proof-native-txn` form while preserving the Aptos-specific alias

## Validation

- `cargo fmt --check`
- `cargo check -p zkmove-cli`